### PR TITLE
Added constructor boolean to set floor extrusion direction along z-axis

### DIFF
--- a/src/Elements/Floor.cs
+++ b/src/Elements/Floor.cs
@@ -69,7 +69,8 @@ namespace Elements
         /// <param name="elevation">The elevation of the top of the floor.</param>
         /// <param name="transform">The floor's transform. If set, this will override the floor's elevation.</param>
         /// <param name="openings">An array of openings in the floor.</param>
-        public Floor(Polygon profile, FloorType elementType, double elevation = 0.0, Transform transform = null, List<Opening> openings = null)
+        /// <param name="extrudeUp">A boolean indicating the polygon extrusion direction along either the positive or negative z-axis. Defaults to positive.</param>
+        public Floor(Polygon profile, FloorType elementType, double elevation = 0.0, Transform transform = null, List<Opening> openings = null, bool extrudeUp = true)
         {
             this.Profile = new Profile(profile);
             if(openings != null)
@@ -80,7 +81,14 @@ namespace Elements
             this.ElementType = elementType;
             var thickness = elementType.Thickness();
             this.Transform = transform != null ? transform : new Transform(new Vector3(0, 0, elevation));
-            this.ExtrudeDirection = Vector3.ZAxis;
+            if (extrudeUp)
+            {
+                this.ExtrudeDirection = Vector3.ZAxis;
+            }
+            else
+            {
+                this.ExtrudeDirection = Vector3.ZAxis * -1;
+            }
         }
 
         /// <summary>
@@ -92,6 +100,7 @@ namespace Elements
         /// <param name="elementType">The floor type of the floor.</param>
         /// <param name="elevation">The elevation of the floor.</param>
         /// <param name="transform">The floor's transform. If set, this will override the elevation.</param>
+        /// <param name="extrudeUp">A boolean indicating the polygon extrusion direction along either the positive or negative z-axis. Defaults to positive.</param>/// 
         public Floor(Profile profile, Transform start, Vector3 direction, FloorType elementType, double elevation = 0.0, Transform transform = null)
         {
             this.Elevation = elevation;

--- a/src/Elements/Floor.cs
+++ b/src/Elements/Floor.cs
@@ -1,3 +1,4 @@
+using System;
 using Elements.Geometry;
 using Elements.Interfaces;
 using Elements.Geometry.Interfaces;
@@ -64,15 +65,14 @@ namespace Elements
         /// <summary>
         /// Create a floor.
         /// </summary>
-        /// <param name="profile">The profile of the floor.</param>
+        /// <param name="polygon">The polygon representing the floor perimeter.</param>
         /// <param name="elementType">The floor type of the floor.</param>
         /// <param name="elevation">The elevation of the top of the floor.</param>
         /// <param name="transform">The floor's transform. If set, this will override the floor's elevation.</param>
         /// <param name="openings">An array of openings in the floor.</param>
-        /// <param name="extrudeUp">A boolean indicating the polygon extrusion direction along either the positive or negative z-axis. Defaults to positive.</param>
-        public Floor(Polygon profile, FloorType elementType, double elevation = 0.0, Transform transform = null, List<Opening> openings = null, bool extrudeUp = true)
+        /// <param name="extrudeUp">Indicates the polygon extrusion direction along either the positive or negative z-axis. Default is positive.</param>
+        public Floor(Polygon polygon, FloorType elementType, double elevation = 0.0, Transform transform = null, List<Opening> openings = null, bool extrudeUp = true)
         {
-            this.Profile = new Profile(profile);
             if(openings != null)
             {
                 this._openings = openings;
@@ -80,13 +80,18 @@ namespace Elements
             this.Elevation = elevation;
             this.ElementType = elementType;
             var thickness = elementType.Thickness();
-            this.Transform = transform != null ? transform : new Transform(new Vector3(0, 0, elevation));
+            this.Transform = transform ?? new Transform(new Vector3(0, 0, elevation));
             if (extrudeUp)
             {
+                this.Profile = new Profile(polygon);
                 this.ExtrudeDirection = Vector3.ZAxis;
             }
             else
             {
+                var vertices = new Vector3[polygon.Vertices.Length];
+                Array.Copy(polygon.Vertices, vertices, polygon.Vertices.Length);
+                Array.Reverse(vertices);
+                this.Profile = new Profile(new Polygon(vertices));
                 this.ExtrudeDirection = Vector3.ZAxis * -1;
             }
         }
@@ -100,20 +105,18 @@ namespace Elements
         /// <param name="elementType">The floor type of the floor.</param>
         /// <param name="elevation">The elevation of the floor.</param>
         /// <param name="transform">The floor's transform. If set, this will override the elevation.</param>
-        /// <param name="extrudeUp">A boolean indicating the polygon extrusion direction along either the positive or negative z-axis. Defaults to positive.</param>/// 
         public Floor(Profile profile, Transform start, Vector3 direction, FloorType elementType, double elevation = 0.0, Transform transform = null)
         {
             this.Elevation = elevation;
             this.ElementType = elementType;
-            this.Transform = transform != null ? transform : new Transform(new Vector3(0, 0, elevation));
+            this.Transform = transform ?? new Transform(new Vector3(0, 0, elevation));
             this.Profile = start.OfProfile(profile);
             this.ExtrudeDirection = start.OfVector(direction);
         }
 
         [JsonConstructor]
-        internal Floor(Profile profile, FloorType elementType, double elevation = 0.0, Transform transform = null, List<Opening> openings = null)
+        internal Floor(Profile profile, FloorType elementType, double elevation = 0.0, Transform transform = null, List<Opening> openings = null, bool extrudeUp = true)
         {
-            this.Profile = profile;
             if(openings != null)
             {
                 this._openings = openings;
@@ -122,7 +125,19 @@ namespace Elements
             this.ElementType = elementType;
             var thickness = elementType.Thickness();
             this.Transform = transform != null ? transform : new Transform(new Vector3(0, 0, elevation));
-            this.ExtrudeDirection = Vector3.ZAxis;
+            if (extrudeUp)
+            {
+                this.Profile = profile;
+                this.ExtrudeDirection = Vector3.ZAxis;
+            }
+            else
+            {
+                var vertices = new Vector3[profile.Perimeter.Vertices.Length];
+                Array.Copy(profile.Perimeter.Vertices, vertices, profile.Perimeter.Vertices.Length);
+                Array.Reverse(vertices);
+                this.Profile = new Profile(new Polygon(vertices));
+                this.ExtrudeDirection = Vector3.ZAxis * -1;
+            }
         }
 
         /// <summary>

--- a/src/Elements/Floor.cs
+++ b/src/Elements/Floor.cs
@@ -65,13 +65,12 @@ namespace Elements
         /// <summary>
         /// Create a floor.
         /// </summary>
-        /// <param name="polygon">The polygon representing the floor perimeter.</param>
+        /// <param name="perimeter">The floor perimeter.</param>
         /// <param name="elementType">The floor type of the floor.</param>
         /// <param name="elevation">The elevation of the top of the floor.</param>
         /// <param name="transform">The floor's transform. If set, this will override the floor's elevation.</param>
         /// <param name="openings">An array of openings in the floor.</param>
-        /// <param name="extrudeUp">Indicates the polygon extrusion direction along either the positive or negative z-axis. Default is positive.</param>
-        public Floor(Polygon polygon, FloorType elementType, double elevation = 0.0, Transform transform = null, List<Opening> openings = null, bool extrudeUp = true)
+        public Floor(Polygon perimeter, FloorType elementType, double elevation = 0.0, Transform transform = null, List<Opening> openings = null)
         {
             if(openings != null)
             {
@@ -81,63 +80,41 @@ namespace Elements
             this.ElementType = elementType;
             var thickness = elementType.Thickness();
             this.Transform = transform ?? new Transform(new Vector3(0, 0, elevation));
-            if (extrudeUp)
-            {
-                this.Profile = new Profile(polygon);
-                this.ExtrudeDirection = Vector3.ZAxis;
-            }
-            else
-            {
-                var vertices = new Vector3[polygon.Vertices.Length];
-                Array.Copy(polygon.Vertices, vertices, polygon.Vertices.Length);
-                Array.Reverse(vertices);
-                this.Profile = new Profile(new Polygon(vertices));
-                this.ExtrudeDirection = Vector3.ZAxis * -1;
-            }
+            this.Profile = new Profile(perimeter.Reversed());
+            this.ExtrudeDirection = Vector3.ZAxis * -1;
         }
 
         /// <summary>
         /// Create a floor.
         /// </summary>
-        /// <param name="profile">The profile of the floor.</param>
+        /// <param name="perimeter">The floor perimeter.</param>
         /// <param name="start">A tranform used to pre-transform the profile and direction vector before sweeping the geometry.</param>
         /// <param name="direction">The direction of the floor's sweep.</param>
         /// <param name="elementType">The floor type of the floor.</param>
         /// <param name="elevation">The elevation of the floor.</param>
         /// <param name="transform">The floor's transform. If set, this will override the elevation.</param>
-        public Floor(Profile profile, Transform start, Vector3 direction, FloorType elementType, double elevation = 0.0, Transform transform = null)
+        public Floor(Profile perimeter, Transform start, Vector3 direction, FloorType elementType, double elevation = 0.0, Transform transform = null)
         {
             this.Elevation = elevation;
             this.ElementType = elementType;
             this.Transform = transform ?? new Transform(new Vector3(0, 0, elevation));
-            this.Profile = start.OfProfile(profile);
+            this.Profile = start.OfProfile(perimeter);
             this.ExtrudeDirection = start.OfVector(direction);
         }
 
         [JsonConstructor]
-        internal Floor(Profile profile, FloorType elementType, double elevation = 0.0, Transform transform = null, List<Opening> openings = null, bool extrudeUp = true)
+        internal Floor(Profile profile, FloorType elementType, double elevation = 0.0, Transform transform = null, List<Opening> openings = null)
         {
-            if(openings != null)
+            this.Profile = profile;
+            if (openings != null)
             {
                 this._openings = openings;
             }
             this.Elevation = elevation;
             this.ElementType = elementType;
             var thickness = elementType.Thickness();
-            this.Transform = transform != null ? transform : new Transform(new Vector3(0, 0, elevation));
-            if (extrudeUp)
-            {
-                this.Profile = profile;
-                this.ExtrudeDirection = Vector3.ZAxis;
-            }
-            else
-            {
-                var vertices = new Vector3[profile.Perimeter.Vertices.Length];
-                Array.Copy(profile.Perimeter.Vertices, vertices, profile.Perimeter.Vertices.Length);
-                Array.Reverse(vertices);
-                this.Profile = new Profile(new Polygon(vertices));
-                this.ExtrudeDirection = Vector3.ZAxis * -1;
-            }
+            this.Transform = transform ?? new Transform(new Vector3(0, 0, elevation));
+            this.ExtrudeDirection = Vector3.ZAxis;
         }
 
         /// <summary>

--- a/src/Elements/Geometry/Polygon.cs
+++ b/src/Elements/Geometry/Polygon.cs
@@ -567,19 +567,12 @@ namespace Elements.Geometry
         {
             var x = 0.0;
             var y = 0.0;
-            var factor = 0.0;
-            for (var i = 0; i < this._vertices.Length; i++)
+            foreach (var pnt in Vertices)
             {
-                factor =
-                    (_vertices[i].X * _vertices[(i + 1) % _vertices.Length].Y) -
-                    (_vertices[(i + 1) % _vertices.Length].X * _vertices[i].Y);
-                x += (_vertices[i].X + _vertices[(i + 1) % _vertices.Length].X) * factor;
-                y += (_vertices[i].Y + _vertices[(i + 1) % _vertices.Length].Y) * factor;
+                x += pnt.X;
+                y += pnt.Y;
             }
-            var divisor = this.Area() * 6;
-            x /= divisor;
-            y /= divisor;
-            return new Vector3(x, y);
+            return new Vector3(x / Vertices.Length, y / Vertices.Length);
         }
 
         /// <summary>

--- a/src/Elements/Geometry/Polygon.cs
+++ b/src/Elements/Geometry/Polygon.cs
@@ -1,6 +1,7 @@
 using ClipperLib;
 using System.Collections.Generic;
 using System.Linq;
+using System;
 
 namespace Elements.Geometry
 {
@@ -593,7 +594,7 @@ namespace Elements.Geometry
                 area += _vertices[i].X * _vertices[j].Y;
                 area -= _vertices[i].Y * _vertices[j].X;
             }
-            return area/2.0;
+            return Math.Abs(area/2.0);
         }
     }
 

--- a/src/Elements/Geometry/Profile.cs
+++ b/src/Elements/Geometry/Profile.cs
@@ -193,7 +193,7 @@ namespace Elements.Geometry
             clipper.AddPaths(this.Voids.Select(p => p.ToClipperPath()).ToList(), ClipperLib.PolyType.ptClip, true);
             var solution = new List<List<ClipperLib.IntPoint>>();
             clipper.Execute(ClipperLib.ClipType.ctDifference, solution, ClipperLib.PolyFillType.pftEvenOdd);
-            return solution.Sum(s => ClipperLib.Clipper.Area(s)) / Math.Pow(1024.0, 2);
+            return Math.Abs(solution.Sum(s => ClipperLib.Clipper.Area(s)) / Math.Pow(1024.0, 2));
         }
 
         private Transform ComputeTransform()

--- a/test/FloorTests.cs
+++ b/test/FloorTests.cs
@@ -1,5 +1,4 @@
-//Uncomment for visual checks.
-//using Elements.Serialization.glTF;
+using Elements.Serialization.glTF;
 using Elements.Geometry;
 using System;
 using System.Collections.Generic;
@@ -9,25 +8,6 @@ namespace Elements.Tests
 {
     public class FloorTests : ModelTest
     {
-        [Fact]
-        public void FloorExtrusions()
-        {
-            var p = Polygon.L(10, 20, 5);
-            var floorType = new FloorType("test", 0.5);
-
-            var floor1 = new Floor(p, floorType, 0.0, null, null, true);
-            var floor2 = new Floor(p, floorType, 0.0, null, null, false);
-
-            Assert.Equal(Vector3.ZAxis, floor1.ExtrudeDirection);
-            Assert.Equal(Vector3.ZAxis * -1, floor2.ExtrudeDirection);
-
-            //Uncomment for visual check.
-            //var model = new Model();
-            //model.AddElement(floor1);
-            //model.AddElement(floor2);
-            //model.ToGlTF("../../../../FloorExtrusions.glb");
-        }
-
         [Fact]
         public void FloorWithAddedOpenings()
         {
@@ -46,6 +26,7 @@ namespace Elements.Tests
             Assert.Equal(0.5, floor1.Elevation);
             Assert.Equal(0.1, floor1.ElementType.Thickness());
             Assert.Equal(0.5, floor1.Transform.Origin.Z);
+            Assert.Equal(Vector3.ZAxis * -1, floor1.ExtrudeDirection);
 
             this.Model.AddElement(floor1);
 

--- a/test/FloorTests.cs
+++ b/test/FloorTests.cs
@@ -1,3 +1,5 @@
+//Uncomment for visual checks.
+//using Elements.Serialization.glTF;
 using Elements.Geometry;
 using System;
 using System.Collections.Generic;
@@ -7,6 +9,25 @@ namespace Elements.Tests
 {
     public class FloorTests : ModelTest
     {
+        [Fact]
+        public void FloorExtrusions()
+        {
+            var p = Polygon.L(10, 20, 5);
+            var floorType = new FloorType("test", 0.5);
+
+            var floor1 = new Floor(p, floorType, 0.0, null, null, true);
+            var floor2 = new Floor(p, floorType, 0.0, null, null, false);
+
+            Assert.Equal(Vector3.ZAxis, floor1.ExtrudeDirection);
+            Assert.Equal(Vector3.ZAxis * -1, floor2.ExtrudeDirection);
+
+            //Uncomment for visual check.
+            //var model = new Model();
+            //model.AddElement(floor1);
+            //model.AddElement(floor2);
+            //model.ToGlTF("../../../../FloorExtrusions.glb");
+        }
+
         [Fact]
         public void FloorWithAddedOpenings()
         {


### PR DESCRIPTION
- Renamed constructor "profile" argument to "polygon" for clarity.
- Reversed polygon vertex order for negative z-axis extrusion to avoid making a hole.
- Added an associated test with optional model creation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/180)
<!-- Reviewable:end -->
