### PR TITLE
Extensions

### DIFF
--- a/src/Elements/Element.cs
+++ b/src/Elements/Element.cs
@@ -82,7 +82,6 @@ namespace Elements
         /// </summary>
         /// <param name="name">The name of the parameter to remove.</param>
         /// <exception cref="System.Exception">Thrown when the specified parameter cannot be found.</exception>
-
         public void RemoveProperty(string name)
         {
             if (_properties.ContainsKey(name))

--- a/src/Elements/Model.cs
+++ b/src/Elements/Model.cs
@@ -31,6 +31,8 @@ namespace Elements
 
         private Dictionary<long, Profile> _profiles = new Dictionary<long, Profile>();
 
+        private List<string> _extensions = new List<string>();
+
         /// <summary>
         /// The version of the assembly.
         /// </summary>
@@ -80,6 +82,14 @@ namespace Elements
         }
 
         /// <summary>
+        /// A collection of extension identifiers which representing
+        /// extensions which must be available at the time of
+        /// serialization or deserialization.
+        /// </summary>
+        [JsonProperty("extensions")]
+        public IEnumerable<string> Extensions => _extensions;
+
+        /// <summary>
         /// Construct an empty model.
         /// </summary>
         public Model()
@@ -109,6 +119,8 @@ namespace Elements
             {
                 throw new ArgumentException("An Element with the same Id already exists in the Model.");
             }
+
+            AddExtension(element.GetType().Assembly.GetName().Name.ToLower());
         }
 
         /// <summary>
@@ -333,14 +345,23 @@ namespace Elements
         }
 
         internal Model(Dictionary<long, Element> elements, Dictionary<long, Material> materials, Dictionary<long, ElementType> elementTypes,
-                        Dictionary<long, Profile> profiles)
+                        Dictionary<long, Profile> profiles, List<string> extensions)
         {
             this._elements = elements;
             this._materials = materials;
             this._elementTypes = elementTypes;
             this._profiles = profiles;
+            this._extensions = extensions;
             AddMaterial(BuiltInMaterials.Edges);
             AddMaterial(BuiltInMaterials.Void);
+        }
+
+        private void AddExtension(string extensionId)
+        {
+            if(!_extensions.Contains(extensionId))
+            {
+                _extensions.Add(extensionId);
+            }
         }
 
         private void AddMaterial(Material material)

--- a/src/Elements/Serialization/ModelConverter.cs
+++ b/src/Elements/Serialization/ModelConverter.cs
@@ -37,12 +37,13 @@ namespace Elements.Serialization
                                 new[] { new ElementTypeConverter() });
             var profiles = JsonConvert.DeserializeObject<Dictionary<long, Profile>>(obj.GetValue("profiles").ToString(),
                                 new[] { new IProfileConverter() });
+            var extensions = JsonConvert.DeserializeObject<List<string>>(obj.GetValue("extensions").ToString());
             var elements = JsonConvert.DeserializeObject<Dictionary<long, Element>>(obj.GetValue("elements").ToString(),
                             new JsonSerializerSettings()
                             {
                                 Converters = new JsonConverter[]
                                                 {
-                                                    new ElementConverter(),
+                                                    new ElementConverter(extensions),
                                                     new MaterialToIdConverter(materials),
                                                     new ElementTypeToIdConverter(elementTypes),
                                                     new ProfileToIdConverter(profiles),
@@ -50,7 +51,7 @@ namespace Elements.Serialization
                                                 },
                                 NullValueHandling = NullValueHandling.Ignore
                             });
-            return new Model(elements, materials, elementTypes, profiles);
+            return new Model(elements, materials, elementTypes, profiles, extensions);
         }
 
         /// <summary>
@@ -64,27 +65,26 @@ namespace Elements.Serialization
             var model = (Model)value;
             writer.WriteStartObject();
 
+            var settings = new JsonSerializerSettings(){
+                Formatting = Formatting.Indented,
+                NullValueHandling = NullValueHandling.Ignore
+            };
+
+            // Write extensions
+            writer.WritePropertyName("extensions");
+            writer.WriteRawValue(JsonConvert.SerializeObject(model.Extensions));
+
             // Write materials
             writer.WritePropertyName("materials");
-            writer.WriteRawValue(JsonConvert.SerializeObject(model.Materials, new JsonSerializerSettings()
-            {
-                Formatting = Formatting.Indented
-            }));
+            writer.WriteRawValue(JsonConvert.SerializeObject(model.Materials, settings));
 
             // Write element types
             writer.WritePropertyName("element_types");
-            writer.WriteRawValue(JsonConvert.SerializeObject(model.ElementTypes, new JsonSerializerSettings()
-            {
-                Formatting = Formatting.Indented
-            }));
+            writer.WriteRawValue(JsonConvert.SerializeObject(model.ElementTypes, settings));
 
             // Write profiles
             writer.WritePropertyName("profiles");
-            writer.WriteRawValue(JsonConvert.SerializeObject(model.Profiles, new JsonSerializerSettings()
-            {
-                Formatting = Formatting.Indented,
-                NullValueHandling = NullValueHandling.Ignore
-            }));
+            writer.WriteRawValue(JsonConvert.SerializeObject(model.Profiles, settings));
 
             // Write elements
             writer.WritePropertyName("elements");

--- a/test/ExtensionTests.cs
+++ b/test/ExtensionTests.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Elements.Tests
+{
+    class TestElement : Element
+    {
+    }
+
+    public class ExtensionsTests
+    {
+        [Fact]
+        public void ExtensionTests()
+        {
+            var model = new Model();
+            model.AddElement(new TestElement());
+            var json = model.ToJson();
+            Console.WriteLine(json);
+            var newModel = Model.FromJson(json);
+            Assert.Equal(newModel.Extensions.Count(), 1);
+            Assert.Equal(newModel.Elements.Count, 1);
+        }
+    }
+}

--- a/test/ExtensionTests.cs
+++ b/test/ExtensionTests.cs
@@ -18,8 +18,8 @@ namespace Elements.Tests
             var json = model.ToJson();
             Console.WriteLine(json);
             var newModel = Model.FromJson(json);
-            Assert.Equal(newModel.Extensions.Count(), 1);
-            Assert.Equal(newModel.Elements.Count, 1);
+            Assert.Equal(1, newModel.Extensions.Count());
+            Assert.Equal(1, newModel.Elements.Count);
         }
     }
 }

--- a/test/ExtensionTests.cs
+++ b/test/ExtensionTests.cs
@@ -16,7 +16,6 @@ namespace Elements.Tests
             var model = new Model();
             model.AddElement(new TestElement());
             var json = model.ToJson();
-            Console.WriteLine(json);
             var newModel = Model.FromJson(json);
             Assert.Equal(1, newModel.Extensions.Count());
             Assert.Equal(1, newModel.Elements.Count);

--- a/test/elements-tests.csproj
+++ b/test/elements-tests.csproj
@@ -22,4 +22,8 @@
     <None Update="execution.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="elevations.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This PR introduces the concept of an extension as specified in #107. Extensions allow the deserialization of arbitrary types that implement IElement, as long as those types are loaded into the app domain. Unlike the previous way of finding IElement types, where the deserializer attempted to reflect on all loaded assemblies, hitting errors as mentioned in #104.

The way this works is that an extension is registered whenever a developer puts an IElement into a Model. The extensions property is then serialized to the JSON. Upon deserialization, the converter attempts to find all the assemblies loaded in the current app domain that are listed in the extensions property, then to deserialize the IElement using a type contained in one of those assemblies.