### PR TITLE
Fixed bug in "Covers" which would give false negatives.

### DIFF
--- a/csharp/src/elements/Geometry/Polygon.cs
+++ b/csharp/src/elements/Geometry/Polygon.cs
@@ -346,7 +346,7 @@ namespace Hypar.Geometry
             var polygons = new List<Polygon>();
             foreach (List<IntPoint> path in solution)
             {
-                polygons.Add(PolygonExtensions.ToPolygon(path));
+                polygons.Add(PolygonExtensions.ToPolygon(path.Distinct().ToList()));
             }
             return polygons;
         }

--- a/csharp/src/elements/Geometry/Polygon.cs
+++ b/csharp/src/elements/Geometry/Polygon.cs
@@ -15,7 +15,6 @@ namespace Hypar.Geometry
     public partial class Polygon : Polyline
     {
         private const double scale = 1024.0;
-        private const double areaTolerance = 0.00001;
 
         /// <summary>
         /// The area enclosed by the polygon.
@@ -163,12 +162,7 @@ namespace Hypar.Geometry
             {
                 return false;
             }
-            var testPolygon = solution.First().ToPolygon();
-            if (Math.Abs(polygon.Area - testPolygon.Area) > areaTolerance)
-            {
-                return false;
-            }
-            return true;
+            return solution.First().ToPolygon().Area == polygon.ToClipperPath().ToPolygon().Area;
         }
 
         /// <summary>

--- a/csharp/src/elements/elements.csproj
+++ b/csharp/src/elements/elements.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://github.com/hypar-io/elements</PackageProjectUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
-    <Version>0.1.5</Version>
+    <Version>0.1.6</Version>
     <Tags>AEC, Architecture, Structure, Engineering</Tags>
   </PropertyGroup>
 


### PR DESCRIPTION
1) Area compare method of Intersection was sometimes faulty due to integer / double conversion. This improved method is exact, deletes a few lines of code, and eliminates the "magic number" areaTolerance.

2) Bumped version number.