### PR TITLE
Get profile union methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -334,3 +334,6 @@ ASALocalRun/
 appsettings.json
 appsettings.dev.json
 *.icloud
+test/*.gltf
+test/*.bin
+.ionide

--- a/.gitignore
+++ b/.gitignore
@@ -333,7 +333,4 @@ ASALocalRun/
 .DS_Store
 appsettings.json
 appsettings.dev.json
-*.icloud
-test/*.gltf
-test/*.bin
 .ionide

--- a/src/Elements/Geometry/Kernel.cs
+++ b/src/Elements/Geometry/Kernel.cs
@@ -49,17 +49,10 @@ namespace Elements.Geometry
                 var o = (IHasOpenings)extrude;
                 // The voids in the profiles are concatenated with the
                 // voids provided by the openings.
-                Polygon[] voids = null;
+                Polygon[] voids = extrude.Profile.Voids ?? new Polygon[] {};
                 if(o.Openings != null && o.Openings.Count > 0)
                 {
-                    if(extrude.Profile.Voids == null)
-                    {
-                        voids = o.Openings.Select(op=>op.Profile.Perimeter).ToArray();
-                    }
-                    else
-                    {
-                        voids = extrude.Profile.Voids.Concat(o.Openings.Select(op=>op.Profile.Perimeter)).ToArray();
-                    }
+                        voids = voids.Concat( o.Openings.Select(op=>op.Profile.Perimeter)).ToArray();
                 }
 
                 return Solid.SweepFace(extrude.Profile.Perimeter, voids, extrude.ExtrudeDirection, extrude.ExtrudeDepth, extrude.BothSides);

--- a/src/Elements/Geometry/Profile.cs
+++ b/src/Elements/Geometry/Profile.cs
@@ -151,30 +151,18 @@ namespace Elements.Geometry
 
         /// <summary>
         /// Perform a union operation, returning a new profile that is the union of the current profile with the other profile
-        /// <param name="other">The other Profile with which to union.</param>
+        /// <param name="profile">The profile with which to create a union.</param>
         /// </summary>
-        public Profile Union(Profile other) {
-            var clipper1 = new ClipperLib.Clipper();
-
-            clipper1.AddPath(this.Perimeter.ToClipperPath(), PolyType.ptSubject, true);
-            clipper1.AddPath(other.Perimeter.ToClipperPath(), PolyType.ptClip, true);
-            var perimeterSolution = new List<List<ClipperLib.IntPoint>>();
-            clipper1.Execute(ClipType.ctUnion, perimeterSolution);
-            var perimeterPolys = perimeterSolution.Select(s => s.ToPolygon()).ToArray();
-            var perimeterPolygon = perimeterPolys[0];
-            var perimeterholes = perimeterPolys.Skip(1);
-
+        public Profile Union(Profile profile) {
             var clipper = new ClipperLib.Clipper();
-            clipper.AddPath(perimeterPolygon.ToClipperPath(), PolyType.ptSubject, true);
-            clipper.AddPaths(perimeterholes.Select(p => p.ToClipperPath()).ToList(), PolyType.ptClip, true);
-            clipper.AddPaths(this.Voids.Select(p => p.ToClipperPath()).ToList(), PolyType.ptClip, true);
-            clipper.AddPaths(other.Voids.Select(p => p.ToClipperPath()).ToList(), PolyType.ptClip, true);
+            clipper.AddPath(this.Perimeter.ToClipperPath(), PolyType.ptSubject, true);
+            clipper.AddPath(profile.Perimeter.ToClipperPath(), PolyType.ptClip, true);
 
+            clipper.AddPaths(this.Voids.Select(v => v.ToClipperPath()).ToList(), PolyType.ptSubject, true);
+            clipper.AddPaths(profile.Voids.Select(v => v.ToClipperPath()).ToList(), PolyType.ptClip, true);
             var solution = new List<List<ClipperLib.IntPoint>>();
-            clipper.Execute(ClipperLib.ClipType.ctDifference, solution, PolyFillType.pftEvenOdd, PolyFillType.pftEvenOdd);
-            var polys = solution.Select(s => s.ToPolygon()).ToArray();
-            var solutionProfile = new Profile(polys[0], polys.Skip(1).ToArray());
-            return solutionProfile;
+            clipper.Execute(ClipType.ctUnion, solution);
+            return new Profile(solution[0].ToPolygon(), solution.Skip(1).Select(s => s.ToPolygon()).ToArray());
         }
 
         /// <summary>

--- a/src/Elements/Geometry/Profile.cs
+++ b/src/Elements/Geometry/Profile.cs
@@ -181,6 +181,21 @@ namespace Elements.Geometry
             }
         }
 
+        public Profile Union(Profile other) {
+            var clipper = new ClipperLib.Clipper();
+            clipper.AddPath(this.Perimeter.ToClipperPath(), ClipperLib.PolyType.ptSubject, true);
+            clipper.AddPaths(this.Voids.Select(p => p.ToClipperPath()).ToList(), ClipperLib.PolyType.ptClip, true);
+
+            clipper.AddPath(other.Perimeter.ToClipperPath(), ClipperLib.PolyType.ptSubject, true);
+            clipper.AddPaths(other.Voids.Select(p => p.ToClipperPath()).ToList(), ClipperLib.PolyType.ptClip, true);
+
+            var solution = new List<List<ClipperLib.IntPoint>>();
+            clipper.Execute(ClipperLib.ClipType.ctUnion, solution, ClipperLib.PolyFillType.pftPositive);
+            var polys = solution.Select(s => s.ToPolygon()).ToArray();
+            var solutionProfile = new Profile(polys[0], polys.Skip(1).ToArray());
+            return solutionProfile;
+        }
+
         private double ClippedArea()
         {
             if (this.Voids == null || this.Voids.Length == 0)

--- a/src/Elements/Geometry/Solids/Solid.cs
+++ b/src/Elements/Geometry/Solids/Solid.cs
@@ -162,8 +162,9 @@ namespace Elements.Geometry.Solids
             // We do a difference of the polygons
             // to get the clipped shape. This will fail in interesting
             // ways if the clip creates two islands.
-            if(holes != null)
+            if(holes != null && holes.Count()>0)
             {
+                var area = perimeter.Area();
                 var newPerimeter = perimeter.Difference(holes);
                 perimeter = newPerimeter[0];
                 holes = newPerimeter.Skip(1).Take(newPerimeter.Count - 1).ToArray();

--- a/src/Elements/Space.cs
+++ b/src/Elements/Space.cs
@@ -89,6 +89,7 @@ namespace Elements
             this.Material = material == null ? BuiltInMaterials.Default : material;
             this.Transform = transform != null ? transform : new Transform(new Vector3(0, 0, elevation));
             this.Height = height;
+            this.Geometry = Solid.SweepFace(profile.Perimeter, profile.Voids, height);
         }
 
         /// <summary>
@@ -110,6 +111,7 @@ namespace Elements
             this.Transform = transform != null ? transform : new Transform(new Vector3(0, 0, elevation));
             this.Material = material == null ? BuiltInMaterials.Mass : material;
             this.Height = height;
+            this.Geometry = Solid.SweepFace(Profile.Perimeter, new Polygon[] {}, height);
         }
 
         /// <summary>

--- a/src/Elements/Space.cs
+++ b/src/Elements/Space.cs
@@ -111,7 +111,6 @@ namespace Elements
             this.Transform = transform != null ? transform : new Transform(new Vector3(0, 0, elevation));
             this.Material = material == null ? BuiltInMaterials.Mass : material;
             this.Height = height;
-            this.Geometry = Solid.SweepFace(Profile.Perimeter, new Polygon[] {}, height);
         }
 
         /// <summary>

--- a/test/PolygonTests.cs
+++ b/test/PolygonTests.cs
@@ -405,6 +405,20 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
+        public void Union2() {
+            var circle = Polygon.Circle(3,4);
+            var seed = new Profile( circle );
+            for(int i=0; i<2; i++) {
+                for(int j=0; j<3; j++) {
+                    Transform t = new Transform(5*i, 5*j, 0);
+                    var newCircle = new Profile( new Polygon(circle.Vertices.Select(v => t.OfPoint(v)).ToArray()) );
+                    seed = seed.Union(newCircle);
+                    if(seed == null) throw new Exception("Making union failed");
+                }
+            }
+        }
+
+        [Fact]
         public void Union()
         {
             var p1 = new Polygon

--- a/test/PolygonTests.cs
+++ b/test/PolygonTests.cs
@@ -405,20 +405,6 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
-        public void Union2() {
-            var circle = Polygon.Circle(3,4);
-            var seed = new Profile( circle );
-            for(int i=0; i<2; i++) {
-                for(int j=0; j<3; j++) {
-                    Transform t = new Transform(5*i, 5*j, 0);
-                    var newCircle = new Profile( new Polygon(circle.Vertices.Select(v => t.OfPoint(v)).ToArray()) );
-                    seed = seed.Union(newCircle);
-                    if(seed == null) throw new Exception("Making union failed");
-                }
-            }
-        }
-
-        [Fact]
         public void Union()
         {
             var p1 = new Polygon

--- a/test/ProfileTests.cs
+++ b/test/ProfileTests.cs
@@ -3,35 +3,37 @@ using System.Linq;
 using Xunit;
 using Elements.Serialization.glTF;
 using System.Collections.Generic;
+using Elements.Tests;
 
 namespace Elements.Geometry.Tests {
-    public class ProfileTests {
+    public class ProfileTests :ModelTest{
         [Fact]
         public void ProfileMultipleUnion()
         {
+            this.Name = "MultipleProfileUnion";
             // small grid of rough circles is unioned
             // 2x3 grid shoud produce 4 openings
             var circle = Polygon.Circle(3,4);
             var seed = new Profile( circle );
+            var originals = new List<Profile>{seed};
             for(int i=0; i<3; i++) {
                 for(int j=0; j<2; j++) {
                     Transform t = new Transform(5*i, 5*j, 0);
                     var newCircle = new Profile( new Polygon(circle.Vertices.Select(v => t.OfPoint(v)).ToArray()) );
+                    originals.Add(newCircle);
+
                     seed = seed.Union(newCircle);
                     
                     if(seed == null) throw new Exception("Making union failed");
                 }
             }
-            // uncomment the following to view the resulting union profile
-            // var floorType = new FloorType("test", new List<MaterialLayer> { new MaterialLayer(new Material("green", Colors.Green, 0.0f, 0.0f), 0.1) });
-            // var floor3 = new Floor(seed, floorType, 0);
-            // var testMdl = new Model();
-            // testMdl.AddElement(floor3);
-            // testMdl.ToGlTF("../../../ProfileMultipleUnion.gltf", false);
+            SaveFloorsOfProfiles(new[] {seed}, "./models/ProfileMultipleUnion.gltf", originals);
+
             Assert.Equal(2, seed.Voids.Count());
         }
         [Fact]
         public void ProfileUnion() {
+            this.Name = "ProfileUnion";
             var largeCirc = Polygon.Circle(3,4);
             var smallCirc = Polygon.Circle(1, 4);
             var firstProfile = new Profile(largeCirc, new Polygon[] {smallCirc});
@@ -41,13 +43,23 @@ namespace Elements.Geometry.Tests {
 
             var unionProfile = firstProfile.Union(secondProfile);
 
-            // uncomment this for viewing the resulting profile
-            // var testMdl = new Model();
-            // var floorType = new FloorType("test", new List<MaterialLayer> { new MaterialLayer(new Material("green", Colors.Green, 0.0f, 0.0f), 0.1) });
-            // var floorUnion = new Floor(unionProfile, floorType, 0);
-            // testMdl.AddElement(floorUnion);
-            // testMdl.ToGlTF("../../../ProfileUnion.gltf",false);
+            SaveFloorsOfProfiles(new[] {unionProfile}, "./models/ProfileUnion.gltf");
             Assert.Equal(2, unionProfile.Voids.Count());
+        }
+
+        private void SaveFloorsOfProfiles(IEnumerable<Profile> profiles, string path, IEnumerable<Profile> originals = null) {
+            foreach(var profile in profiles) {
+                var floorType = new FloorType("profile", new List<MaterialLayer> { new MaterialLayer(new Material("green", Colors.Green, 0.0f, 0.0f), 0.1) });
+                var floor = new Floor(profile, floorType, 0);
+                this.Model.AddElement(floor);
+            }
+            if(originals != null) {
+                foreach(var original in originals) {
+                    var floorType = new FloorType("original", new List<MaterialLayer> { new MaterialLayer(new Material("red", Colors.Red, 0.0f, 0.0f), 0.1) });
+                    var floor = new Floor(original, floorType, -1);
+                    this.Model.AddElement(floor);
+                }
+            }
         }
     }
 }

--- a/test/ProfileTests.cs
+++ b/test/ProfileTests.cs
@@ -1,12 +1,16 @@
 using System;
 using System.Linq;
 using Xunit;
+using Elements.Serialization.glTF;
+using System.Collections.Generic;
 
 namespace Elements.Geometry.Tests {
     public class ProfileTests {
         [Fact]
-        public void ProfileUnion()
+        public void ProfileMultipleUnion()
         {
+            // small grid of rough circles is unioned
+            // 2x3 grid shoud produce 4 openings
             var circle = Polygon.Circle(3,4);
             var seed = new Profile( circle );
             for(int i=0; i<3; i++) {
@@ -14,10 +18,36 @@ namespace Elements.Geometry.Tests {
                     Transform t = new Transform(5*i, 5*j, 0);
                     var newCircle = new Profile( new Polygon(circle.Vertices.Select(v => t.OfPoint(v)).ToArray()) );
                     seed = seed.Union(newCircle);
+                    
                     if(seed == null) throw new Exception("Making union failed");
                 }
             }
+            // uncomment the following to view the resulting union profile
+            // var floorType = new FloorType("test", new List<MaterialLayer> { new MaterialLayer(new Material("green", Colors.Green, 0.0f, 0.0f), 0.1) });
+            // var floor3 = new Floor(seed, floorType, 0);
+            // var testMdl = new Model();
+            // testMdl.AddElement(floor3);
+            // testMdl.ToGlTF("../../../ProfileMultipleUnion.gltf", false);
             Assert.Equal(2, seed.Voids.Count());
+        }
+        [Fact]
+        public void ProfileUnion() {
+            var largeCirc = Polygon.Circle(3,4);
+            var smallCirc = Polygon.Circle(1, 4);
+            var firstProfile = new Profile(largeCirc, new Polygon[] {smallCirc});
+
+            var transform = new Transform(new Vector3(4.5,0,0));
+            var secondProfile = transform.OfProfile(firstProfile);
+
+            var unionProfile = firstProfile.Union(secondProfile);
+
+            // uncomment this for viewing the resulting profile
+            // var testMdl = new Model();
+            // var floorType = new FloorType("test", new List<MaterialLayer> { new MaterialLayer(new Material("green", Colors.Green, 0.0f, 0.0f), 0.1) });
+            // var floorUnion = new Floor(unionProfile, floorType, 0);
+            // testMdl.AddElement(floorUnion);
+            // testMdl.ToGlTF("../../../ProfileUnion.gltf",false);
+            Assert.Equal(2, unionProfile.Voids.Count());
         }
     }
 }

--- a/test/ProfileTests.cs
+++ b/test/ProfileTests.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Elements.Geometry.Tests {
+    public class ProfileTests {
+        [Fact]
+        public void ProfileUnion()
+        {
+            var circle = Polygon.Circle(3,4);
+            var seed = new Profile( circle );
+            for(int i=0; i<3; i++) {
+                for(int j=0; j<2; j++) {
+                    Transform t = new Transform(5*i, 5*j, 0);
+                    var newCircle = new Profile( new Polygon(circle.Vertices.Select(v => t.OfPoint(v)).ToArray()) );
+                    seed = seed.Union(newCircle);
+                    if(seed == null) throw new Exception("Making union failed");
+                }
+            }
+            Assert.Equal(2, seed.Voids.Count());
+        }
+    }
+}


### PR DESCRIPTION
Few things here all trying to get a union method on profiles.
1) The union method and 2 corresponding tests.
2) .ignore gltf files as well as their .bin in test folder
3) fix to how openings are added to solid sweeps.  old logic was faulty and would ignore voids if there were no openings
4) create default empty array for voids  
THIS CREATES A PROBLEM!!!
you will see the test fail, but I believe I have uncovered a failure that should have always been there.  In IFC2X3 there is a call to perimeter.difference() which previously was not called because the voids array was null.  Now it is being called, but hte problem was there prior to my logic change.  I think it has to do with a floor with slopes, because the profile vertices have various Z coordinates.

parts 1-3 I like and want to use.  Part 4 is an interseting problem, if you want the test to pass like they used to, to ignore this problem for now, the fix is trivial and I can add a check that voids.count() > 0 to skip this place where the error occurs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/181)
<!-- Reviewable:end -->
