### PR TITLE
Openings

### DIFF
--- a/src/Elements/Floor.cs
+++ b/src/Elements/Floor.cs
@@ -4,6 +4,7 @@ using Elements.Geometry.Interfaces;
 using Newtonsoft.Json;
 using Hypar.Elements.Interfaces;
 using Elements.Geometry.Solids;
+using System.Collections.Generic;
 
 namespace Elements
 {
@@ -35,7 +36,7 @@ namespace Elements
         /// <summary>
         /// The openings in the floor.
         /// </summary>
-        public Opening[] Openings { get; }
+        public List<Opening> Openings { get; }
 
         /// <summary>
         /// The extrude direction of the floor.
@@ -60,10 +61,10 @@ namespace Elements
         /// <param name="elevation">The elevation of the top of the floor.</param>
         /// <param name="transform">The floor's transform. If set, this will override the floor's elevation.</param>
         /// <param name="openings">An array of openings in the floor.</param>
-        public Floor(Polygon profile, FloorType elementType, double elevation = 0.0, Transform transform = null, Opening[] openings = null)
+        public Floor(Polygon profile, FloorType elementType, double elevation = 0.0, Transform transform = null, List<Opening> openings = null)
         {
             this.Profile = new Profile(profile);
-            this.Openings = openings;
+            this.Openings = openings != null ? openings : new List<Opening>();
             this.Elevation = elevation;
             this.ElementType = elementType;
             var thickness = elementType.Thickness();
@@ -91,10 +92,10 @@ namespace Elements
         }
 
         [JsonConstructor]
-        internal Floor(Profile profile, FloorType elementType, double elevation = 0.0, Transform transform = null, Opening[] openings = null)
+        internal Floor(Profile profile, FloorType elementType, double elevation = 0.0, Transform transform = null, List<Opening> openings = null)
         {
             this.Profile = profile;
-            this.Openings = openings;
+            this.Openings = openings != null ? openings : new List<Opening>();
             this.Elevation = elevation;
             this.ElementType = elementType;
             var thickness = elementType.Thickness();

--- a/src/Elements/Interfaces/IHasOpenings.cs
+++ b/src/Elements/Interfaces/IHasOpenings.cs
@@ -1,4 +1,5 @@
 using Elements;
+using System.Collections.Generic;
 
 namespace Hypar.Elements.Interfaces
 {
@@ -10,6 +11,6 @@ namespace Hypar.Elements.Interfaces
         /// <summary>
         /// A collection of openings which are transformed in the coordinate system of their host element.
         /// </summary>
-        Opening[] Openings{get;}
+        List<Opening> Openings{get;}
     }
 }

--- a/src/Elements/Model.cs
+++ b/src/Elements/Model.cs
@@ -108,10 +108,46 @@ namespace Elements
                 throw new ArgumentException("An Element with the same Id already exists in the Model.");
             }
 
-            if(element is IAggregateElements)
+            if (element is IAggregateElements)
             {
                 var agg = (IAggregateElements)element;
                 AddElements(agg.Elements);
+            }
+
+            AddExtension(element.GetType().Assembly.GetName().Name.ToLower());
+        }
+
+                /// <summary>
+        /// Update an element existing in the model.
+        /// </summary>
+        /// <param name="element">The element to update in the model.</param>
+        /// <exception cref="System.ArgumentException">Thrown when no element 
+        /// with the same Id exists in the model.</exception>
+        public void UpdateElement(Element element)
+        {
+            if (element == null)
+            {
+                return;
+            }
+
+            if (this._elements.ContainsKey(element.Id))
+            {
+                // remove the previous element
+                this._elements.Remove(element.Id);
+                // Update the element itselft
+                this._elements.Add(element.Id, element);
+                // Update the root elements
+                GetRootLevelElementData(element);
+            }
+            else
+            {
+                throw new ArgumentException("No Element with this Id exists in the Model.");
+            }
+
+            if (element is IAggregateElements)
+            {
+                var agg = (IAggregateElements)element;
+                UpdateElements(agg.Elements);
             }
 
             AddExtension(element.GetType().Assembly.GetName().Name.ToLower());
@@ -126,6 +162,18 @@ namespace Elements
             foreach (var e in elements)
             {
                 AddElement(e);
+            }
+        }
+
+                /// <summary>
+        /// Update a collection of elements in the model.
+        /// </summary>
+        /// <param name="elements">The elements to be updated in the model.</param>
+        public void UpdateElements(IEnumerable<Element> elements)
+        {
+            foreach (var e in elements)
+            {
+                UpdateElement(e);
             }
         }
 
@@ -260,7 +308,7 @@ namespace Elements
 
         private void GetRootLevelElementData(IElement element)
         {
-            if(element is IMaterial)
+            if (element is IMaterial)
             {
                 var mat = (IMaterial)element;
                 AddMaterial(mat.Material);
@@ -278,9 +326,9 @@ namespace Elements
             if (element is IHasOpenings)
             {
                 var ho = (IHasOpenings)element;
-                if(ho.Openings != null)
+                if (ho.Openings != null)
                 {
-                    foreach(var o in ho.Openings)
+                    foreach (var o in ho.Openings)
                     {
                         AddProfile(o.Profile);
                     }
@@ -293,7 +341,7 @@ namespace Elements
                 if (wtp.ElementType != null)
                 {
                     AddElementType(wtp.ElementType);
-                    foreach(var layer in wtp.ElementType.MaterialLayers)
+                    foreach (var layer in wtp.ElementType.MaterialLayers)
                     {
                         AddMaterial(layer.Material);
                     }
@@ -306,17 +354,17 @@ namespace Elements
                 if (ftp.ElementType != null)
                 {
                     AddElementType(ftp.ElementType);
-                    foreach(var layer in ftp.ElementType.MaterialLayers)
+                    foreach (var layer in ftp.ElementType.MaterialLayers)
                     {
                         AddMaterial(layer.Material);
                     }
                 }
             }
 
-            if(element is IElementType<StructuralFramingType>)
+            if (element is IElementType<StructuralFramingType>)
             {
                 var sft = (IElementType<StructuralFramingType>)element;
-                if(sft.ElementType != null)
+                if (sft.ElementType != null)
                 {
                     AddElementType(sft.ElementType);
                     AddProfile(sft.ElementType.Profile);

--- a/src/Elements/Serialization/glTF/GltfExtensions.cs
+++ b/src/Elements/Serialization/glTF/GltfExtensions.cs
@@ -627,7 +627,7 @@ namespace Elements.Serialization.glTF
                         // The voids in the profiles are concatenated with the
                         // voids provided by the openings.
                         Polygon[] voids = null;
-                        if(o.Openings != null && o.Openings.Length > 0)
+                        if(o.Openings != null && o.Openings.Count > 0)
                         {
                             if(ex.Profile.Voids == null)
                             {

--- a/src/Elements/StandardWall.cs
+++ b/src/Elements/StandardWall.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Elements.Geometry;
 using Elements.Geometry.Solids;
 using Hypar.Elements.Interfaces;
@@ -18,7 +19,7 @@ namespace Elements
         /// <summary>
         /// An array of openings in the wall.
         /// </summary>
-        public Opening[] Openings{ get; protected set;}
+        public List<Opening> Openings{ get; protected set;}
 
         /// <summary>
         /// Extrude to both sides?
@@ -36,7 +37,7 @@ namespace Elements
         /// This transform will be concatenated to the transform created to describe the wall in 2D.</param>
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the height of the wall is less than or equal to zero.</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the Z components of wall's start and end points are not the same.</exception>
-        public StandardWall(Line centerLine, WallType elementType, double height, Opening[] openings = null, Transform transform = null)
+        public StandardWall(Line centerLine, WallType elementType, double height, List<Opening> openings = null, Transform transform = null)
         {
             if (height <= 0.0)
             {
@@ -51,7 +52,7 @@ namespace Elements
             this.CenterLine = centerLine;
             this.Height = height;
             this.ElementType = elementType;
-            this.Openings = openings;
+            this.Openings = openings != null ? openings : new List<Opening>();
             
             // Construct a transform whose X axis is the centerline of the wall.
             // The wall is described as if it's lying flat in the XY plane of that Transform.

--- a/test/BuildingTests.cs
+++ b/test/BuildingTests.cs
@@ -29,7 +29,7 @@ namespace Elements.Tests
 
             foreach(var el in elevations)
             {
-                var slab = new Floor(site, floorType, el, null, new[]{opening});
+                var slab = new Floor(site, floorType, el, null, new List<Opening>(){opening});
                 this.Model.AddElement(slab);
                 var edgeBeams = slab.CreateEdgeBeams(beamType);
                 this.Model.AddElements(edgeBeams);

--- a/test/FloorTests.cs
+++ b/test/FloorTests.cs
@@ -51,10 +51,14 @@ namespace Elements.Tests
 
             this.Model.AddElement(floor1);
 
-            foreach (Floor floor in this.Model.ElementsOfType<Floor>())
+            List<Floor> updatedFloors = new List<Floor>(this.Model.ElementsOfType<Floor>());
+
+            foreach (Floor floor in updatedFloors)
             {
                 floor.Openings.AddRange(openings);
             }
+
+            this.Model.UpdateElements(updatedFloors);
 
             Assert.Equal(2, floor1.Openings.Count);
         }

--- a/test/FloorTests.cs
+++ b/test/FloorTests.cs
@@ -13,8 +13,8 @@ namespace Elements.Tests
         {
             this.Name = "Floor";
             var p = Polygon.L(10, 20, 5);
-            var floorType = new FloorType("test", new List<MaterialLayer>{new MaterialLayer(new Material("green", Colors.Green, 0.0f,0.0f),0.1)});
-            var openings = new Opening[]{
+            var floorType = new FloorType("test", new List<MaterialLayer> { new MaterialLayer(new Material("green", Colors.Green, 0.0f, 0.0f), 0.1) });
+            var openings = new List<Opening>(){
                 new Opening(1, 1, 1, 1),
                 new Opening(3, 3, 1, 3),
             };
@@ -22,7 +22,7 @@ namespace Elements.Tests
 
             var model = new Model();
 
-            Assert.Equal(2, floor1.Openings.Length);
+            Assert.Equal(2, floor1.Openings.Count);
             Assert.Equal(0.5, floor1.Elevation);
             Assert.Equal(0.1, floor1.ElementType.Thickness());
             Assert.Equal(0.5, floor1.Transform.Origin.Z);
@@ -31,11 +31,40 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void FloorWithAddedOpenings()
+        {
+            this.Name = "FloorWithAddedOpenings";
+            var p = Polygon.L(10, 20, 5);
+            var floorType = new FloorType("test", new List<MaterialLayer> { new MaterialLayer(new Material("green", Colors.Green, 0.0f, 0.0f), 0.1) });
+            var openings = new List<Opening>(){
+                new Opening(1, 1, 1, 1),
+                new Opening(3, 3, 1, 3),
+            };
+            var floor1 = new Floor(p, floorType, 0.5, null, null);
+
+            var model = new Model();
+
+            Assert.Equal(0, floor1.Openings.Count);
+            Assert.Equal(0.5, floor1.Elevation);
+            Assert.Equal(0.1, floor1.ElementType.Thickness());
+            Assert.Equal(0.5, floor1.Transform.Origin.Z);
+
+            this.Model.AddElement(floor1);
+
+            foreach (Floor floor in this.Model.ElementsOfType<Floor>())
+            {
+                floor.Openings.AddRange(openings);
+            }
+
+            Assert.Equal(2, floor1.Openings.Count);
+        }
+
+        [Fact]
         public void ZeroThickness()
         {
             var model = new Model();
-            var poly = Polygon.Rectangle(width:20, height:20);
-            Assert.Throws<ArgumentOutOfRangeException>(()=> {var floorType = new FloorType("test", 0.0);});
+            var poly = Polygon.Rectangle(width: 20, height: 20);
+            Assert.Throws<ArgumentOutOfRangeException>(() => { var floorType = new FloorType("test", 0.0); });
         }
 
         [Fact]
@@ -47,7 +76,7 @@ namespace Elements.Tests
             var o1 = new Opening(p1, 1, 1);
             var o2 = new Opening(p2, 3, 3);
             var floorType = new FloorType("test", 0.2);
-            var floor = new Floor(Polygon.Rectangle(10, 10), floorType, 0.0, null, new []{o1,o2});
+            var floor = new Floor(Polygon.Rectangle(10, 10), floorType, 0.0, null, new List<Opening>() { o1, o2 });
             Assert.Equal(100.0, floor.Area());
         }
     }

--- a/test/WallTests.cs
+++ b/test/WallTests.cs
@@ -12,10 +12,10 @@ namespace Elements.Tests
         public void Wall()
         {
             this.Name = "Wall";
-            var testWallType = new WallType("test", new List<MaterialLayer>{new MaterialLayer(new Material("blue", Colors.Blue, 0.0f, 0.0f), 0.1)});
+            var testWallType = new WallType("test", new List<MaterialLayer> { new MaterialLayer(new Material("blue", Colors.Blue, 0.0f, 0.0f), 0.1) });
 
-            var l = new Line(new Vector3(0,0,0), new Vector3(10,10,0));
-            var openings = new Opening[]{
+            var l = new Line(new Vector3(0, 0, 0), new Vector3(10, 10, 0));
+            var openings = new List<Opening>(){
                 new Opening(1.0, 2.0, 1.0, 1.0),
                 new Opening(3.0, 1.0, 1.0, 2.0),
                 new Opening(Polygon.Ngon(3, 2.0), 8,2)
@@ -28,13 +28,39 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void WallWithAddedOpenings()
+        {
+            this.Name = "WallWithAddedOpenings";
+            var testWallType = new WallType("test", new List<MaterialLayer> { new MaterialLayer(new Material("blue", Colors.Blue, 0.0f, 0.0f), 0.1) });
+
+            var l = new Line(new Vector3(0, 0, 0), new Vector3(10, 10, 0));
+            var openings = new List<Opening>(){
+                new Opening(1.0, 2.0, 1.0, 1.0),
+                new Opening(3.0, 1.0, 1.0, 2.0),
+                new Opening(Polygon.Ngon(3, 2.0), 8,2)
+            };
+
+            var frameProfile = new Profile(Polygon.Rectangle(0.075, 0.01));
+
+            var w = new StandardWall(l, testWallType, 3.0, null);
+            this.Model.AddElement(w);
+
+            foreach (StandardWall wall in this.Model.ElementsOfType<StandardWall>())
+            {
+                wall.Openings.AddRange(openings);
+            }
+
+            Assert.Equal(3, w.Openings.Count);
+        }
+
+        [Fact]
         public void ZeroHeight()
         {
             var a = Vector3.Origin;
             var b = new Vector3(0.0, 5.0);
-            var line = new Line(a,b);
+            var line = new Line(a, b);
             var testWallType = new WallType("test", 0.1);
-            Assert.Throws<ArgumentOutOfRangeException>(()=>new StandardWall(line, testWallType, 0.0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new StandardWall(line, testWallType, 0.0));
         }
 
         [Fact]
@@ -42,8 +68,8 @@ namespace Elements.Tests
         {
             var a = Vector3.Origin;
             var b = new Vector3(0.0, 5.0);
-            var line = new Line(a,b);
-            Assert.Throws<ArgumentOutOfRangeException>(()=>{var testWallType = new WallType("test", 0.0);});
+            var line = new Line(a, b);
+            Assert.Throws<ArgumentOutOfRangeException>(() => { var testWallType = new WallType("test", 0.0); });
         }
 
         [Fact]
@@ -51,9 +77,9 @@ namespace Elements.Tests
         {
             var a = Vector3.Origin;
             var b = new Vector3(0.0, 5.0, 5.0);
-            var line = new Line(a,b);
+            var line = new Line(a, b);
             var testWallType = new WallType("test", 0.1);
-            Assert.Throws<ArgumentException>(()=>new StandardWall(line, testWallType, 5.0));
+            Assert.Throws<ArgumentException>(() => new StandardWall(line, testWallType, 5.0));
         }
 
         [Fact]
@@ -61,7 +87,7 @@ namespace Elements.Tests
         {
             var a = Vector3.Origin;
             var b = new Vector3(0.0, 5.0);
-            var line = new Line(a,b);
+            var line = new Line(a, b);
             var testWallType = new WallType("test", 0.1);
             var wall = new StandardWall(line, testWallType, 4.0);
             Assert.Null(wall.Openings);

--- a/test/WallTests.cs
+++ b/test/WallTests.cs
@@ -94,7 +94,7 @@ namespace Elements.Tests
             var line = new Line(a, b);
             var testWallType = new WallType("test", 0.1);
             var wall = new StandardWall(line, testWallType, 4.0);
-            Assert.Null(wall.Openings);
+            Assert.Equal(0, wall.Openings.Count);
         }
     }
 }

--- a/test/WallTests.cs
+++ b/test/WallTests.cs
@@ -45,10 +45,14 @@ namespace Elements.Tests
             var w = new StandardWall(l, testWallType, 3.0, null);
             this.Model.AddElement(w);
 
-            foreach (StandardWall wall in this.Model.ElementsOfType<StandardWall>())
+            List<StandardWall> updatedWalls = new List<StandardWall>(this.Model.ElementsOfType<StandardWall>());
+
+            foreach (StandardWall wall in updatedWalls)
             {
                 wall.Openings.AddRange(openings);
             }
+
+            this.Model.UpdateElements(updatedWalls);
 
             Assert.Equal(3, w.Openings.Count);
         }


### PR DESCRIPTION
Following on the #139 to be able to add openings after the creation of a wall or a floor, this pull request contains:

- Change from an array `Opening[]` to a `List<Opening>` to be able to easily add openings (in `StandardWall` and `Floor`)
- Add the `UpdateElement` (and `UpdateElements`) method on the `Model` class to be able to update an Element after it has been added to the model.
- Updated 'FloorTests' and 'WallTests' to test for these modifications