### PR TITLE
Don't return after adding IAggregateElement geometry

### DIFF
--- a/src/Elements/Serialization/glTF/GltfExtensions.cs
+++ b/src/Elements/Serialization/glTF/GltfExtensions.cs
@@ -575,8 +575,6 @@ namespace Elements.Serialization.glTF
                         GetRenderDataForElement(esub, gltf, materials, lines, buffer);
                     }
                 }
-
-                return;
             }
 
             var materialName = BuiltInMaterials.Default.Name;


### PR DESCRIPTION
Users (aka Eric) might want to add geometry of an element as well as the geometry of the aggregated elements, so we should not return from the GetRenderDataForElement method just because we've finished adding the aggregated geometries.