### PR TITLE
Polygon Fixes and Enhancements

### DIFF
--- a/csharp/src/elements/Geometry/Polygon.cs
+++ b/csharp/src/elements/Geometry/Polygon.cs
@@ -73,20 +73,20 @@ namespace Hypar.Geometry
         public Polygon(IList<Vector3> vertices) : base(vertices){}
 
         /// <summary>
-        /// Tests if the supplied Vector3 point is within this Polygon without coincidence with an edge when compared on a shared plane.
+        /// Tests if the supplied Vector3 is within this Polygon without coincidence with an edge when compared on a shared plane.
         /// </summary>
-        /// <param name="point">The Vector3 point to compare to this Polygon.</param>
+        /// <param name="vector">The Vector3 to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if the supplied Vector3 point is within this Polygon when compared on a shared plane. Returns false if the Vector3 point is outside this Polygon or if the supplied Vector3 point is null.
+        /// Returns true if the supplied Vector3 is within this Polygon when compared on a shared plane. Returns false if the Vector3 is outside this Polygon or if the supplied Vector3 is null.
         /// </returns>
-        public bool Contains(Vector3 point)
+        public bool Contains(Vector3 vector)
         {
-            if (point == null)
+            if (vector == null)
             {
                 return false;
             }
             var thisPath = this.ToClipperPath();
-            var intPoint = new IntPoint(point.X * scale, point.Y * scale);
+            var intPoint = new IntPoint(vector.X * scale, vector.Y * scale);
             if (Clipper.PointInPolygon(intPoint, thisPath) != 1)
             {
                 return false;
@@ -120,20 +120,20 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if the supplied Vector3 point is within this Polygon or coincident with an edge when compared on a shared plane.
+        /// Tests if the supplied Vector3 is within this Polygon or coincident with an edge when compared on a shared plane.
         /// </summary>
-        /// <param name="point">The Vector3 point to compare to this Polygon.</param>
+        /// <param name="vector">The Vector3 to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if the supplied Vector3 point is within this Polygon or coincident with an edge when compared on a shared plane. Returns false if the supplied point is outside this Polygon, or if the supplied Vector3 point is null.
+        /// Returns true if the supplied Vector3 is within this Polygon or coincident with an edge when compared on a shared plane. Returns false if the supplied Vector3 is outside this Polygon, or if the supplied Vector3 is null.
         /// </returns>
-        public bool Covers(Vector3 point)
+        public bool Covers(Vector3 vector)
         {
-            if (point == null)
+            if (vector == null)
             {
                 return false;
             }
             var thisPath = this.ToClipperPath();
-            var intPoint = new IntPoint(point.X * scale, point.Y * scale);
+            var intPoint = new IntPoint(vector.X * scale, vector.Y * scale);
             if (Clipper.PointInPolygon(intPoint, thisPath) == 0)
             {
                 return false;
@@ -171,21 +171,21 @@ namespace Hypar.Geometry
             return true;
         }
 
-         /// <summary>
-        /// Tests if the supplied Vector3 point is outside this Polygon when compared on a shared plane.
+        /// <summary>
+        /// Tests if the supplied Vector3 is outside this Polygon when compared on a shared plane.
         /// </summary>
-        /// <param name="point">The Vector3 point to compare to this Polygon.</param>
+        /// <param name="vector">The Vector3 to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if the supplied Vector3 point is outside this Polygon when compared on a shared plane or if the supplied Vector3 point is null.
+        /// Returns true if the supplied Vector3 is outside this Polygon when compared on a shared plane or if the supplied Vector3 is null.
         /// </returns>
-        public bool Disjoint(Vector3 point)
+        public bool Disjoint(Vector3 vector)
         {
-            if (point == null)
+            if (vector == null)
             {
                 return true;
             }
             var thisPath = this.ToClipperPath();
-            var intPoint = new IntPoint(point.X * scale, point.Y * scale);
+            var intPoint = new IntPoint(vector.X * scale, vector.Y * scale);
             if (Clipper.PointInPolygon(intPoint, thisPath) != 0)
             {
                 return false;
@@ -247,20 +247,20 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if the supplied Vector3 point is coincident with an edge of this Polygon when compared on a shared plane.
+        /// Tests if the supplied Vector3 is coincident with an edge of this Polygon when compared on a shared plane.
         /// </summary>
-        /// <param name="point">The Vector3 point to compare to this Polygon.</param>
+        /// <param name="vector">The Vector3 to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if the supplied Vector3 point coincides with an edge of this Polygon when compared on a shared plane. Returns false if the supplied Vector3 point is not coincident with an edge of this Polygon, or if the supplied Vector3 point is null.
+        /// Returns true if the supplied Vector3 coincides with an edge of this Polygon when compared on a shared plane. Returns false if the supplied Vector3 is not coincident with an edge of this Polygon, or if the supplied Vector3 is null.
         /// </returns>
-        public bool Touches(Vector3 point)
+        public bool Touches(Vector3 vector)
         {
-            if (point == null)
+            if (vector == null)
             {
                 return false;
             }
             var thisPath = this.ToClipperPath();
-            var intPoint = new IntPoint(point.X * scale, point.Y * scale);
+            var intPoint = new IntPoint(vector.X * scale, vector.Y * scale);
             if (Clipper.PointInPolygon(intPoint, thisPath) != -1)
             {
                 return false;

--- a/csharp/src/elements/Geometry/Polygon.cs
+++ b/csharp/src/elements/Geometry/Polygon.cs
@@ -95,29 +95,6 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if all the supplied Vector3 points are within this Polygon without coincidence with an edge when compared on a shared plane.
-        /// </summary>
-        /// <param name="points">The list of Vector3 points to compare to this Polygon.</param>
-        /// <returns>
-        /// Returns true if all the supplied Vector3 points are within this Polygon when compared on a shared plane. Returns false if any of the Vector3 points are outside this Polygon or if the supplied Vector3 point list is null.
-        /// </returns>
-        public bool Contains(IList<Vector3> points)
-        {
-            if (points == null)
-            {
-                return false;
-            }
-            foreach (Vector3 point in points)
-            {
-                if (!this.Contains(point))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        /// <summary>
         /// Tests if the supplied Polygon is within this Polygon without coincident edges when compared on a shared plane.
         /// </summary>
         /// <param name="polygon">The Polygon to compare to this Polygon.</param>
@@ -135,29 +112,6 @@ namespace Hypar.Geometry
             foreach (IntPoint vertex in polyPath)
             {
                 if (Clipper.PointInPolygon(vertex, thisPath) != 1)
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        /// <summary>
-        /// Tests if all the supplied Polygons are within this Polygon without coincident edges when compared on a shared plane.
-        /// </summary>
-        /// <param name="polygons">The list of Polygons to compare to this Polygon.</param>
-        /// <returns>
-        /// Returns true if every vertex of the supplied Polygons are within this Polygon when compared on a shared plane. Returns false if any of the supplied Polygons is not entirely within this Polygon, or if the supplied list of Polygons is null.
-        /// </returns>
-        public bool Contains(IList<Polygon> polygons)
-        {
-            if (polygons == null)
-            {
-                return false;
-            }
-            foreach (Polygon polygon in polygons)
-            {
-                if (!this.Contains(polygon))
                 {
                     return false;
                 }
@@ -187,30 +141,7 @@ namespace Hypar.Geometry
             return true;
         }
 
-        /// <summary>
-        /// Tests if all the supplied Vector3 points are within this Polygon or coincident with an edge when compared on a shared plane.
-        /// </summary>
-        /// <param name="points">The list of Vector3 points to compare to this Polygon.</param>
-        /// <returns>
-        /// Returns true if all the supplied Vector3 points are within this Polygon or coincident with an edge when compared on a shared plane. Returns false if all the supplied point are outside this Polygon, or if the supplied list Vector3 points is null.
-        /// </returns>
-        public bool Covers(IList<Vector3> points)
-        {
-            if (points == null)
-            {
-                return false;
-            }
-            foreach (Vector3 point in points)
-            {
-                if (!this.Covers(point))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        /// <summary>
+         /// <summary>
         /// Tests if the supplied Polygon is within this Polygon with or without edge coincident vertices when compared on a shared plane.
         /// </summary>
         /// <param name="polygon">The Polygon to compare to this Polygon.</param>
@@ -240,30 +171,7 @@ namespace Hypar.Geometry
             return true;
         }
 
-        /// <summary>
-        /// Tests if all the supplied Polygons are within this Polygon with or without edge coincident vertices when compared on a shared plane.
-        /// </summary>
-        /// <param name="polygons">The Polygon to compare to this Polygon.</param>
-        /// <returns>
-        /// Returns true if every vertex of the supplied Polygons is within this Polygon or coincident with an edge when compared on a shared plane. Returns false if any vertex of the supplied Polygons is outside this Polygon, or if the supplied list of Polygons is null.
-        /// </returns>
-        public bool Covers(IList<Polygon> polygons)
-        {
-            if (polygons == null)
-            {
-                return false;
-            }
-            foreach (Polygon polygon in polygons)
-            {
-                if(!this.Covers(polygon))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        /// <summary>
+         /// <summary>
         /// Tests if the supplied Vector3 point is outside this Polygon when compared on a shared plane.
         /// </summary>
         /// <param name="point">The Vector3 point to compare to this Polygon.</param>
@@ -281,29 +189,6 @@ namespace Hypar.Geometry
             if (Clipper.PointInPolygon(intPoint, thisPath) != 0)
             {
                 return false;
-            }
-            return true;
-        }
-
-        /// <summary>
-        /// Tests if all the supplied Vector3 points are outside this Polygon when compared on a shared plane.
-        /// </summary>
-        /// <param name="points">The list of Vector3 points to compare to this Polygon.</param>
-        /// <returns>
-        /// Returns true if all the supplied Vector3 points are outside this Polygon when compared on a shared plane or if the supplied Vector3 point list is null.
-        /// </returns>
-        public bool Disjoint(IList<Vector3> points)
-        {
-            if (points == null)
-            {
-                return true;
-            }
-            foreach (Vector3 point in points)
-            {
-                if (!this.Disjoint(point))
-                {
-                    return false;
-                }
             }
             return true;
         }
@@ -341,29 +226,6 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if all the supplied Polygons are coincident in any way when compared on a shared plane.
-        /// </summary>
-        /// <param name="polygons">The list of Polygons to compare to this Polygon.</param>
-        /// <returns>
-        /// Returns true if none of the supplied Polygons do not intersect or touch this Polygon when compared on a shared plane or if the supplied list of Polygons is null.
-        /// </returns>
-        public bool Disjoint(IList<Polygon> polygons)
-        {
-            if (polygons == null)
-            {
-                return true;
-            }
-            foreach (Polygon polygon in polygons)
-            {
-                if (!this.Disjoint(polygon))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        /// <summary>
         /// Tests if the supplied Polygon shares one or more areas with this Polygon when compared on a shared plane.
         /// </summary>
         /// <param name="polygon">The Polygon to compare with this Polygon.</param>
@@ -382,34 +244,6 @@ namespace Hypar.Geometry
             clipper.AddPath(polygon.ToClipperPath(), PolyType.ptClip, true);
             clipper.Execute(ClipType.ctIntersection, solution);
             return solution.Count != 0;
-        }
-
-        /// <summary>
-        /// Tests if any of the supplied Polygons share one or more areas with this Polygon when compared on a shared plane.
-        /// </summary>
-        /// <param name="polygons">The Polygon to compare with this Polygon.</param>
-        /// <returns>
-        /// Returns true if any of the supplied Polygons share one or more areas with this Polygon when compared on a shared plane or if the list of supplied Polygons is null. Returns false if the none of the supplied Polygons share an area with this Polygon or if the supplied list of Polygons is null.
-        /// </returns>
-        public bool Intersects(IList<Polygon> polygons)
-        {
-            if (polygons == null)
-            {
-                return false;
-            }
-            var clipper = new Clipper();
-            var solution = new List<List<IntPoint>>();
-            clipper.AddPath(this.ToClipperPath(), PolyType.ptSubject, true);
-            foreach (Polygon polygon in polygons)
-            {
-                clipper.AddPath(polygon.ToClipperPath(), PolyType.ptClip, true);
-            }
-            clipper.Execute(ClipType.ctIntersection, solution);
-            if (solution.Count != 0)
-            {
-                return true;
-            }
-            return false;
         }
 
         /// <summary>
@@ -435,29 +269,6 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if the all supplied Vector3 point are coincident with an edge of this Polygon when compared on a shared plane.
-        /// </summary>
-        /// <param name="points">The list of Vector3 points to compare to this Polygon.</param>
-        /// <returns>
-        /// Returns true if all the supplied Vector3 points coincide with an edge of this Polygon when compared on a shared plane. Returns false if at least one of the supplied Vector3 points are not coincident with an edge of this Polygon, or if the supplied list of Vector3 points is null.
-        /// </returns>
-        public bool Touches(IList<Vector3> points)
-        {
-            if (points == null)
-            {
-                return false;
-            }
-            foreach (Vector3 point in points)
-            {
-                if (!this.Touches(point))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        /// <summary>
         /// Tests if at least one point of an edge of the supplied Polygon is shared with an edge of this Polygon without the Polygons interesecting when compared on a shared plane.
         /// </summary>
         /// <param name="polygon">The Polygon to compare to this Polygon.</param>
@@ -477,30 +288,6 @@ namespace Hypar.Geometry
                 if (Clipper.PointInPolygon(vertex, polyPath) == -1)
                 {
                     return true;
-                }
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Tests if all the supplied Polygons share at least one point of an edge with an edge of this Polygon without the Polygons interesecting when compared on a shared plane.
-        /// </summary>
-        /// <param name="polygons">The list of Polygons to compare to this Polygon.</param>
-        /// <returns>
-        /// Returns true if all the supplied Polygon share at least one edge point with this Polygon without the Polygons intersecting when compared on a shared plane. Returns false if any of the Polygons intersect, is disjoint, or if the supplied list of Polygons is null.
-        /// </returns>
-        public bool Touches(IList<Polygon> polygons)
-        {
-            if (polygons == null)
-            {
-                return false;
-            }
-            var thisPath = this.ToClipperPath();
-            foreach (Polygon polygon in polygons)
-            {
-                if (!this.Touches(polygon))
-                {
-                    return false;
                 }
             }
             return false;
@@ -624,9 +411,9 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Constructs the geometric union between this Polygon and the supplied Polygon.
+        /// Constructs the geometric union between this Polygon and the supplied list of Polygons.
         /// </summary>
-        /// <param name="polygons">The Polygons to be combined with this Polygon.</param>
+        /// <param name="polygons">The list of Polygons to be combined with this Polygon.</param>
         /// <returns>
         /// Returns a single Polygon from a successful union.
         /// Returns null if a union cannot be performed on the complete list of Polygons.

--- a/csharp/src/elements/Geometry/Polygon.cs
+++ b/csharp/src/elements/Geometry/Polygon.cs
@@ -14,6 +14,9 @@ namespace Hypar.Geometry
     // [JsonConverter(typeof(PolygonConverter))]
     public partial class Polygon : Polyline
     {
+        private const double scale = 1024.0;
+        private const double areaTolerance = 0.00001;
+
         /// <summary>
         /// The area enclosed by the polygon.
         /// </summary>
@@ -70,15 +73,18 @@ namespace Hypar.Geometry
         public Polygon(IList<Vector3> vertices) : base(vertices){}
 
         /// <summary>
-        /// Tests if the supplied 2D point is within the perimeter of this Polygon.
+        /// Tests if the supplied Vector3 point is within this Polygon without coincidence with an edge when compared on a shared plane.
         /// </summary>
-        /// <param name="point">The 2D Vector3 point to compare.</param>
+        /// <param name="point">The Vector3 point to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if the supplied Vector3 point is inside this Polygon.
+        /// Returns true if the supplied Vector3 point is within this Polygon when compared on a shared plane. Returns false if the Vector3 point is outside this Polygon or if the supplied Vector3 point is null.
         /// </returns>
         public bool Contains(Vector3 point)
         {
-            var scale = 1024.0;
+            if (point == null)
+            {
+                return false;
+            }
             var thisPath = this.ToClipperPath();
             var intPoint = new IntPoint(point.X * scale, point.Y * scale);
             if (Clipper.PointInPolygon(intPoint, thisPath) != 1)
@@ -89,20 +95,21 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if all the supplied 2D Vector3 points fall within the perimeter of this Polygon.
+        /// Tests if all the supplied Vector3 points are within this Polygon without coincidence with an edge when compared on a shared plane.
         /// </summary>
-        /// <param name="points">The collection of 2D Vector3 points to compare.</param>
+        /// <param name="points">The list of Vector3 points to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if the supplied Vector3 point is inside this Polygon.
+        /// Returns true if all the supplied Vector3 points are within this Polygon when compared on a shared plane. Returns false if any of the Vector3 points are outside this Polygon or if the supplied Vector3 point list is null.
         /// </returns>
         public bool Contains(IList<Vector3> points)
         {
-            var scale = 1024.0;
-            var thisPath = this.ToClipperPath();
+            if (points == null)
+            {
+                return false;
+            }
             foreach (Vector3 point in points)
             {
-                var intPoint = new IntPoint(point.X * scale, point.Y * scale);
-                if (Clipper.PointInPolygon(intPoint, thisPath) != 1)
+                if (!this.Contains(point))
                 {
                     return false;
                 }
@@ -111,14 +118,18 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if the supplied Polygon is within the perimeter of this Polygon.
+        /// Tests if the supplied Polygon is within this Polygon without coincident edges when compared on a shared plane.
         /// </summary>
-        /// <param name="polygon">The Polygon to compare.</param>
+        /// <param name="polygon">The Polygon to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if every vertex of the supplied Polygon falls within the perimeter of this Polygon.
+        /// Returns true if every vertex of the supplied Polygon is within this Polygon when compared on a shared plane. Returns false if the supplied Polygon is not entirely within this Polygon, or if the supplied Polygon is null.
         /// </returns>
         public bool Contains(Polygon polygon)
         {
+            if (polygon == null)
+            {
+                return false;
+            }
             var thisPath = this.ToClipperPath();
             var polyPath = polygon.ToClipperPath();
             foreach (IntPoint vertex in polyPath)
@@ -132,39 +143,41 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if all Polygons in the supplied collection are within the perimeter of this Polygon.
+        /// Tests if all the supplied Polygons are within this Polygon without coincident edges when compared on a shared plane.
         /// </summary>
-        /// <param name="polygons">The collection of Polygons to compare.</param>
+        /// <param name="polygons">The list of Polygons to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if every supplied Polygon falls within the perimeter of this Polygon.
+        /// Returns true if every vertex of the supplied Polygons are within this Polygon when compared on a shared plane. Returns false if any of the supplied Polygons is not entirely within this Polygon, or if the supplied list of Polygons is null.
         /// </returns>
         public bool Contains(IList<Polygon> polygons)
         {
-            var thisPath = this.ToClipperPath();
+            if (polygons == null)
+            {
+                return false;
+            }
             foreach (Polygon polygon in polygons)
             {
-                var polyPath = polygon.ToClipperPath();
-                foreach (IntPoint vertex in polyPath)
+                if (!this.Contains(polygon))
                 {
-                    if (Clipper.PointInPolygon(vertex, thisPath) != 1)
-                    {
-                        return false;
-                    }
+                    return false;
                 }
             }
             return true;
         }
 
         /// <summary>
-        /// Tests if the supplied 2D Vector3 point is within or touches the perimeter of this Polygon.
+        /// Tests if the supplied Vector3 point is within this Polygon or coincident with an edge when compared on a shared plane.
         /// </summary>
-        /// <param name="point">The 2D Vector3 point to compare.</param>
+        /// <param name="point">The Vector3 point to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if the supplied 2D Vector3 point falls within or touches the perimeter of this Polygon.
+        /// Returns true if the supplied Vector3 point is within this Polygon or coincident with an edge when compared on a shared plane. Returns false if the supplied point is outside this Polygon, or if the supplied Vector3 point is null.
         /// </returns>
         public bool Covers(Vector3 point)
         {
-            var scale = 1024.0;
+            if (point == null)
+            {
+                return false;
+            }
             var thisPath = this.ToClipperPath();
             var intPoint = new IntPoint(point.X * scale, point.Y * scale);
             if (Clipper.PointInPolygon(intPoint, thisPath) == 0)
@@ -175,20 +188,21 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if all the 2D Vector3 points in the supplied list fall within or on the perimeter of this Polygon.
+        /// Tests if all the supplied Vector3 points are within this Polygon or coincident with an edge when compared on a shared plane.
         /// </summary>
-        /// <param name="points">The list of 2D Vector3 points to compare.</param>
+        /// <param name="points">The list of Vector3 points to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if any of the supplied 2D Vector3 points fall within or on the perimeter of this Polygon.
+        /// Returns true if all the supplied Vector3 points are within this Polygon or coincident with an edge when compared on a shared plane. Returns false if all the supplied point are outside this Polygon, or if the supplied list Vector3 points is null.
         /// </returns>
         public bool Covers(IList<Vector3> points)
         {
-            var scale = 1024.0;
-            var thisPath = this.ToClipperPath();
+            if (points == null)
+            {
+                return false;
+            }
             foreach (Vector3 point in points)
             {
-                var intPoint = new IntPoint(point.X * scale, point.Y * scale);
-                if (Clipper.PointInPolygon(intPoint, thisPath) == 0)
+                if (!this.Covers(point))
                 {
                     return false;
                 }
@@ -197,15 +211,18 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if this Polygon covers the supplied Polygon. This Polygon covers the supplied Polygon if all points of the supplied Polygon fall within or on the perimeter of this Polygon.
+        /// Tests if the supplied Polygon is within this Polygon with or without edge coincident vertices when compared on a shared plane.
         /// </summary>
-        /// <param name="polygon">The Polygon to test for coverage by this Polygon.</param>
+        /// <param name="polygon">The Polygon to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if the supplied Polygon is contained by or coincides with the perimeter of the supplied Polygon.
+        /// Returns true if every vertex of the supplied Polygon is within this Polygon or coincident with an edge when compared on a shared plane. Returns false if any vertex of the supplied Polygon is outside this Polygon, or if the supplied Polygon is null.
         /// </returns>
         public bool Covers(Polygon polygon)
         {
-            var tolerance = 0.00001;
+            if (polygon == null)
+            {
+                return false;
+            }
             var clipper = new Clipper();
             var solution = new List<List<IntPoint>>();
             clipper.AddPath(this.ToClipperPath(), PolyType.ptSubject, true);
@@ -216,7 +233,7 @@ namespace Hypar.Geometry
                 return false;
             }
             var testPolygon = solution.First().ToPolygon();
-            if (Math.Abs(polygon.Area - testPolygon.Area) > tolerance)
+            if (Math.Abs(polygon.Area - testPolygon.Area) > areaTolerance)
             {
                 return false;
             }
@@ -224,47 +241,41 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if this Polygon covers all of the supplied Polygons. This Polygon covers the supplied Polygons if all points of the supplied Polygons fall within or on the perimeter of this Polygon.
+        /// Tests if all the supplied Polygons are within this Polygon with or without edge coincident vertices when compared on a shared plane.
         /// </summary>
-        /// <param name="polygons">The list of Polygons to compare.</param>
+        /// <param name="polygons">The Polygon to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if any of the supplied Polygons intersects with this Polygon.
+        /// Returns true if every vertex of the supplied Polygons is within this Polygon or coincident with an edge when compared on a shared plane. Returns false if any vertex of the supplied Polygons is outside this Polygon, or if the supplied list of Polygons is null.
         /// </returns>
         public bool Covers(IList<Polygon> polygons)
         {
-            var tolerance = 0.00001;
-            var clipper = new Clipper();
-            var solution = new List<List<IntPoint>>();
+            if (polygons == null)
+            {
+                return false;
+            }
             foreach (Polygon polygon in polygons)
             {
-                clipper.AddPath(this.ToClipperPath(), PolyType.ptSubject, true);
-                clipper.AddPath(polygon.ToClipperPath(), PolyType.ptClip, true);
-                clipper.Execute(ClipType.ctIntersection, solution);
-                if (solution.Count == 0)
+                if(!this.Covers(polygon))
                 {
                     return false;
                 }
-                var testPolygon = solution.First().ToPolygon();
-                if (Math.Abs(polygon.Area - testPolygon.Area) > tolerance)
-                {
-                    return false;
-                }
-                solution.Clear();
-                clipper.Clear();
             }
             return true;
         }
 
         /// <summary>
-        /// Tests if the supplied 2D Vector3 point is outside the perimeter of this Polygon.
+        /// Tests if the supplied Vector3 point is outside this Polygon when compared on a shared plane.
         /// </summary>
-        /// <param name="point">The 2D Vector3 point to compare.</param>
+        /// <param name="point">The Vector3 point to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if the supplied 2D Vector3 point falls outside the perimeter of this Polygon.
+        /// Returns true if the supplied Vector3 point is outside this Polygon when compared on a shared plane or if the supplied Vector3 point is null.
         /// </returns>
         public bool Disjoint(Vector3 point)
         {
-            var scale = 1024.0;
+            if (point == null)
+            {
+                return true;
+            }
             var thisPath = this.ToClipperPath();
             var intPoint = new IntPoint(point.X * scale, point.Y * scale);
             if (Clipper.PointInPolygon(intPoint, thisPath) != 0)
@@ -275,20 +286,21 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if all the supplied 2D Vector3 points are outside the perimeter of this Polygon.
+        /// Tests if all the supplied Vector3 points are outside this Polygon when compared on a shared plane.
         /// </summary>
-        /// <param name="points">The collection of 2D Vector3 points to compare.</param>
+        /// <param name="points">The list of Vector3 points to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if any of the supplied 2D Vector3 points fall outside the perimeter of this Polygon.
+        /// Returns true if all the supplied Vector3 points are outside this Polygon when compared on a shared plane or if the supplied Vector3 point list is null.
         /// </returns>
         public bool Disjoint(IList<Vector3> points)
         {
-            var scale = 1024.0;
-            var thisPath = this.ToClipperPath();
+            if (points == null)
+            {
+                return true;
+            }
             foreach (Vector3 point in points)
             {
-                var intPoint = new IntPoint(point.X * scale, point.Y * scale);
-                if (Clipper.PointInPolygon(intPoint, thisPath) != 0)
+                if (!this.Disjoint(point))
                 {
                     return false;
                 }
@@ -297,14 +309,18 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if this Polygon and the supplied Polygon are coincident in any way.
+        /// Tests if the supplied Polygon and this Polygon are coincident in any way when compared on a shared plane.
         /// </summary>
-        /// <param name="polygon">The Polygon to compare.</param>
+        /// <param name="polygon">The Polygon to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if this Polygon and the supplied Polygon do not intersect or touch.
+        /// Returns true if the supplied Polygon do not intersect or touch this Polygon when compared on a shared plane or if the supplied Polygon is null.
         /// </returns>
         public bool Disjoint(Polygon polygon)
         {
+            if (polygon == null)
+            {
+                return true;
+            }
             var thisPath = this.ToClipperPath();
             var polyPath = polygon.ToClipperPath();
             foreach (IntPoint vertex in thisPath)
@@ -325,42 +341,34 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if any of the supplied Polygons are coincident with this Polygon.
+        /// Tests if all the supplied Polygons are coincident in any way when compared on a shared plane.
         /// </summary>
-        /// <param name="polygons">The collection of Polygons to compare.</param>
+        /// <param name="polygons">The list of Polygons to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if any of the supplied Polygons do not intersect or touch.
+        /// Returns true if none of the supplied Polygons do not intersect or touch this Polygon when compared on a shared plane or if the supplied list of Polygons is null.
         /// </returns>
         public bool Disjoint(IList<Polygon> polygons)
         {
-            var thisPath = this.ToClipperPath();
+            if (polygons == null)
+            {
+                return true;
+            }
             foreach (Polygon polygon in polygons)
             {
-                var polyPath = polygon.ToClipperPath();
-                foreach (IntPoint vertex in thisPath)
+                if (!this.Disjoint(polygon))
                 {
-                    if (Clipper.PointInPolygon(vertex, polyPath) != 0)
-                    {
-                        return false;
-                    }
-                }
-                foreach (IntPoint vertex in polyPath)
-                {
-                    if (Clipper.PointInPolygon(vertex, thisPath) != 0)
-                    {
-                        return false;
-                    }
+                    return false;
                 }
             }
             return true;
         }
 
         /// <summary>
-        /// Tests if the supplied Polygon shares areas with this Polygon.
+        /// Tests if the supplied Polygon shares one or more areas with this Polygon when compared on a shared plane.
         /// </summary>
         /// <param name="polygon">The Polygon to compare with this Polygon.</param>
         /// <returns>
-        /// Returns true if the two Polygons intersect at least once.
+        /// Returns true if the supplied Polygon shares one or more areas with this Polygon when compared on a shared plane. Returns false if the supplied Polygon does not share an area with this Polygon or if the supplied Polygon is null.
         /// </returns>
         public bool Intersects(Polygon polygon)
         {
@@ -377,11 +385,11 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if any of the supplied Polygons share areas with this Polygon.
+        /// Tests if any of the supplied Polygons share one or more areas with this Polygon when compared on a shared plane.
         /// </summary>
-        /// <param name="polygons">The list of Polygons to compare.</param>
+        /// <param name="polygons">The Polygon to compare with this Polygon.</param>
         /// <returns>
-        /// Returns true if any of the supplied Polygons intersects with this Polygon.
+        /// Returns true if any of the supplied Polygons share one or more areas with this Polygon when compared on a shared plane or if the list of supplied Polygons is null. Returns false if the none of the supplied Polygons share an area with this Polygon or if the supplied list of Polygons is null.
         /// </returns>
         public bool Intersects(IList<Polygon> polygons)
         {
@@ -405,15 +413,18 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if the supplied 2D Vector3 point is on the perimeter of this Polygon.
+        /// Tests if the supplied Vector3 point is coincident with an edge of this Polygon when compared on a shared plane.
         /// </summary>
-        /// <param name="point">The 2D Vector3 point to compare.</param>
+        /// <param name="point">The Vector3 point to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if the supplied 2D Vector3 point coincides with the perimeter of this Polygon.
+        /// Returns true if the supplied Vector3 point coincides with an edge of this Polygon when compared on a shared plane. Returns false if the supplied Vector3 point is not coincident with an edge of this Polygon, or if the supplied Vector3 point is null.
         /// </returns>
         public bool Touches(Vector3 point)
         {
-            var scale = 1024.0;
+            if (point == null)
+            {
+                return false;
+            }
             var thisPath = this.ToClipperPath();
             var intPoint = new IntPoint(point.X * scale, point.Y * scale);
             if (Clipper.PointInPolygon(intPoint, thisPath) != -1)
@@ -424,20 +435,21 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if all the 2D Vector3 points in the supplied collection are on the perimeter of this Polygon.
+        /// Tests if the all supplied Vector3 point are coincident with an edge of this Polygon when compared on a shared plane.
         /// </summary>
-        /// <param name="points">The 2D Vector3 point to compare.</param>
+        /// <param name="points">The list of Vector3 points to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if all the supplied 2D Vector3 points coincide with the perimeter of this Polygon.
+        /// Returns true if all the supplied Vector3 points coincide with an edge of this Polygon when compared on a shared plane. Returns false if at least one of the supplied Vector3 points are not coincident with an edge of this Polygon, or if the supplied list of Vector3 points is null.
         /// </returns>
         public bool Touches(IList<Vector3> points)
         {
-            var scale = 1024.0;
-            var thisPath = this.ToClipperPath();
+            if (points == null)
+            {
+                return false;
+            }
             foreach (Vector3 point in points)
             {
-                var intPoint = new IntPoint(point.X * scale, point.Y * scale);
-                if (Clipper.PointInPolygon(intPoint, thisPath) != -1)
+                if (!this.Touches(point))
                 {
                     return false;
                 }
@@ -446,15 +458,15 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if this Polygon and the supplied Polygon share at least one perimeter point without interesecting.
+        /// Tests if at least one point of an edge of the supplied Polygon is shared with an edge of this Polygon without the Polygons interesecting when compared on a shared plane.
         /// </summary>
-        /// <param name="polygon">The Polygon to compare.</param>
+        /// <param name="polygon">The Polygon to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if this Polygon and the supplied polygon share at least one perimeter point.
+        /// Returns true if the supplied Polygon shares at least one edge point with this Polygon without the Polygons intersecting when compared on a shared plane. Returns false if the Polygons intersect, are disjoint, or if the supplied Polygon is null.
         /// </returns>
         public bool Touches(Polygon polygon)
         {
-            if (this.Intersects(polygon))
+            if (polygon == null || this.Intersects(polygon))
             {
                 return false;
             }
@@ -471,11 +483,11 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
-        /// Tests if the all the Polygons in the supplied collection share at least one perimeter point without interesecting.
+        /// Tests if all the supplied Polygons share at least one point of an edge with an edge of this Polygon without the Polygons interesecting when compared on a shared plane.
         /// </summary>
-        /// <param name="polygons">The Polygons to compare.</param>
+        /// <param name="polygons">The list of Polygons to compare to this Polygon.</param>
         /// <returns>
-        /// Returns true if this Polygon and any of the supplied Polygons share at least one perimeter point and do not intersect.
+        /// Returns true if all the supplied Polygon share at least one edge point with this Polygon without the Polygons intersecting when compared on a shared plane. Returns false if any of the Polygons intersect, is disjoint, or if the supplied list of Polygons is null.
         /// </returns>
         public bool Touches(IList<Polygon> polygons)
         {
@@ -486,17 +498,9 @@ namespace Hypar.Geometry
             var thisPath = this.ToClipperPath();
             foreach (Polygon polygon in polygons)
             {
-                if (this.Intersects(polygon))
+                if (!this.Touches(polygon))
                 {
                     return false;
-                }
-                var polyPath = polygon.ToClipperPath();
-                foreach (IntPoint vertex in thisPath)
-                {
-                    if (Clipper.PointInPolygon(vertex, polyPath) == -1)
-                    {
-                        return true;
-                    }
                 }
             }
             return false;
@@ -679,7 +683,6 @@ namespace Hypar.Geometry
         /// <returns>A new polyline offset by offset.</returns>
         public IList<Polygon> Offset(double offset)
         {
-            var scale = 1024.0;
             var path = this.ToClipperPath();
 
             var solution = new List<List<IntPoint>>();
@@ -820,6 +823,8 @@ namespace Hypar.Geometry
     /// </summary>
     internal static class PolygonExtensions
     {
+        private const double scale = 1024.0;
+
         /// <summary>
         /// Construct a clipper path from a Polygon.
         /// </summary>
@@ -827,7 +832,6 @@ namespace Hypar.Geometry
         /// <returns></returns>
         internal static List<IntPoint> ToClipperPath(this Polygon p)
         {
-            var scale = 1024.0;
             var path = new List<IntPoint>();
             foreach(var v in p.Vertices)
             {
@@ -843,7 +847,6 @@ namespace Hypar.Geometry
         /// <returns></returns>
         internal static Polygon ToPolygon(this List<IntPoint> p)
         {
-            var scale = 1024.0;
             return new Polygon(p.Select(v=>new Vector3(v.X/scale, v.Y/scale)).ToArray());
         }
     }

--- a/csharp/src/elements/elements.csproj
+++ b/csharp/src/elements/elements.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://github.com/hypar-io/elements</PackageProjectUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
-    <Version>0.1.3</Version>
+    <Version>0.1.4</Version>
     <Tags>AEC, Architecture, Structure, Engineering</Tags>
   </PropertyGroup>
 

--- a/csharp/src/elements/elements.csproj
+++ b/csharp/src/elements/elements.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://github.com/hypar-io/elements</PackageProjectUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
-    <Version>0.1.4</Version>
+    <Version>0.1.5</Version>
     <Tags>AEC, Architecture, Structure, Engineering</Tags>
   </PropertyGroup>
 

--- a/csharp/test/PolygonTests.cs
+++ b/csharp/test/PolygonTests.cs
@@ -32,92 +32,142 @@ namespace Hypar.Tests
         [Fact]
         public void Contains()
         {
+            var v1 = new Vector3();
+            var v2 = new Vector3(7.5, 7.5);
+            var vs = new List<Vector3> { v1, v2 };
             var p1 = new Polygon
             (
                 new[]
                 {
-                    new Vector3(0, 0),
-                    new Vector3(20, 0),
-                    new Vector3(20, 20),
-                    new Vector3(0, 20)
+                    new Vector3(0.0, 0.0),
+                    new Vector3(20.0, 0.0),
+                    new Vector3(20.0, 20.0),
+                    new Vector3(0.0, 20.0)
                 }
             );
             var p2 = new Polygon
             (
                 new[]
                 {
-                    new Vector3(0, 0),
-                    new Vector3(10, 5),
-                    new Vector3(10, 10),
-                    new Vector3(5, 10)
+                    new Vector3(0.0, 0.0),
+                    new Vector3(10.0, 5.0),
+                    new Vector3(10.0, 10.0),
+                    new Vector3(5.0, 10.0)
                 }
             );
             var p3 = new Polygon
             (
                 new[]
                 {
-                    new Vector3(5, 5),
-                    new Vector3(10, 5),
-                    new Vector3(10, 10),
-                    new Vector3(5, 10)
+                    new Vector3(5.0, 5.0),
+                    new Vector3(10.0, 5.0),
+                    new Vector3(10.0, 10.0),
+                    new Vector3(5.0, 10.0)
                 }
             );
+            var ps = new List<Polygon> { p2, p3 };
 
+            Assert.False(p1.Contains(v1));
+            Assert.True(p1.Contains(v2));
+            Assert.False(p1.Contains(vs));
             Assert.False(p1.Contains(p2));
             Assert.True(p1.Contains(p3));
             Assert.False(p3.Contains(p1));
+            Assert.False(p1.Contains(ps));
         }
 
         [Fact]
         public void Covers()
         {
+            var v1 = new Vector3();
+            var v2 = new Vector3(7.5, 7.5);
+            var vs = new List<Vector3> { v1, v2 };
             var p1 = new Polygon
             (
                 new[]
                 {
-                    new Vector3(0, 0),
-                    new Vector3(20, 0),
-                    new Vector3(20, 20),
-                    new Vector3(0, 20)
+                new Vector3(0.0, 0.0),
+                new Vector3(20.0, 0.0),
+                new Vector3(20.0, 20.0),
+                new Vector3(0.0, 20.0)
                 }
             );
             var p2 = new Polygon
             (
                 new[]
                 {
-                    new Vector3(0, 0),
-                    new Vector3(10, 0),
-                    new Vector3(10, 10),
-                    new Vector3(0, 10)
+                new Vector3(0.0, 0.0),
+                new Vector3(10.0, 5.0),
+                new Vector3(10.0, 10.0),
+                new Vector3(5.0, 10.0)
                 }
             );
+            var p3 = new Polygon
+            (
+                new[]
+                {
+                new Vector3(5.0, 5.0),
+                new Vector3(10.0, 5.0),
+                new Vector3(10.0, 10.0),
+                new Vector3(5.0, 10.0)
+                }
+            );
+            var ps = new List<Polygon> { p2, p3 };
+
+            Assert.True(p1.Covers(v1));
+            Assert.True(p3.Covers(v2));
+            Assert.False(p3.Covers(v1));
+            Assert.False(p3.Covers(vs));
+            Assert.True(p1.Covers(p3));
             Assert.True(p1.Covers(p2));
+            Assert.False(p3.Covers(p1));
+            Assert.True(p1.Covers(ps));
         }
 
         [Fact]
         public void Disjoint()
         {
+            var v1 = new Vector3();
+            var v2 = new Vector3(27.5, 27.5);
+            var vs = new List<Vector3> { v1, v2 };
             var p1 = new Polygon
             (
                 new[]
                 {
-                    new Vector3(0, 0),
-                    new Vector3(10, 0),
-                    new Vector3(10, 10),
-                    new Vector3(0, 10)
+                new Vector3(0.0, 0.0),
+                new Vector3(20.0, 0.0),
+                new Vector3(20.0, 20.0),
+                new Vector3(0.0, 20.0)
                 }
             );
             var p2 = new Polygon
             (
                 new[]
                 {
-                    new Vector3(20, 20),
-                    new Vector3(40, 0),
-                    new Vector3(40, 40),
-                    new Vector3(0, 20)
+                new Vector3(0.0, 0.0),
+                new Vector3(10.0, 5.0),
+                new Vector3(10.0, 10.0),
+                new Vector3(5.0, 10.0)
                 }
             );
-            Assert.True(p1.Disjoint(p2));
+            var p3 = new Polygon
+            (
+                new[]
+                {
+                new Vector3(25.0, 25.0),
+                new Vector3(210.0, 25.0),
+                new Vector3(210.0, 210.0),
+                new Vector3(25.0, 210.0)
+                }
+            );
+            var ps = new List<Polygon> { p2, p3 };
+
+            Assert.True(p1.Disjoint(v2));
+            Assert.False(p1.Disjoint(v1));
+            Assert.False(p1.Disjoint(vs));
+            Assert.True(p1.Disjoint(p3));
+            Assert.False(p1.Disjoint(p2));
+            Assert.False(p1.Disjoint(ps));
         }
 
         [Fact]
@@ -127,23 +177,37 @@ namespace Hypar.Tests
             (
                 new[]
                 {
-                    new Vector3(0, 5),
-                    new Vector3(4, 5),
-                    new Vector3(4, 10),
-                    new Vector3(0, 10)
+                new Vector3(0.0, 0.0),
+                new Vector3(20.0, 0.0),
+                new Vector3(20.0, 20.0),
+                new Vector3(0.0, 20.0)
                 }
             );
             var p2 = new Polygon
             (
                 new[]
                 {
-                    new Vector3(1, 4),
-                    new Vector3(5, 0),
-                    new Vector3(8, 4),
-                    new Vector3(5, 8)
+                new Vector3(0.0, 0.0),
+                new Vector3(10.0, 5.0),
+                new Vector3(10.0, 10.0),
+                new Vector3(5.0, 10.0)
                 }
             );
+            var p3 = new Polygon
+            (
+                new[]
+                {
+                new Vector3(25.0, 25.0),
+                new Vector3(210.0, 25.0),
+                new Vector3(210.0, 210.0),
+                new Vector3(25.0, 210.0)
+                }
+            );
+            var ps = new List<Polygon> { p2, p3 };
+
             Assert.True(p1.Intersects(p2));
+            Assert.False(p1.Intersects(p3));
+            Assert.True(p1.Intersects(ps));
         }
 
         [Fact]
@@ -154,44 +218,43 @@ namespace Hypar.Tests
                 new[]
                 {
                     new Vector3(),
-                    new Vector3(4, 0),
-                    new Vector3(4, 4),
-                    new Vector3(0, 4)
+                    new Vector3(4.0, 0.0),
+                    new Vector3(4.0, 4.0),
+                    new Vector3(0.0, 4.0)
                 }
             );
             var p2 = new Polygon
             (
                 new[]
                 {
-                    new Vector3(3, 1),
-                    new Vector3(7, 1),
-                    new Vector3(7, 5),
-                    new Vector3(3, 5)
+                    new Vector3(0.0, 1.0),
+                    new Vector3(7.0, 1.0),
+                    new Vector3(7.0, 2.0),
+                    new Vector3(0.0, 2.0)
                 }
             );
-            Assert.False(p1.Touches(p2));
-
-            p1 = new Polygon
+            var p3 = new Polygon
             (
                 new[]
                 {
                     new Vector3(),
-                    new Vector3(4, 0),
-                    new Vector3(4, 4),
-                    new Vector3(0, 4)
+                    new Vector3(4.0, 0.0),
+                    new Vector3(4.0, 4.0),
+                    new Vector3(0.0, 4.0)
                 }
             );
-            p2 = new Polygon
+            var p4 = new Polygon
             (
                 new[]
                 {
-                    new Vector3(4, 0),
-                    new Vector3(8, 0),
-                    new Vector3(8, 4),
-                    new Vector3(4, 8)
+                    new Vector3(4.0, 0.0),
+                    new Vector3(8.0, 0.0),
+                    new Vector3(8.0, 4.0),
+                    new Vector3(4.0, 8.0)
                 }
             );
-            Assert.True(p1.Touches(p2));
+            Assert.False(p1.Touches(p2));
+            Assert.True(p3.Touches(p4));
         }
 
         [Fact]
@@ -235,21 +298,32 @@ namespace Hypar.Tests
                 new[]
                 {
                     new Vector3(),
-                    new Vector3(4, 0),
-                    new Vector3(4, 4),
-                    new Vector3(0, 4)
+                    new Vector3(4.0, 0.0),
+                    new Vector3(4.0, 4.0),
+                    new Vector3(0.0, 4.0)
                 }
             );
             var p2 = new Polygon
             (
                 new[]
                 {
-                    new Vector3(3, 1),
-                    new Vector3(7, 1),
-                    new Vector3(7, 5),
-                    new Vector3(3, 5)
+                    new Vector3(3.0, 1.0),
+                    new Vector3(7.0, 1.0),
+                    new Vector3(7.0, 5.0),
+                    new Vector3(3.0, 5.0)
                 }
             );
+            var p3 = new Polygon
+            (
+                new[]
+                {
+                    new Vector3(3.0, 2.0),
+                    new Vector3(6.0, 2.0),
+                    new Vector3(6.0, 3.0),
+                    new Vector3(3.0, 3.0)
+                }
+            );
+            var ps = new List<Polygon> { p2, p3 };
             var vertices = p1.Intersection(p2).First().Vertices;
 
             Assert.Contains(vertices, p => p.X == 3.0 && p.Y == 1.0);
@@ -266,21 +340,33 @@ namespace Hypar.Tests
                 new[]
                 {
                     new Vector3(),
-                    new Vector3(4, 0),
-                    new Vector3(4, 4),
-                    new Vector3(0, 4)
+                    new Vector3(4.0, 0.0),
+                    new Vector3(4.0, 4.0),
+                    new Vector3(0.0, 4.0)
                 }
             );
             var p2 = new Polygon
             (
                 new[]
                 {
-                    new Vector3(3, 1),
-                    new Vector3(7, 1),
-                    new Vector3(7, 5),
-                    new Vector3(3, 5)
+                    new Vector3(3.0, 1.0),
+                    new Vector3(7.0, 1.0),
+                    new Vector3(7.0, 5.0),
+                    new Vector3(3.0, 5.0)
                 }
             );
+            var p3 = new Polygon
+            (
+                new[]
+                {
+                    new Vector3(3.0, 2.0),
+                    new Vector3(8.0, 2.0),
+                    new Vector3(8.0, 3.0),
+                    new Vector3(3.0, 3.0)
+                }
+            );
+            var ps = new List<Polygon> { p2, p3 };
+
             var vertices = p1.Union(p2).Vertices;
 
             Assert.Contains(vertices, p => p.X == 0.0 && p.Y == 0.0);
@@ -291,6 +377,22 @@ namespace Hypar.Tests
             Assert.Contains(vertices, p => p.X == 3.0 && p.Y == 5.0);
             Assert.Contains(vertices, p => p.X == 3.0 && p.Y == 4.0);
             Assert.Contains(vertices, p => p.X == 0.0 && p.Y == 4.0);
+
+            vertices = p1.Union(ps).Vertices;
+
+            Assert.Contains(vertices, p => p.X == 0.0 && p.Y == 0.0);
+            Assert.Contains(vertices, p => p.X == 4.0 && p.Y == 0.0);
+            Assert.Contains(vertices, p => p.X == 4.0 && p.Y == 1.0);
+            Assert.Contains(vertices, p => p.X == 7.0 && p.Y == 1.0);
+            Assert.Contains(vertices, p => p.X == 7.0 && p.Y == 2.0);
+            Assert.Contains(vertices, p => p.X == 8.0 && p.Y == 2.0);
+            Assert.Contains(vertices, p => p.X == 8.0 && p.Y == 3.0);
+            Assert.Contains(vertices, p => p.X == 7.0 && p.Y == 3.0);
+            Assert.Contains(vertices, p => p.X == 7.0 && p.Y == 5.0);
+            Assert.Contains(vertices, p => p.X == 3.0 && p.Y == 5.0);
+            Assert.Contains(vertices, p => p.X == 3.0 && p.Y == 4.0);
+            Assert.Contains(vertices, p => p.X == 0.0 && p.Y == 4.0);
+
         }
 
         [Fact]

--- a/csharp/test/PolygonTests.cs
+++ b/csharp/test/PolygonTests.cs
@@ -34,7 +34,6 @@ namespace Hypar.Tests
         {
             var v1 = new Vector3();
             var v2 = new Vector3(7.5, 7.5);
-            var vs = new List<Vector3> { v1, v2 };
             var p1 = new Polygon
             (
                 new[]
@@ -65,15 +64,12 @@ namespace Hypar.Tests
                     new Vector3(5.0, 10.0)
                 }
             );
-            var ps = new List<Polygon> { p2, p3 };
 
             Assert.False(p1.Contains(v1));
             Assert.True(p1.Contains(v2));
-            Assert.False(p1.Contains(vs));
             Assert.False(p1.Contains(p2));
             Assert.True(p1.Contains(p3));
             Assert.False(p3.Contains(p1));
-            Assert.False(p1.Contains(ps));
         }
 
         [Fact]
@@ -81,7 +77,6 @@ namespace Hypar.Tests
         {
             var v1 = new Vector3();
             var v2 = new Vector3(7.5, 7.5);
-            var vs = new List<Vector3> { v1, v2 };
             var p1 = new Polygon
             (
                 new[]
@@ -112,16 +107,12 @@ namespace Hypar.Tests
                 new Vector3(5.0, 10.0)
                 }
             );
-            var ps = new List<Polygon> { p2, p3 };
-
             Assert.True(p1.Covers(v1));
             Assert.True(p3.Covers(v2));
             Assert.False(p3.Covers(v1));
-            Assert.False(p3.Covers(vs));
             Assert.True(p1.Covers(p3));
             Assert.True(p1.Covers(p2));
             Assert.False(p3.Covers(p1));
-            Assert.True(p1.Covers(ps));
         }
 
         [Fact]
@@ -129,7 +120,6 @@ namespace Hypar.Tests
         {
             var v1 = new Vector3();
             var v2 = new Vector3(27.5, 27.5);
-            var vs = new List<Vector3> { v1, v2 };
             var p1 = new Polygon
             (
                 new[]
@@ -164,10 +154,8 @@ namespace Hypar.Tests
 
             Assert.True(p1.Disjoint(v2));
             Assert.False(p1.Disjoint(v1));
-            Assert.False(p1.Disjoint(vs));
             Assert.True(p1.Disjoint(p3));
             Assert.False(p1.Disjoint(p2));
-            Assert.False(p1.Disjoint(ps));
         }
 
         [Fact]
@@ -203,11 +191,9 @@ namespace Hypar.Tests
                 new Vector3(25.0, 210.0)
                 }
             );
-            var ps = new List<Polygon> { p2, p3 };
 
             Assert.True(p1.Intersects(p2));
             Assert.False(p1.Intersects(p3));
-            Assert.True(p1.Intersects(ps));
         }
 
         [Fact]


### PR DESCRIPTION
1) Fixed false positives on "Touches" when Polygons actually intersect.
2) Added methods for relationships between Vector3 point(s) and Polygons.
3) Multiple Polygon and Vector3 relationship methods are freestanding from single entity methods.
4) Simplified "Intersects" method.
5) Added Distinct operator to returned Clipper list on "Union" operation to avoid sending duplicate points to "ToPolygon".
6) Updated test suite to cover new methods.