### PR TITLE
Allow null voids on Profiles.

### DIFF
--- a/Schemas/Geometry/Profile.json
+++ b/Schemas/Geometry/Profile.json
@@ -13,7 +13,7 @@
             "$ref": "https://hypar.io/Schemas/Geometry/Polygon.json"
         },
         "Voids": {
-            "type": "array",
+            "type": ["array","null"],
             "description": "A collection of Polygons representing voids in the profile.",
             "items": {
                 "$ref": "https://hypar.io/Schemas/Geometry/Polygon.json"

--- a/src/Elements/Generate/Geometry/Profile.g.cs
+++ b/src/Elements/Generate/Geometry/Profile.g.cs
@@ -42,9 +42,8 @@ namespace Elements.Geometry
         public Polygon Perimeter { get; set; }
     
         /// <summary>A collection of Polygons representing voids in the profile.</summary>
-        [Newtonsoft.Json.JsonProperty("Voids", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
-        public IList<Polygon> Voids { get; set; } = new List<Polygon>();
+        [Newtonsoft.Json.JsonProperty("Voids", Required = Newtonsoft.Json.Required.AllowNull)]
+        public IList<Polygon> Voids { get; set; }
     
     
     }

--- a/src/Elements/Geometry/Profile.cs
+++ b/src/Elements/Geometry/Profile.cs
@@ -159,15 +159,18 @@ namespace Elements.Geometry
         /// <param name="other">The other profile.</param>
         public bool Equals(Profile other)
         {
-            if(this.Voids.Count != other.Voids.Count)
+            if((this.Voids != null && other.Voids != null))
             {
-                return false;
-            }
-            for(var i=0; i<this.Voids.Count; i++)
-            {
-                if(!this.Voids[i].Equals(other.Voids[i]))
+                if(this.Voids.Count != other.Voids.Count)
                 {
                     return false;
+                }
+                for(var i=0; i<this.Voids.Count; i++)
+                {
+                    if(!this.Voids[i].Equals(other.Voids[i]))
+                    {
+                        return false;
+                    }
                 }
             }
             return this.Perimeter.Equals(other.Perimeter);

--- a/test/Elements.Tests/ModelTests.cs
+++ b/test/Elements.Tests/ModelTests.cs
@@ -78,7 +78,7 @@ namespace Elements.Tests
             }
 
             Assert.Equal(2, model.Elements.Count);
-            Assert.Equal(3, errors.Count);
+            Assert.Equal(2, errors.Count);
         }
 
         /// <summary>


### PR DESCRIPTION
BACKGROUND:
- After the release of 0.5.1 it was found that older models which generated JSON in which profile voids were null, were not able to be merged by the export server, or consumed in downstream functions where the non-null requirement was imposed.

DESCRIPTION:
- This PR removes the restriction that `Voids` be defined and non-null.

TESTING:
- Update any function to use 0.5.2 (this version).
- Run that function in a workflow containing functions referencing an older version of Elements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/243)
<!-- Reviewable:end -->
