### PR TITLE
Test that Geometry for spaces is actually created if profile used

### DIFF
--- a/src/Elements/Space.cs
+++ b/src/Elements/Space.cs
@@ -110,6 +110,7 @@ namespace Elements
             this.Transform = transform != null ? transform : new Transform(new Vector3(0, 0, elevation));
             this.Material = material == null ? BuiltInMaterials.Mass : material;
             this.Height = height;
+            this.Geometry = Solid.SweepFace(profile, new Polygon[] {}, this.Height, this.BothSides);
         }
 
         /// <summary>

--- a/test/SpaceTests.cs
+++ b/test/SpaceTests.cs
@@ -19,6 +19,7 @@ namespace Elements.Tests
             var material = new Material("Space Color", Colors.Coral, 0.0f, 0.0f);
             var space = new Space(profile, 10, 0, material);
 
+            Assert.NotNull(space.Geometry);
             this.Model.AddElement(space);
         }
 


### PR DESCRIPTION
Spaces currently don't have their geometry created if they are created with a profile.  This adds a test that geometry exists and also generates the geometry.

If users are meant to generate the geometry themselves from the properties of the IExtrude interface, that's fine, but then the space should probably not be an ISolid, which implies there will be readily available geometry for the user to access.