### PR TITLE
add additional Scale overloads

### DIFF
--- a/src/Elements/Geometry/Transform.cs
+++ b/src/Elements/Geometry/Transform.cs
@@ -322,6 +322,27 @@ namespace Elements.Geometry
         {
             return new Plane(this.Origin, this.YAxis);
         }
+        /// <summary>
+        /// Scale uniformly about the origin.
+        /// </summary>
+        /// <param name="amount">The amount to scale uniformly</param>
+        public void Scale(double amount)
+        {
+            Scale(new Vector3(amount, amount, amount));
+        }
+        /// <summary>
+        /// Scale uniformly about a point
+        /// </summary>
+        /// <param name="amount">The scale factor</param>
+        /// <param name="origin">The origin of scaling</param>
+        /// /// <returns></returns>
+        public void Scale(double amount, Vector3 origin)
+        {
+            Move(origin.Negate());
+            Scale(amount);
+            Move(origin);
+
+        }
 
         /// <summary>
         /// Create a transform that is oriented along 

--- a/src/Elements/Geometry/Transform.cs
+++ b/src/Elements/Geometry/Transform.cs
@@ -43,13 +43,14 @@ namespace Elements.Geometry
         {
             this.Matrix = new Matrix();
         }
-        
+
         /// <summary>
         /// Create a transform by copying another transform.
         /// </summary>
         /// <param name="t">The transform to copy.</param>
-        public Transform(Transform t): 
-            this(new Matrix(new Vector3(t.XAxis), new Vector3(t.YAxis), new Vector3(t.ZAxis), new Vector3(t.Origin))){}
+        public Transform(Transform t) :
+            this(new Matrix(new Vector3(t.XAxis), new Vector3(t.YAxis), new Vector3(t.ZAxis), new Vector3(t.Origin)))
+        { }
 
         /// <summary>
         /// Create a transform with a translation.
@@ -89,22 +90,22 @@ namespace Elements.Geometry
             Vector3 x = Vector3.XAxis;
             Vector3 y = Vector3.YAxis;
 
-            if(!z.IsParallelTo(Vector3.ZAxis))
-            {   
+            if (!z.IsParallelTo(Vector3.ZAxis))
+            {
                 // Project up onto the ortho plane
                 var p = new Plane(origin, z);
                 var test = Vector3.ZAxis.Project(p);
                 x = test.Cross(z);
-                y = x.Cross(z.Negate()); 
+                y = x.Cross(z.Negate());
             }
-            
+
             this.Matrix = new Matrix(x, y, z, Vector3.Origin);
             ApplyRotationAndTranslation(rotation, z, origin);
         }
 
         private void ApplyRotationAndTranslation(double rotation, Vector3 axis, Vector3 translation)
         {
-            if(rotation != 0.0)
+            if (rotation != 0.0)
             {
                 this.Rotate(axis, rotation);
             }
@@ -171,9 +172,9 @@ namespace Elements.Geometry
         {
             var m = new Matrix(this.XAxis, this.YAxis, this.ZAxis, Vector3.Origin);
             return new Vector3(
-                vector.X*m.XAxis.X + vector.Y*YAxis.X + vector.Z*ZAxis.X,
-                vector.X*m.XAxis.Y + vector.Y*YAxis.Y + vector.Z*ZAxis.Y,
-                vector.X*m.XAxis.Z + vector.Y*YAxis.Z + vector.Z*ZAxis.Z
+                vector.X * m.XAxis.X + vector.Y * YAxis.X + vector.Z * ZAxis.X,
+                vector.X * m.XAxis.Y + vector.Y * YAxis.Y + vector.Z * ZAxis.Y,
+                vector.X * m.XAxis.Z + vector.Y * YAxis.Z + vector.Z * ZAxis.Z
             );
         }
 
@@ -201,7 +202,7 @@ namespace Elements.Geometry
         public Polygon[] OfPolygons(IList<Polygon> polygons)
         {
             var result = new Polygon[polygons.Count];
-            for(var i=0; i<polygons.Count; i++)
+            for (var i = 0; i < polygons.Count; i++)
             {
                 result[i] = OfPolygon(polygons[i]);
             }
@@ -337,9 +338,8 @@ namespace Elements.Geometry
         /// <param name="origin">The origin of scaling</param>
         public void Scale(double factor, Vector3 origin)
         {
-            Move(origin.Negate());
             Scale(factor);
-            Move(origin);
+            Move(origin * (1-factor));
         }
 
         /// <summary>
@@ -364,7 +364,7 @@ namespace Elements.Geometry
         /// <returns>True if the two transforms are equal, otherwise false.</returns>
         public bool Equals(Transform other)
         {
-            if(other == null)
+            if (other == null)
             {
                 return false;
             }

--- a/src/Elements/Geometry/Transform.cs
+++ b/src/Elements/Geometry/Transform.cs
@@ -43,14 +43,13 @@ namespace Elements.Geometry
         {
             this.Matrix = new Matrix();
         }
-
+        
         /// <summary>
         /// Create a transform by copying another transform.
         /// </summary>
         /// <param name="t">The transform to copy.</param>
-        public Transform(Transform t) :
-            this(new Matrix(new Vector3(t.XAxis), new Vector3(t.YAxis), new Vector3(t.ZAxis), new Vector3(t.Origin)))
-        { }
+        public Transform(Transform t): 
+            this(new Matrix(new Vector3(t.XAxis), new Vector3(t.YAxis), new Vector3(t.ZAxis), new Vector3(t.Origin))){}
 
         /// <summary>
         /// Create a transform with a translation.
@@ -90,22 +89,22 @@ namespace Elements.Geometry
             Vector3 x = Vector3.XAxis;
             Vector3 y = Vector3.YAxis;
 
-            if (!z.IsParallelTo(Vector3.ZAxis))
-            {
+            if(!z.IsParallelTo(Vector3.ZAxis))
+            {   
                 // Project up onto the ortho plane
                 var p = new Plane(origin, z);
                 var test = Vector3.ZAxis.Project(p);
                 x = test.Cross(z);
-                y = x.Cross(z.Negate());
+                y = x.Cross(z.Negate()); 
             }
-
+            
             this.Matrix = new Matrix(x, y, z, Vector3.Origin);
             ApplyRotationAndTranslation(rotation, z, origin);
         }
 
         private void ApplyRotationAndTranslation(double rotation, Vector3 axis, Vector3 translation)
         {
-            if (rotation != 0.0)
+            if(rotation != 0.0)
             {
                 this.Rotate(axis, rotation);
             }
@@ -172,9 +171,9 @@ namespace Elements.Geometry
         {
             var m = new Matrix(this.XAxis, this.YAxis, this.ZAxis, Vector3.Origin);
             return new Vector3(
-                vector.X * m.XAxis.X + vector.Y * YAxis.X + vector.Z * ZAxis.X,
-                vector.X * m.XAxis.Y + vector.Y * YAxis.Y + vector.Z * ZAxis.Y,
-                vector.X * m.XAxis.Z + vector.Y * YAxis.Z + vector.Z * ZAxis.Z
+                vector.X*m.XAxis.X + vector.Y*YAxis.X + vector.Z*ZAxis.X,
+                vector.X*m.XAxis.Y + vector.Y*YAxis.Y + vector.Z*ZAxis.Y,
+                vector.X*m.XAxis.Z + vector.Y*YAxis.Z + vector.Z*ZAxis.Z
             );
         }
 
@@ -202,7 +201,7 @@ namespace Elements.Geometry
         public Polygon[] OfPolygons(IList<Polygon> polygons)
         {
             var result = new Polygon[polygons.Count];
-            for (var i = 0; i < polygons.Count; i++)
+            for(var i=0; i<polygons.Count; i++)
             {
                 result[i] = OfPolygon(polygons[i]);
             }
@@ -364,7 +363,7 @@ namespace Elements.Geometry
         /// <returns>True if the two transforms are equal, otherwise false.</returns>
         public bool Equals(Transform other)
         {
-            if (other == null)
+            if(other == null)
             {
                 return false;
             }

--- a/src/Elements/Geometry/Transform.cs
+++ b/src/Elements/Geometry/Transform.cs
@@ -325,23 +325,21 @@ namespace Elements.Geometry
         /// <summary>
         /// Scale uniformly about the origin.
         /// </summary>
-        /// <param name="amount">The amount to scale uniformly</param>
-        public void Scale(double amount)
+        /// <param name="factor">The amount to scale uniformly</param>
+        public void Scale(double factor)
         {
-            Scale(new Vector3(amount, amount, amount));
+            Scale(new Vector3(factor, factor, factor));
         }
         /// <summary>
         /// Scale uniformly about a point
         /// </summary>
-        /// <param name="amount">The scale factor</param>
+        /// <param name="factor">The scale factor</param>
         /// <param name="origin">The origin of scaling</param>
-        /// /// <returns></returns>
-        public void Scale(double amount, Vector3 origin)
+        public void Scale(double factor, Vector3 origin)
         {
             Move(origin.Negate());
-            Scale(amount);
+            Scale(factor);
             Move(origin);
-
         }
 
         /// <summary>

--- a/test/Elements.Tests/TransformTests.cs
+++ b/test/Elements.Tests/TransformTests.cs
@@ -38,18 +38,19 @@ namespace Elements.Tests
             Assert.Equal(0.5, vt.Z);
         }
 
+
         [Fact]
-        public void Transform_AboutPoint()
+        public void Transform_ScaleAboutPoint()
         {
-            var transformOrigin = new Vector3(5, 5, 10);
-            var pointToTransform = new Vector3(0, 10, 20);
-            var scaleFactor = 0.5;
+            var transformOrigin = new Vector3(10, -5, 4);
+            var pointToTransform = new Vector3(2, 9, 18);
+            var scaleFactor = 2.5;
             var t = new Transform();
             t.Scale(scaleFactor,transformOrigin);
             var vt = t.OfPoint(pointToTransform);
-            Assert.Equal(2.5, vt.X);
-            Assert.Equal(7.5, vt.Y);
-            Assert.Equal(15.0, vt.Z);
+            Assert.Equal(-10, vt.X);
+            Assert.Equal(30, vt.Y);
+            Assert.Equal(39, vt.Z);
         }
 
         [Fact]

--- a/test/Elements.Tests/TransformTests.cs
+++ b/test/Elements.Tests/TransformTests.cs
@@ -39,6 +39,20 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void Transform_AboutPoint()
+        {
+            var transformOrigin = new Vector3(5, 5, 10);
+            var pointToTransform = new Vector3(0, 10, 20);
+            var scaleFactor = 0.5;
+            var t = new Transform();
+            t.Scale(scaleFactor,transformOrigin);
+            var vt = t.OfPoint(pointToTransform);
+            Assert.Equal(2.5, vt.X);
+            Assert.Equal(7.5, vt.Y);
+            Assert.Equal(15.0, vt.Z);
+        }
+
+        [Fact]
         public void Transform_Translate()
         {
             var t = new Transform(new Vector3(5,0,0), Vector3.XAxis, Vector3.YAxis.Negate());


### PR DESCRIPTION
Adding a few utility overloads to Transform.Scale(): 
```csharp
Transform.Scale(double amount)
Transform.Scale(double amount, Vector3 origin)
```
open to better/more efficient ways to scale about an origin without the double-translate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/225)
<!-- Reviewable:end -->
