### PR TITLE
Performance improvements for glTF write.

### DIFF
--- a/src/Elements/Geometry/Solids/Face.cs
+++ b/src/Elements/Geometry/Solids/Face.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Text;
-using Newtonsoft.Json;
 
 namespace Elements.Geometry.Solids
 {

--- a/src/Elements/Geometry/Solids/Solid.cs
+++ b/src/Elements/Geometry/Solids/Solid.cs
@@ -380,17 +380,12 @@ namespace Elements.Geometry.Solids
             
             var tessellations = new Tess[this.Faces.Count];
 
-            // TODO: I would prefer to get the normals from the tesselated elements,
-            // but my experience has been that those normals are not consistent.
-            var normals = new Vector3[this.Faces.Count];
-
             var fi = 0;
             foreach (var f in this.Faces.Values)
             {
                 var tess = new Tess();
                 tess.NoEmptyPolygons = true;
                 tess.AddContour(f.Outer.ToContourVertexArray(f));
-                normals[fi] = f.Outer.Face.Plane().Normal;
 
                 if (f.Inner != null)
                 {
@@ -437,7 +432,11 @@ namespace Elements.Geometry.Solids
             for(var i=0; i<tessellations.Length; i++)
             {
                 var tess = tessellations[i];
-                var n = normals[i];
+
+                var a = tess.Vertices[tess.Elements[0]].Position.ToVector3();
+                var b = tess.Vertices[tess.Elements[1]].Position.ToVector3();
+                var c = tess.Vertices[tess.Elements[2]].Position.ToVector3();
+                var n = (b-a).Cross(c-a).Normalized();
 
                 for (var j = 0; j < tess.Vertices.Length; j++)
                 {

--- a/src/Elements/Serialization/glTF/GltfExtensions.cs
+++ b/src/Elements/Serialization/glTF/GltfExtensions.cs
@@ -680,6 +680,7 @@ namespace Elements.Serialization.glTF
             List<BufferView> bufferViews, List<Accessor> accessors)
         {
             var currLines = lines.Last();
+            // var sw = new Stopwatch();
 
             foreach (var edge in solid.Edges.Values)
             {
@@ -702,8 +703,10 @@ namespace Elements.Serialization.glTF
                     currLines.AddRange(new[] { edge.Left.Vertex.Point, edge.Right.Vertex.Point });
                 }
             }
-
-            // var sw = new Stopwatch();
+            // sw.Stop();
+            // Console.WriteLine($"glTF:\t\t{sw.Elapsed} for parsing the edges.");
+            // sw.Reset();
+            
             // sw.Start();
             byte[] vertexBuffer;
             byte[] normalBuffer;

--- a/src/Elements/Serialization/glTF/GltfExtensions.cs
+++ b/src/Elements/Serialization/glTF/GltfExtensions.cs
@@ -578,7 +578,7 @@ namespace Elements.Serialization.glTF
         private static void GetRenderDataForElement(IElement e, Gltf gltf, 
             Dictionary<string, int> materials, List<List<Vector3>> lines, List<byte> buffer, List<BufferView> bufferViews , List<Accessor> accessors)
         {
-            // var sw = new Stopwatch();
+            var sw = new Stopwatch();
             // sw.Start();
             if (e is IAggregateElements)
             {
@@ -679,7 +679,6 @@ namespace Elements.Serialization.glTF
             ref Dictionary<string, int> materials, ref List<List<Vector3>> lines, ref List<byte> buffer, 
             List<BufferView> bufferViews, List<Accessor> accessors)
         {
-            Elements.Geometry.Mesh mesh = null;
             var currLines = lines.Last();
 
             foreach (var edge in solid.Edges.Values)
@@ -706,14 +705,6 @@ namespace Elements.Serialization.glTF
 
             // var sw = new Stopwatch();
             // sw.Start();
-
-            mesh = new Elements.Geometry.Mesh();
-            solid.Tessellate(ref mesh);
-            // sw.Stop();
-            // Console.WriteLine($"glTF:\t\t{sw.Elapsed} for tessellating the solid.");
-            // sw.Reset();
-
-            // sw.Start();
             byte[] vertexBuffer;
             byte[] normalBuffer;
             byte[] indexBuffer;
@@ -723,11 +714,11 @@ namespace Elements.Serialization.glTF
             float[] cmin; float[] cmax;
             ushort imin; ushort imax;
 
-            mesh.GetBuffers(out vertexBuffer, out indexBuffer, out normalBuffer, out colorBuffer,
+            solid.Tessellate(out vertexBuffer, out indexBuffer, out normalBuffer, out colorBuffer,
                             out vmax, out vmin, out nmin, out nmax, out cmin,
                             out cmax, out imin, out imax);
             // sw.Stop();
-            // Console.WriteLine($"glTF:\t\t{sw.Elapsed} for getting the mesh buffers.");
+            // Console.WriteLine($"glTF:\t\t{sw.Elapsed} for tessellating the solid.");
             // sw.Reset();
 
             // sw.Start();

--- a/test/GridTests.cs
+++ b/test/GridTests.cs
@@ -1,9 +1,4 @@
-using Elements.Geometry;
 using Elements.Geometry.Profiles;
-using Elements;
-using System;
-using System.IO;
-using System.Linq;
 using Xunit;
 using Elements.Tests;
 

--- a/test/IFCTests.cs
+++ b/test/IFCTests.cs
@@ -1,11 +1,8 @@
 using Elements.Geometry;
-using Elements;
 using System;
 using System.IO;
-using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
-using System.Reflection;
 using System.Collections.Generic;
 using Elements.Geometry.Profiles;
 

--- a/test/StructuralFramingTests.cs
+++ b/test/StructuralFramingTests.cs
@@ -1,4 +1,3 @@
-using Elements;
 using Elements.Geometry;
 using Elements.Geometry.Interfaces;
 using Elements.Geometry.Profiles;


### PR DESCRIPTION
This PR addresses #177. Instead of writing tessellated solid data to a mesh and then converting that mesh into buffers appropriate for glTF, we write the tessellated solid information directly to buffers.