### PR TITLE
take IsClockwise and covers from GeometryEx

### DIFF
--- a/src/Elements/Geometry/Polygon.cs
+++ b/src/Elements/Geometry/Polygon.cs
@@ -62,6 +62,23 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Calculates whether this polygon is configured clockwise.
+        /// </summary>
+        /// <returns>True if this polygon is oriented clockwise.</returns>
+        public bool IsClockWise()
+        {
+            // https://en.wikipedia.org/wiki/Shoelace_formula
+            var sum = 0.0;
+            for (int i = 0; i < this.Vertices.Count; i++)
+            {
+                var point = this.Vertices[i];
+                var nextPoint = this.Vertices[(i + 1) % this.Vertices.Count];
+                sum += (nextPoint.X - point.X) * (nextPoint.Y + point.Y);
+            }
+            return sum > 0;
+        }
+
+        /// <summary>
         /// Tests if the supplied Vector3 is within this Polygon or coincident with an edge when compared on a shared plane.
         /// </summary>
         /// <param name="vector">The Vector3 to compare to this Polygon.</param>
@@ -92,6 +109,9 @@ namespace Elements.Geometry
             {
                 return false;
             }
+            if (this.IsClockWise() != polygon.IsClockWise()) {
+                polygon = polygon.Reversed();
+            }
             var clipper = new Clipper();
             var solution = new List<List<IntPoint>>();
             clipper.AddPath(this.ToClipperPath(), PolyType.ptSubject, true);
@@ -101,7 +121,7 @@ namespace Elements.Geometry
             {
                 return false;
             }
-            return solution.First().ToPolygon().Area() == polygon.ToClipperPath().ToPolygon().Area();
+            return Math.Abs(solution.First().ToPolygon().Area() - this.ToClipperPath().ToPolygon().Area()) <= 0.0001;
         }
 
         /// <summary>

--- a/src/Elements/Geometry/Polygon.cs
+++ b/src/Elements/Geometry/Polygon.cs
@@ -116,7 +116,7 @@ namespace Elements.Geometry
             var solution = new List<List<IntPoint>>();
             clipper.AddPath(this.ToClipperPath(), PolyType.ptSubject, true);
             clipper.AddPath(polygon.ToClipperPath(), PolyType.ptClip, true);
-            clipper.Execute(ClipType.ctIntersection, solution);
+            clipper.Execute(ClipType.ctUnion, solution);
             if (solution.Count != 1)
             {
                 return false;

--- a/test/Elements.Tests/PolygonTests.cs
+++ b/test/Elements.Tests/PolygonTests.cs
@@ -194,6 +194,7 @@ namespace Elements.Geometry.Tests
                 }
             );
             Assert.True(p1.Covers(v1));
+            Assert.True(p1.Covers(p2.Reversed()));
             Assert.True(p3.Covers(v2));
             Assert.False(p3.Covers(v1));
             Assert.True(p1.Covers(p3));


### PR DESCRIPTION
BACKGROUND:
there are methods in GeometryEx that are updated and need to live in Elements for other downstream functionality.

DESCRIPTION:
Move IsClockwise into Polygon class and use it to improve the Covers method.  

TESTING:
run the test called "Covers" in the file "PolygonTests.cs"  this test now includes a test of covers for a reversed polygon.
  
FUTURE WORK:
None

COMMENTS:
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/237)
<!-- Reviewable:end -->
