### PR TITLE
Add method for extracting walls from Revit models

### DIFF
--- a/src/Dynamo/README.md
+++ b/src/Dynamo/README.md
@@ -9,5 +9,6 @@ The Zero-Touch node library is mostly a simple wrapper around the [RevitHyparToo
 
 Testing
 To test these nodes:
-- Run the `deploy/deployForTesting.sh` bash script.  It basically removes the old package, runs `dotnet publish` and then copies the newly created package (found in the "deploy" folder) to the Dynamo Revit 2.3 packages folder.
-- Open Revit2020, open Dynamo, and test the nodes.  Optionally you may simply open the graph found in the "test" folder adjacent to "src" which contains sample dynamo graphs.
+- run `dotnet publish`
+- Open Revit2020, open Dynamo, and test the nodes.  
+- Option to test the `dyn` files found in the "test" folder adjacent to "src".

--- a/src/Dynamo/src/HyparDynamo/Hypar.cs
+++ b/src/Dynamo/src/HyparDynamo/Hypar.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Elements.Serialization.glTF;
 using Elements.Serialization.JSON;
+using Hypar.Revit;
 using RevitServices.Persistence;
 
 
@@ -22,7 +23,7 @@ namespace HyparDynamo.Hypar
             // wrapped exception catching to deliver more meaningful message in Dynamo
             try 
             {
-                return RevitHyparTools.Create.WallsFromRevitWall(r_Wall, DocumentManager.Instance.CurrentDBDocument);
+                return Create.WallsFromRevitWall(r_Wall, DocumentManager.Instance.CurrentDBDocument);
             }
             catch (Exception ex) {
                 throw new Exception(ex.Message);
@@ -36,7 +37,7 @@ namespace HyparDynamo.Hypar
             
             // wrapped exception catching to deliver more meaningful message in Dynamo
             try {
-                return RevitHyparTools.Create.FloorsFromRevitFloor(DocumentManager.Instance.CurrentDBDocument, r_Floor);
+                return Create.FloorsFromRevitFloor(DocumentManager.Instance.CurrentDBDocument, r_Floor);
             }
             catch (Exception ex) {
                 throw new Exception(ex.Message);

--- a/src/Dynamo/src/HyparDynamo/Hypar.cs
+++ b/src/Dynamo/src/HyparDynamo/Hypar.cs
@@ -15,12 +15,14 @@ namespace HyparDynamo.Hypar
         /// </summary>
         /// <param name="wall">The walls to be exported</param>
         /// <returns name="Hypar.Wall">The Hypar Wall element </param>
-        public static Elements.Wall FromRevitWall( this Revit.Elements.Wall RevitWall) {
+        public static Elements.Wall[] FromRevitWall( this Revit.Elements.Wall RevitWall) 
+        {
             var r_Wall = (Autodesk.Revit.DB.Wall)RevitWall.InternalElement;
 
             // wrapped exception catching to deliver more meaningful message in Dynamo
-            try {
-                return RevitHyparTools.Create.WallFromRevitWall(r_Wall);
+            try 
+            {
+                return RevitHyparTools.Create.WallsFromRevitWall(r_Wall, DocumentManager.Instance.CurrentDBDocument);
             }
             catch (Exception ex) {
                 throw new Exception(ex.Message);
@@ -49,12 +51,15 @@ namespace HyparDynamo.Hypar
     }
     public static class Model {
 
-        public static void WriteJson(string filePath, Elements.Model model) {
-            try {
+        public static void WriteJson(string filePath, Elements.Model model)
+        {
+            try
+            {
                 var json = model.ToJson();
                 System.IO.File.WriteAllText(filePath, json);
             }
-            catch (Exception ex) {
+            catch (Exception ex)
+            {
                 throw new Exception(ex.Message);
             }
         }

--- a/src/Dynamo/src/HyparDynamo/HyparDynamo.csproj
+++ b/src/Dynamo/src/HyparDynamo/HyparDynamo.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="DynamoVisualProgramming.DynamoServices" Version="2.5.0.7432">
       <Private>False</Private>
     </PackageReference>
-    <PackageReference Include="Hypar.Elements" Version="0.4.4.2"/>
   </ItemGroup>
 
   <ItemGroup>
@@ -31,6 +30,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Revit\RevitHyparTools\RevitHyparTools.csproj" />
+    <ProjectReference Include="..\..\..\Elements\Elements.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -38,7 +38,7 @@
   </ItemGroup>
 
 
-  <Target Name="BuildPackage" AfterTargets="Publish" >
+  <Target Name="BuildPackage" AfterTargets="Publish">
     <RemoveDir Directories="..\..\deploy\HyparDynamo\bin\" />     
     <Copy SourceFiles="@(NodeLibraries)" DestinationFolder="..\..\deploy\HyparDynamo\bin\" ContinueOnError="true" />
     <Copy SourceFiles=".\HyparDynamo_DynamoCustomization.xml" DestinationFolder="..\..\deploy\HyparDynamo\bin\" ContinueOnError="true" />
@@ -48,8 +48,8 @@
     <DynamoPackage Include="$(ProjectDir)..\..\deploy\HyparDynamo\**\*.*" />
   </ItemGroup>
   <Target Name="Deploy" AfterTargets="BuildPackage" Condition=" '$(Configuration)' == 'Debug' ">
-    <RemoveDir Directories="$(AppData)\Dynamo\Dynamo Revit\2.3\packages\HyparDynamo\"/>
-    <Copy SourceFiles="@(DynamoPackage)" DestinationFiles="@(DynamoPackage->'$(AppData)\Dynamo\Dynamo Revit\2.3\packages\HyparDynamo\%(RecursiveDir)%(Filename)%(Extension)')"/>
+    <RemoveDir Directories="$(AppData)\Dynamo\Dynamo Revit\2.3\packages\HyparDynamo\" />
+    <Copy SourceFiles="@(DynamoPackage)" DestinationFiles="@(DynamoPackage->'$(AppData)\Dynamo\Dynamo Revit\2.3\packages\HyparDynamo\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
 </Project>

--- a/src/Dynamo/test/FloorFromFloor.dyn
+++ b/src/Dynamo/test/FloorFromFloor.dyn
@@ -11,8 +11,8 @@
   "Nodes": [
     {
       "ConcreteType": "CoreNodeModels.Input.Filename, CoreNodeModels",
-      "HintPath": "C:\\Users\\Eric Wassail\\source\\Elements\\src\\Dynamo\\test\\RevitToDynamoToHypar.glb",
-      "InputValue": ".\\RevitToDynamoToHypar.glb",
+      "HintPath": "C:\\Users\\Eric Wassail\\source\\Elements\\src\\Dynamo\\test\\Floors-RevitToHypar.glb",
+      "InputValue": ".\\Floors-RevitToHypar.glb",
       "NodeType": "ExtensionNode",
       "Id": "45cde40e2ce7481cbafbea583359e37b",
       "Inputs": [],
@@ -29,56 +29,6 @@
       ],
       "Replication": "Disabled",
       "Description": "Allows you to select a file on the system to get its filename"
-    },
-    {
-      "ConcreteType": "DSRevitNodesUI.Categories, DSRevitNodesUI",
-      "SelectedIndex": 209,
-      "SelectedString": "OST_Floors",
-      "NodeType": "ExtensionNode",
-      "Id": "a236c39f394f467993b929002bac30cf",
-      "Inputs": [],
-      "Outputs": [
-        {
-          "Id": "bba8ad0d7b84428d96d49c448195cdb6",
-          "Name": "Category",
-          "Description": "The selected Category.",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Replication": "Disabled",
-      "Description": "All built-in categories."
-    },
-    {
-      "ConcreteType": "DSRevitNodesUI.ElementsOfCategory, DSRevitNodesUI",
-      "NodeType": "ExtensionNode",
-      "Id": "0cd1e3c1845344f798171a0210105240",
-      "Inputs": [
-        {
-          "Id": "200e1dc5921d46bb9af8a25a1082b549",
-          "Name": "Category",
-          "Description": "The Category",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Outputs": [
-        {
-          "Id": "8b548da52bc94d7592eb7205a4fabc66",
-          "Name": "Elements",
-          "Description": "An element type.",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Replication": "Disabled",
-      "Description": "Get all elements of the specified category from the model."
     },
     {
       "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
@@ -150,8 +100,8 @@
     },
     {
       "ConcreteType": "DSRevitNodesUI.Categories, DSRevitNodesUI",
-      "SelectedIndex": 610,
-      "SelectedString": "OST_Walls",
+      "SelectedIndex": 209,
+      "SelectedString": "OST_Floors",
       "NodeType": "ExtensionNode",
       "Id": "726627cf255d47b3a9c4476435c20124",
       "Inputs": [],
@@ -168,116 +118,6 @@
       ],
       "Replication": "Disabled",
       "Description": "All built-in categories."
-    },
-    {
-      "ConcreteType": "DSRevitNodesUI.ElementsOfCategory, DSRevitNodesUI",
-      "NodeType": "ExtensionNode",
-      "Id": "2f5181b463d74d829226f5430f418ff3",
-      "Inputs": [
-        {
-          "Id": "e5869c656ed0433685f5f79630fcf46e",
-          "Name": "Category",
-          "Description": "The Category",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Outputs": [
-        {
-          "Id": "e06259f38ebd40b58cb18f51c2953f63",
-          "Name": "Elements",
-          "Description": "An element type.",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Replication": "Disabled",
-      "Description": "Get all elements of the specified category from the model."
-    },
-    {
-      "ConcreteType": "DSRevitNodesUI.Categories, DSRevitNodesUI",
-      "SelectedIndex": 510,
-      "SelectedString": "OST_StructuralColumns",
-      "NodeType": "ExtensionNode",
-      "Id": "5b8ea21568e849d6bea558eb4c190719",
-      "Inputs": [],
-      "Outputs": [
-        {
-          "Id": "276c368089324dfb93619befd1a6a2e4",
-          "Name": "Category",
-          "Description": "The selected Category.",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Replication": "Disabled",
-      "Description": "All built-in categories."
-    },
-    {
-      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
-      "NodeType": "FunctionNode",
-      "FunctionSignature": "HyparDynamo.Hypar.Wall.FromRevitWall@Revit.Elements.Wall",
-      "Id": "df0610661bed452ea1d6df9e144f7a90",
-      "Inputs": [
-        {
-          "Id": "99cb4169a9d24af1bd20e8b0f95cca75",
-          "Name": "RevitWall",
-          "Description": "Wall",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Outputs": [
-        {
-          "Id": "ef8dec85a13a4ff2b145948cd409a132",
-          "Name": "Wall",
-          "Description": "Wall",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Replication": "Auto",
-      "Description": "Wall.FromRevitWall (RevitWall: Wall): Wall"
-    },
-    {
-      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
-      "NodeType": "FunctionNode",
-      "FunctionSignature": "HyparDynamo.Hypar.Floor.FromRevitFloor@Revit.Elements.Floor",
-      "Id": "274c7fb51b26441e9140637c820d82e3",
-      "Inputs": [
-        {
-          "Id": "be6a1d0b99114d498f7d917080454ac5",
-          "Name": "RevitFloor",
-          "Description": "Floor",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Outputs": [
-        {
-          "Id": "abfb5d520801421da832708b1bbfbd9b",
-          "Name": "Floor[]",
-          "Description": "Floor[]",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Replication": "Auto",
-      "Description": "Floor.FromRevitFloor (RevitFloor: Floor): Floor[]"
     },
     {
       "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
@@ -351,36 +191,6 @@
     {
       "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
       "NodeType": "FunctionNode",
-      "FunctionSignature": "HyparDynamo.Hypar.Column.FromRevitColumn@Revit.Elements.Element",
-      "Id": "4318c517b5264e44925ed521a5da3fd0",
-      "Inputs": [
-        {
-          "Id": "75f82f21cc914befb0d9d3ad72c9c21f",
-          "Name": "column",
-          "Description": "Element",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Outputs": [
-        {
-          "Id": "b31593e832cc4a9e9f15e843689c3caa",
-          "Name": "string",
-          "Description": "string",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Replication": "Auto",
-      "Description": "Column.FromRevitColumn (column: Element): string"
-    },
-    {
-      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
-      "NodeType": "FunctionNode",
       "FunctionSignature": "HyparDynamo.Hypar.Model.WriteJson@string,var",
       "Id": "8f1f7b08e47b40049966be6981419fa6",
       "Inputs": [
@@ -419,8 +229,8 @@
     },
     {
       "ConcreteType": "CoreNodeModels.Input.Filename, CoreNodeModels",
-      "HintPath": "C:\\Users\\Eric Wassail\\source\\Elements\\src\\Dynamo\\test\\RevitToDynamoToHypar.json",
-      "InputValue": ".\\RevitToDynamoToHypar.json",
+      "HintPath": "C:\\Users\\Eric Wassail\\source\\Elements\\src\\Dynamo\\test\\Floors-RevitToHypar.json",
+      "InputValue": ".\\Floors-RevitToHypar.json",
       "NodeType": "ExtensionNode",
       "Id": "f73f15b237a74f01b3df349058c3ed4b",
       "Inputs": [],
@@ -437,6 +247,36 @@
       ],
       "Replication": "Disabled",
       "Description": "Allows you to select a file on the system to get its filename"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "HyparDynamo.Hypar.Floor.FromRevitFloor@Revit.Elements.Floor",
+      "Id": "634d50b70b6c499091f956152afac737",
+      "Inputs": [
+        {
+          "Id": "143dacc5991f41b0a37aa78495cd967b",
+          "Name": "RevitFloor",
+          "Description": "Floor",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "09b053e5214e47c9a26d7dcc12897148",
+          "Name": "Floor[]",
+          "Description": "Floor[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Floor.FromRevitFloor (RevitFloor: Floor): Floor[]"
     }
   ],
   "Connectors": [
@@ -446,44 +286,19 @@
       "Id": "2c182ab27c1a40079de231c7d66699c0"
     },
     {
-      "Start": "bba8ad0d7b84428d96d49c448195cdb6",
-      "End": "200e1dc5921d46bb9af8a25a1082b549",
-      "Id": "aabf524ca85a4ff4b56e180de7383aaf"
-    },
-    {
-      "Start": "8b548da52bc94d7592eb7205a4fabc66",
-      "End": "be6a1d0b99114d498f7d917080454ac5",
-      "Id": "004451f814a84b0389a36ecec56efefe"
-    },
-    {
       "Start": "7f6a23524caf4e70ab0fc7f55c635c2e",
       "End": "bfffd205f15e4752adc8936e81746eaa",
       "Id": "adfb111f084d46438eaf3e8ceb0c258d"
     },
     {
       "Start": "ea60ce6e53ad4fb4b9aec3d43d25d2bd",
-      "End": "99cb4169a9d24af1bd20e8b0f95cca75",
-      "Id": "2cf0e599c75e4afc8b25c6625aa19434"
+      "End": "143dacc5991f41b0a37aa78495cd967b",
+      "Id": "0afcd17909604749a6fd91fe88e286c4"
     },
     {
       "Start": "6f13ec7433d54ab39a12fd1161005238",
       "End": "ec1b567c102b4f079f75be27f43a472c",
       "Id": "3db969aa8d084762855359a1586138a8"
-    },
-    {
-      "Start": "e06259f38ebd40b58cb18f51c2953f63",
-      "End": "75f82f21cc914befb0d9d3ad72c9c21f",
-      "Id": "53cc286988614a0582a0b97b8aaa7de2"
-    },
-    {
-      "Start": "276c368089324dfb93619befd1a6a2e4",
-      "End": "e5869c656ed0433685f5f79630fcf46e",
-      "Id": "0f1bf9c3153e42d8b3f9cda4435ae588"
-    },
-    {
-      "Start": "abfb5d520801421da832708b1bbfbd9b",
-      "End": "ce3cbf7bc84a4fe4bd9d260f2a1de335",
-      "Id": "f20ea35b17514a5cbc9239a02ae53f17"
     },
     {
       "Start": "3defde2d0bd04056863fed2f4e8aef20",
@@ -499,6 +314,11 @@
       "Start": "67277948f87b40e8af5b58b6735c96bd",
       "End": "70641fb35acf4edfad901ef2b1d93f71",
       "Id": "55d901ee4731484d82e4907f5514a954"
+    },
+    {
+      "Start": "09b053e5214e47c9a26d7dcc12897148",
+      "End": "ce3cbf7bc84a4fe4bd9d260f2a1de335",
+      "Id": "5ea9e77c970a4827892a581d1c44ab2d"
     }
   ],
   "Dependencies": [],
@@ -508,12 +328,10 @@
       "Version": "0.0.1",
       "ReferenceType": "Package",
       "Nodes": [
-        "df0610661bed452ea1d6df9e144f7a90",
-        "274c7fb51b26441e9140637c820d82e3",
         "0f2680a18b6a4251a74e71a8cb4d73bb",
         "e316758480dc4822b74633be22e7cc72",
-        "4318c517b5264e44925ed521a5da3fd0",
-        "8f1f7b08e47b40049966be6981419fa6"
+        "8f1f7b08e47b40049966be6981419fa6",
+        "634d50b70b6c499091f956152afac737"
       ]
     }
   ],
@@ -552,26 +370,6 @@
       },
       {
         "ShowGeometry": true,
-        "Name": "Categories",
-        "Id": "a236c39f394f467993b929002bac30cf",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": false,
-        "X": 540.73213283082237,
-        "Y": 782.41486927451047
-      },
-      {
-        "ShowGeometry": true,
-        "Name": "All Elements of Category",
-        "Id": "0cd1e3c1845344f798171a0210105240",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": false,
-        "X": 783.73213283082237,
-        "Y": 782.41486927451047
-      },
-      {
-        "ShowGeometry": true,
         "Name": "List.Flatten",
         "Id": "f00a0d336f224b078f92ec05c4a330e2",
         "IsSetAsInput": false,
@@ -587,8 +385,8 @@
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 783.73213283082237,
-        "Y": 648.508617368962
+        "X": 785.08472123390879,
+        "Y": 783.76745767759678
       },
       {
         "ShowGeometry": true,
@@ -597,48 +395,8 @@
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 540.73213283082237,
-        "Y": 648.508617368962
-      },
-      {
-        "ShowGeometry": true,
-        "Name": "All Elements of Category",
-        "Id": "2f5181b463d74d829226f5430f418ff3",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": false,
-        "X": 783.73213283082237,
-        "Y": 1000.1816021714126
-      },
-      {
-        "ShowGeometry": true,
-        "Name": "Categories",
-        "Id": "5b8ea21568e849d6bea558eb4c190719",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": false,
-        "X": 504.73213283082237,
-        "Y": 1000.1816021714126
-      },
-      {
-        "ShowGeometry": true,
-        "Name": "Wall.FromRevitWall",
-        "Id": "df0610661bed452ea1d6df9e144f7a90",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": false,
-        "X": 1060.2349236620041,
-        "Y": 648.508617368962
-      },
-      {
-        "ShowGeometry": true,
-        "Name": "Floor.FromRevitFloor",
-        "Id": "274c7fb51b26441e9140637c820d82e3",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": false,
-        "X": 1041.2349236620041,
-        "Y": 782.41486927451047
+        "X": 542.08472123390879,
+        "Y": 783.76745767759678
       },
       {
         "ShowGeometry": true,
@@ -662,16 +420,6 @@
       },
       {
         "ShowGeometry": true,
-        "Name": "Column.FromRevitColumn",
-        "Id": "4318c517b5264e44925ed521a5da3fd0",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": false,
-        "X": 1056.853452654288,
-        "Y": 998.829013768326
-      },
-      {
-        "ShowGeometry": true,
         "Name": "Model.WriteJson",
         "Id": "8f1f7b08e47b40049966be6981419fa6",
         "IsSetAsInput": false,
@@ -689,6 +437,16 @@
         "Excluded": false,
         "X": 1612.6794527523436,
         "Y": 931.60082279178062
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Floor.FromRevitFloor",
+        "Id": "634d50b70b6c499091f956152afac737",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1041.9749802203382,
+        "Y": 782.41486927451035
       }
     ],
     "Annotations": [],

--- a/src/Dynamo/test/WallFromWall.dyn
+++ b/src/Dynamo/test/WallFromWall.dyn
@@ -1,0 +1,779 @@
+{
+  "Uuid": "3c9a5bd3-0e97-40cb-aa3a-3c253e1a7d6b",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "WallFromWall",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.Input.Filename, CoreNodeModels",
+      "HintPath": "C:\\Users\\Eric Wassail\\source\\Elements\\src\\Dynamo\\test\\Walls-RevitToHypar.glb",
+      "InputValue": ".\\Walls-RevitToHypar.glb",
+      "NodeType": "ExtensionNode",
+      "Id": "45cde40e2ce7481cbafbea583359e37b",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "2f979b19b79e4853acccf5bff0a158b9",
+          "Name": "",
+          "Description": "Filename",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows you to select a file on the system to get its filename"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.Flatten@var[]..[],int",
+      "Id": "f00a0d336f224b078f92ec05c4a330e2",
+      "Inputs": [
+        {
+          "Id": "ce3cbf7bc84a4fe4bd9d260f2a1de335",
+          "Name": "list",
+          "Description": "List to flatten.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "8db1ec480a184b979e7408e36033daf3",
+          "Name": "amt",
+          "Description": "Layers of nesting to remove.\n\nint\nDefault value : -1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "7f6a23524caf4e70ab0fc7f55c635c2e",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Flattens a nested list of lists by a certain amount.\n\nList.Flatten (list: var[]..[], amt: int = -1): var[]..[]"
+    },
+    {
+      "ConcreteType": "DSRevitNodesUI.ElementsOfCategory, DSRevitNodesUI",
+      "NodeType": "ExtensionNode",
+      "Id": "084ecda30f20455c8d5d535bcc3db8ce",
+      "Inputs": [
+        {
+          "Id": "ec1b567c102b4f079f75be27f43a472c",
+          "Name": "Category",
+          "Description": "The Category",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "ea60ce6e53ad4fb4b9aec3d43d25d2bd",
+          "Name": "Elements",
+          "Description": "An element type.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Get all elements of the specified category from the model."
+    },
+    {
+      "ConcreteType": "DSRevitNodesUI.Categories, DSRevitNodesUI",
+      "SelectedIndex": 610,
+      "SelectedString": "OST_Walls",
+      "NodeType": "ExtensionNode",
+      "Id": "726627cf255d47b3a9c4476435c20124",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "6f13ec7433d54ab39a12fd1161005238",
+          "Name": "Category",
+          "Description": "The selected Category.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "All built-in categories."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "HyparDynamo.Hypar.Wall.FromRevitWall@Revit.Elements.Wall",
+      "Id": "df0610661bed452ea1d6df9e144f7a90",
+      "Inputs": [
+        {
+          "Id": "99cb4169a9d24af1bd20e8b0f95cca75",
+          "Name": "RevitWall",
+          "Description": "Wall",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "ef8dec85a13a4ff2b145948cd409a132",
+          "Name": "Wall[]",
+          "Description": "Wall[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Wall.FromRevitWall (RevitWall: Wall): Wall[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "HyparDynamo.Hypar.Model.ModelFromElements@var[]",
+      "Id": "0f2680a18b6a4251a74e71a8cb4d73bb",
+      "Inputs": [
+        {
+          "Id": "bfffd205f15e4752adc8936e81746eaa",
+          "Name": "elements",
+          "Description": "var[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "3defde2d0bd04056863fed2f4e8aef20",
+          "Name": "var",
+          "Description": "var",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Model.ModelFromElements (elements: var[]): var"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "HyparDynamo.Hypar.Model.WriteGlb@string,var",
+      "Id": "e316758480dc4822b74633be22e7cc72",
+      "Inputs": [
+        {
+          "Id": "0728e268fa164c91aaed24cd7fac99d9",
+          "Name": "filePath",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "bee99355f7cf4c9783ab9cc815cb2d51",
+          "Name": "model",
+          "Description": "var",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "134d4520f84c4fbaa4f62a6ce581bd0d",
+          "Name": "void",
+          "Description": "void",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Model.WriteGlb (filePath: string, model: var): void"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "HyparDynamo.Hypar.Model.WriteJson@string,var",
+      "Id": "8f1f7b08e47b40049966be6981419fa6",
+      "Inputs": [
+        {
+          "Id": "70641fb35acf4edfad901ef2b1d93f71",
+          "Name": "filePath",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "1d6e0a9576c94c30a375f193e99bf46a",
+          "Name": "model",
+          "Description": "var",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "39370f4bfd624dcc993a4fb23e6de327",
+          "Name": "void",
+          "Description": "void",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Model.WriteJson (filePath: string, model: var): void"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.Filename, CoreNodeModels",
+      "HintPath": "C:\\Users\\Eric Wassail\\source\\Elements\\src\\Dynamo\\test\\Walls-RevitToHypar.json",
+      "InputValue": ".\\Walls-RevitToHypar.json",
+      "NodeType": "ExtensionNode",
+      "Id": "f73f15b237a74f01b3df349058c3ed4b",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "67277948f87b40e8af5b58b6735c96bd",
+          "Name": "",
+          "Description": "Filename",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows you to select a file on the system to get its filename"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.GetItemAtIndex@var[]..[],int",
+      "Id": "8ead248692814b06bbbbfa978ace4243",
+      "Inputs": [
+        {
+          "Id": "8dbbf613dd0148e59ac94a44e7cb3a81",
+          "Name": "list",
+          "Description": "List to fetch an item from.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "85202795c4544039bb52844bafc02907",
+          "Name": "index",
+          "Description": "Index of the item to be fetched.\n\nint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "15c491f4c292420ab2a36919a4a6a0a9",
+          "Name": "item",
+          "Description": "Item in the list at the given index.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Returns an item from the given list that's located at the specified index.\n\nList.GetItemAtIndex (list: var[]..[], index: int): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "6;",
+      "Id": "bc0c942970d7428781fd2eb0700786c6",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "8ad9f05478294c90aac1182e904d7f47",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Nodes.DSModelElementSelection, DSRevitNodesUI",
+      "NodeType": "ExtensionNode",
+      "InstanceId": [
+        "59371552-5800-43eb-9ba3-609565158fc5-00067bda"
+      ],
+      "Id": "d4cbc6d928fa4e5ca1f224fcd082273f",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "dcf5c0ee16654c4bbe68355d98179952",
+          "Name": "Element",
+          "Description": "The selected elements.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled"
+    },
+    {
+      "ConcreteType": "Dynamo.Nodes.DSModelElementsSelection, DSRevitNodesUI",
+      "NodeType": "ExtensionNode",
+      "InstanceId": [],
+      "Id": "2b39079b838a4907bf1ff93d73d6f36c",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "1492f726e01744cbb116bdbaa0fe5193",
+          "Name": "Elements",
+          "Description": "The selected elements.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "",
+      "Id": "bca1102c92804ca6ac7e187b7e00fdb5",
+      "Inputs": [],
+      "Outputs": [],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.CreateList, CoreNodeModels",
+      "VariableInputPorts": true,
+      "NodeType": "ExtensionNode",
+      "Id": "a447dd661d6246118831eb92e05c3d17",
+      "Inputs": [
+        {
+          "Id": "339cd13d7f0c4bdc935c9544e6487330",
+          "Name": "item0",
+          "Description": "Item Index #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "1ac9d40ed0344de8a08587e2b7997882",
+          "Name": "list",
+          "Description": "A list",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Makes a new list out of the given inputs"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.Object.IsNull@var",
+      "Id": "3c87ecb6fecf4558b322609e17b8d3de",
+      "Inputs": [
+        {
+          "Id": "e34ee77b2c1e414e8b514d6309ab750a",
+          "Name": "obj",
+          "Description": "Object to test.\n\nvar",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "3ef61d1d392444599f21787e11e82e29",
+          "Name": "bool",
+          "Description": "Whether object is null.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Determines the if the given object is null.\n\nObject.IsNull (obj: var): bool"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.FilterByBoolMask@var[]..[],var[]..[]",
+      "Id": "5ef3ccdfb58e4e55a8c414d0a7ab9960",
+      "Inputs": [
+        {
+          "Id": "1692de1f05dc4ebca99bdb22dd22322e",
+          "Name": "list",
+          "Description": "List to filter.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "2f90910c02764ae4a69bac1b063faae8",
+          "Name": "mask",
+          "Description": "List of booleans representing a mask.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "bfe6eebd6baf4ce9af3e2eae4d6ee8d6",
+          "Name": "in",
+          "Description": "Items whose mask index is true.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f41802bbd3d547cdb9d45cca50a3ae47",
+          "Name": "out",
+          "Description": "Items whose mask index is false.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Filters a sequence by looking up corresponding indices in a separate list of booleans.\n\nList.FilterByBoolMask (list: var[]..[], mask: var[]..[]): var[]..[]"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "2f979b19b79e4853acccf5bff0a158b9",
+      "End": "0728e268fa164c91aaed24cd7fac99d9",
+      "Id": "2c182ab27c1a40079de231c7d66699c0"
+    },
+    {
+      "Start": "7f6a23524caf4e70ab0fc7f55c635c2e",
+      "End": "e34ee77b2c1e414e8b514d6309ab750a",
+      "Id": "f43849ee58074791950f8c417bd76fa2"
+    },
+    {
+      "Start": "7f6a23524caf4e70ab0fc7f55c635c2e",
+      "End": "1692de1f05dc4ebca99bdb22dd22322e",
+      "Id": "8e2f29f9eba14f849697fcc6d01dd8c7"
+    },
+    {
+      "Start": "ea60ce6e53ad4fb4b9aec3d43d25d2bd",
+      "End": "8dbbf613dd0148e59ac94a44e7cb3a81",
+      "Id": "00a87f24d39c4f9d8b5d1e868e1dadcc"
+    },
+    {
+      "Start": "6f13ec7433d54ab39a12fd1161005238",
+      "End": "ec1b567c102b4f079f75be27f43a472c",
+      "Id": "3db969aa8d084762855359a1586138a8"
+    },
+    {
+      "Start": "ef8dec85a13a4ff2b145948cd409a132",
+      "End": "ce3cbf7bc84a4fe4bd9d260f2a1de335",
+      "Id": "6effed35d45e4d36aba2819a145bc5c4"
+    },
+    {
+      "Start": "3defde2d0bd04056863fed2f4e8aef20",
+      "End": "bee99355f7cf4c9783ab9cc815cb2d51",
+      "Id": "25c2b97b280045e3b1d27cc0026d206b"
+    },
+    {
+      "Start": "3defde2d0bd04056863fed2f4e8aef20",
+      "End": "1d6e0a9576c94c30a375f193e99bf46a",
+      "Id": "bc920d7a78d840efaeac3e34c578ea03"
+    },
+    {
+      "Start": "67277948f87b40e8af5b58b6735c96bd",
+      "End": "70641fb35acf4edfad901ef2b1d93f71",
+      "Id": "55d901ee4731484d82e4907f5514a954"
+    },
+    {
+      "Start": "8ad9f05478294c90aac1182e904d7f47",
+      "End": "85202795c4544039bb52844bafc02907",
+      "Id": "ae1e3cdac38f478cb0e33e5b7301dde2"
+    },
+    {
+      "Start": "dcf5c0ee16654c4bbe68355d98179952",
+      "End": "99cb4169a9d24af1bd20e8b0f95cca75",
+      "Id": "6cd798b792784006886e4d350e1ff37e"
+    },
+    {
+      "Start": "3ef61d1d392444599f21787e11e82e29",
+      "End": "2f90910c02764ae4a69bac1b063faae8",
+      "Id": "ada1b0b37f1f4ae8b9e6c03a84ecb9e7"
+    },
+    {
+      "Start": "f41802bbd3d547cdb9d45cca50a3ae47",
+      "End": "bfffd205f15e4752adc8936e81746eaa",
+      "Id": "b52dd0fa3d3640dc9d215b84771b9a4c"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [
+    {
+      "Name": "Hypar Dynamo",
+      "Version": "0.0.1",
+      "ReferenceType": "Package",
+      "Nodes": [
+        "df0610661bed452ea1d6df9e144f7a90",
+        "0f2680a18b6a4251a74e71a8cb4d73bb",
+        "e316758480dc4822b74633be22e7cc72",
+        "8f1f7b08e47b40049966be6981419fa6"
+      ]
+    }
+  ],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.3.0.5885",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Default Camera",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "File Path",
+        "Id": "45cde40e2ce7481cbafbea583359e37b",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1900.9230761528022,
+        "Y": 497.64464786397616
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.Flatten",
+        "Id": "f00a0d336f224b078f92ec05c4a330e2",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1398.4420264956257,
+        "Y": 645.08010168938858
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "All Elements of Category",
+        "Id": "084ecda30f20455c8d5d535bcc3db8ce",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 785.08472123390879,
+        "Y": 783.76745767759678
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Categories",
+        "Id": "726627cf255d47b3a9c4476435c20124",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 542.08472123390879,
+        "Y": 783.76745767759678
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Wall.FromRevitWall",
+        "Id": "df0610661bed452ea1d6df9e144f7a90",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1061.5875120650908,
+        "Y": 783.76745767759678
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Model.ModelFromElements",
+        "Id": "0f2680a18b6a4251a74e71a8cb4d73bb",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1893.6256478340497,
+        "Y": 785.05592249730125
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Model.WriteGlb",
+        "Id": "e316758480dc4822b74633be22e7cc72",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2185.7847429007006,
+        "Y": 622.74531412693932
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Model.WriteJson",
+        "Id": "8f1f7b08e47b40049966be6981419fa6",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2231.096454404093,
+        "Y": 898.67334835655436
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "File Path",
+        "Id": "f73f15b237a74f01b3df349058c3ed4b",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1938.8495257670086,
+        "Y": 934.2418760145714
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.GetItemAtIndex",
+        "Id": "8ead248692814b06bbbbfa978ace4243",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 939.04521785378392,
+        "Y": 952.2694731283475
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "bc0c942970d7428781fd2eb0700786c6",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 735.81250045784168,
+        "Y": 1030.7979417776094
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Select Model Element",
+        "Id": "d4cbc6d928fa4e5ca1f224fcd082273f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 765.32488087498552,
+        "Y": 592.33042772668352
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Select Model Elements",
+        "Id": "2b39079b838a4907bf1ff93d73d6f36c",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 757.20935045646718,
+        "Y": 455.71899901496249
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "bca1102c92804ca6ac7e187b7e00fdb5",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2173.0,
+        "Y": 256.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List Create",
+        "Id": "a447dd661d6246118831eb92e05c3d17",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1737.8707085015278,
+        "Y": 919.81973838283056
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Object.IsNull",
+        "Id": "3c87ecb6fecf4558b322609e17b8d3de",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1494.8938120047735,
+        "Y": 898.691312600504
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List.FilterByBoolMask",
+        "Id": "5ef3ccdfb58e4e55a8c414d0a7ab9960",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1659.9596384291992,
+        "Y": 745.51022567863708
+      }
+    ],
+    "Annotations": [],
+    "X": -468.04368553021072,
+    "Y": -291.55524579762505,
+    "Zoom": 0.75727364474942116
+  }
+}

--- a/src/Revit/RevitHyparTools/Create.Wall.cs
+++ b/src/Revit/RevitHyparTools/Create.Wall.cs
@@ -7,13 +7,13 @@ using Elements.Geometry;
 using GeometryEx;
 using ElemGeom = Elements.Geometry;
 
-using Revit = Autodesk.Revit.DB;
+using ADSK = Autodesk.Revit.DB;
 
-namespace RevitHyparTools
+namespace Hypar.Revit
 {
     public static partial class Create
     {
-        public static Elements.Wall[] WallsFromRevitWall(Revit.Wall wall, Document doc)
+        public static Elements.Wall[] WallsFromRevitWall(ADSK.Wall wall, Document doc)
         {
 
             var side_faces = HostObjectUtils.GetSideFaces(wall, ShellLayerType.Interior);

--- a/src/Revit/RevitHyparTools/Create.Wall.cs
+++ b/src/Revit/RevitHyparTools/Create.Wall.cs
@@ -1,0 +1,41 @@
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Elements.Geometry;
+using GeometryEx;
+using ElemGeom = Elements.Geometry;
+
+using Revit = Autodesk.Revit.DB;
+
+namespace RevitHyparTools
+{
+    public static partial class Create
+    {
+        public static Elements.Wall[] WallsFromRevitWall(Revit.Wall wall, Document doc)
+        {
+
+            var side_faces = HostObjectUtils.GetSideFaces(wall, ShellLayerType.Interior);
+            if (side_faces.Count != 1)
+            {
+                throw new InvalidOperationException($"This wall has ${(side_faces.Count < 1 ? "not enough" : "too many")} interior faces");
+            }
+
+            var wallFace = doc.GetElement(side_faces[0]).GetGeometryObjectFromReference(side_faces[0]);
+            if (!(wallFace is PlanarFace))
+            {
+                throw new InvalidCastException("This wall does not have planar faces");
+            }
+
+            var wallPlane = wallFace as PlanarFace;
+            var profiles = GetProfilesOfFace(wallPlane);
+
+            var centerline = (wall.Location as LocationCurve).Curve;
+            var line = new ElemGeom.Line(centerline.GetEndPoint(0).ToVector3(), centerline.GetEndPoint(1).ToVector3());
+
+            var walls = profiles.Select(p => new WallByProfile(line, p, wall.Width));
+            return walls.ToArray();
+        }
+    }
+}

--- a/src/Revit/RevitHyparTools/Create.cs
+++ b/src/Revit/RevitHyparTools/Create.cs
@@ -10,18 +10,9 @@ using Revit = Autodesk.Revit.DB;
 
 namespace RevitHyparTools
 {
-    public static class Create
+    public static partial class Create
     {
-        public static Elements.Wall WallFromRevitWall(Revit.Wall wall) {
-            //TODO this is a non-functioning placeholder method.  
-            throw new NotImplementedException();
-            var profile = new Elements.Geometry.Profile(ElemGeom.Polygon.Rectangle(6,600), new List<ElemGeom.Polygon>(), Guid.NewGuid(), $"Wall-{wall.Id.IntegerValue}");
-            var height = wall.LookupParameter("Unconnected Height").AsDouble();
 
-            var hWall = new Elements.Wall(profile,height);
-            return hWall;
-        }
-        
         public static Elements.Floor[] FloorsFromRevitFloor(Revit.Document doc, Revit.Floor floor)
         {
             var profiles = GetProfilesOfTopFacesOfFloor(doc, floor);

--- a/src/Revit/RevitHyparTools/Create.cs
+++ b/src/Revit/RevitHyparTools/Create.cs
@@ -6,14 +6,14 @@ using Elements.Geometry;
 using GeometryEx;
 using ElemGeom = Elements.Geometry;
 
-using Revit = Autodesk.Revit.DB;
+using ADSK = Autodesk.Revit.DB;
 
-namespace RevitHyparTools
+namespace Hypar.Revit
 {
     public static partial class Create
     {
 
-        public static Elements.Floor[] FloorsFromRevitFloor(Revit.Document doc, Revit.Floor floor)
+        public static Elements.Floor[] FloorsFromRevitFloor(ADSK.Document doc, ADSK.Floor floor)
         {
             var profiles = GetProfilesOfTopFacesOfFloor(doc, floor);
 

--- a/src/Revit/RevitHyparTools/RevitExtensions.cs
+++ b/src/Revit/RevitHyparTools/RevitExtensions.cs
@@ -1,7 +1,7 @@
 using Autodesk.Revit.DB;
 using Elements.Geometry;
 
-namespace RevitHyparTools 
+namespace Hypar.Revit 
 {
     public static class RevitExtensions {
         public static Vector3 ToVector3(this XYZ xyz) {

--- a/src/Revit/RevitHyparTools/RevitHyparTools.csproj
+++ b/src/Revit/RevitHyparTools/RevitHyparTools.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="0.4.4.2"/>
     <PackageReference Include="GeometryEx" Version="2.27.0"/>
   </ItemGroup>
 
@@ -16,4 +15,7 @@
     </Reference>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\Elements\Elements.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Revit/RevitHyparTools/WallByProfile.cs
+++ b/src/Revit/RevitHyparTools/WallByProfile.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Elements;
+using Elements.Geometry;
+using Elements.Geometry.Solids;
+
+namespace RevitHyparTools {
+    [UserElement]
+    public class WallByProfile : Wall
+    {
+        public Line CenterLine {get;}
+        public double Thickness {get;}
+        public WallByProfile(Line centerLine,
+                             Profile profile,
+                             double thickness,
+                             Material material = null,
+                             Transform transform = null,
+                             Representation representation = null,
+                             bool isElementDefinition = false,
+                             Guid id = default,
+                             string name = null) : base(transform != null ? transform : new Transform(),
+                                                 material != null ? material : BuiltInMaterials.Concrete,
+                                                 representation != null ? representation : new Representation(new List<SolidOperation>()),
+                                                 isElementDefinition,
+                                                 id != default(Guid) ? id : Guid.NewGuid(),
+                                                 name)
+        {
+            Profile = profile;
+            CenterLine = centerLine;
+            Thickness = thickness;
+        }
+
+        public override void UpdateRepresentations() {
+            this.Representation.SolidOperations.Clear();
+            // The wall is a simple extrusion of the profile
+            this.Representation.SolidOperations.Add(new Extrude(this.Profile, this.Thickness, Profile.Perimeter.Normal(), false));
+        }
+    }
+}

--- a/src/Revit/RevitHyparTools/WallByProfile.cs
+++ b/src/Revit/RevitHyparTools/WallByProfile.cs
@@ -5,7 +5,7 @@ using Elements;
 using Elements.Geometry;
 using Elements.Geometry.Solids;
 
-namespace RevitHyparTools {
+namespace Hypar.Revit {
     [UserElement]
     public class WallByProfile : Wall
     {


### PR DESCRIPTION
BACKGROUND:
We want to export walls from Revit as well as floors.

DESCRIPTION:
This PR adds nodes to extract walls, there is a new UserElement class created to make the wall from a face extracted from the Revit wall.

TESTING:
run `dotnet build` and checkout the new nodes.
  
FUTURE WORK:
This only handles Planar walls with a line centerline.

COMMENTS:
There are some geometry issues around the intersections of walls, the joining behavior is not kept with this method of gathering the wall geometry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/246)
<!-- Reviewable:end -->
