### PR TITLE
use thickness and appropriate z transform with floor profiles

### DIFF
--- a/src/Revit/RevitHyparTools/WallByProfile.cs
+++ b/src/Revit/RevitHyparTools/WallByProfile.cs
@@ -18,7 +18,7 @@ namespace RevitHyparTools {
                              Transform transform = null,
                              Representation representation = null,
                              bool isElementDefinition = false,
-                             Guid id = default,
+                             Guid id = default(Guid),
                              string name = null) : base(transform != null ? transform : new Transform(),
                                                  material != null ? material : BuiltInMaterials.Concrete,
                                                  representation != null ? representation : new Representation(new List<SolidOperation>()),


### PR DESCRIPTION
BACKGROUND:
Floors need to use the revit floor thickness and they need to have a floor transform that describes their "top" rather than simply an elevate profile.

DESCRIPTION:
changes to how floors are drawn.

TESTING:
look at floors exported from Revit
  
FUTURE WORK:
None

COMMENTS:
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/247)
<!-- Reviewable:end -->
