### PR TITLE
Remove the .Normalize() to fix PointAtInternal

### DIFF
--- a/src/Elements/Geometry/Polyline.cs
+++ b/src/Elements/Geometry/Polyline.cs
@@ -159,7 +159,7 @@ namespace Elements.Geometry
                 var a = this._vertices[i];
                 var b = this._vertices[i + 1];
                 var currLength = a.DistanceTo(b);
-                var currVec = (b - a).Normalized();
+                var currVec = (b - a)
                 if (totalLength <= d && totalLength + currLength >= d)
                 {
                     segmentIndex = i;

--- a/src/Elements/Geometry/Polyline.cs
+++ b/src/Elements/Geometry/Polyline.cs
@@ -159,7 +159,7 @@ namespace Elements.Geometry
                 var a = this._vertices[i];
                 var b = this._vertices[i + 1];
                 var currLength = a.DistanceTo(b);
-                var currVec = (b - a)
+                var currVec = (b - a);
                 if (totalLength <= d && totalLength + currLength >= d)
                 {
                     segmentIndex = i;

--- a/test/PolygonTests.cs
+++ b/test/PolygonTests.cs
@@ -501,6 +501,9 @@ namespace Elements.Geometry.Tests
             var p = new Polygon(new[]{a,b,c,d});
             Assert.Equal(4, p.Segments().Count());
             Assert.Equal(new Vector3(1.0, 1.0), p.PointAt(0.5));
+
+            var r = Polygon.Rectangle(2,2);
+            Assert.Equal(new Vector3(1,1,0), r.PointAt(0.5));
         }
 
         [Fact]


### PR DESCRIPTION
The Normalize method call when calculating the current vector is causing errors.  Line 166 does not want a normalized vector, it wants to compute how much of the full vector is needed to reach the desired paramter.  
Suggest adding a test in Polyline tests that looks like
``` C#
            var r = Polygon.Rectangle(2,2);
            Assert.Equal(new Vector3(1,1,0), r.PointAt(0.5));
```
This test, which uses a rectangle not of unit length will reveal the problem.