### PR TITLE
Change GetHashCode() on Vector3

### DIFF
--- a/src/Elements/Geometry/Vector3.cs
+++ b/src/Elements/Geometry/Vector3.cs
@@ -66,7 +66,7 @@ namespace Elements.Geometry
         /// <returns></returns>
         public override int GetHashCode()
         {
-            return new[] { this.ToArray() }.GetHashCode();
+            return this.ToString().GetHashCode();
         }
 
         /// <summary>


### PR DESCRIPTION
To solve #147 , I propose a different implementation for `GetHashCode()` on `Vector3`