### PR TITLE
fix determinant calculation

### DIFF
--- a/src/Elements/Geometry/Matrix.cs
+++ b/src/Elements/Geometry/Matrix.cs
@@ -429,7 +429,7 @@ namespace Elements.Geometry
         /// </summary>
         public double Determinant()
         {
-            return m11 * (m22 * m33 - m22 * m32)
+            return m11 * (m22 * m33 - m23 * m32)
                 + m12 * (m23 * m31 - m21 * m33)
                 + m13 * (m21 * m32 - m22 * m31);
         }

--- a/test/Elements.Tests/MatrixTests.cs
+++ b/test/Elements.Tests/MatrixTests.cs
@@ -1,0 +1,20 @@
+
+using Elements.Geometry;
+using Xunit;
+
+namespace Elements.Tests
+{
+    public class MatrixTests {
+        [Fact]
+        public void DeterminantTest()
+        {
+            var matrix = new Matrix(new Vector3(6, 1, 1),
+                                    new Vector3(4, -2, 5),
+                                    new Vector3(2, 8, 7),
+                                    new Vector3(0, 0, 0));
+
+            var det = matrix.Determinant();
+            Assert.Equal(det, -306.0);
+        }
+    }
+}

--- a/test/Elements.Tests/TransformTests.cs
+++ b/test/Elements.Tests/TransformTests.cs
@@ -46,6 +46,22 @@ namespace Elements.Tests
             Assert.Equal(0.5, vt.Z);
         }
 
+        [Fact]
+        public void Involute_Transform_Inverse() 
+        {
+            // our library should handle involute matrices well
+            // https://en.wikipedia.org/wiki/Involutory_matrix 
+            var origin = new Vector3(0, 0);
+            var xAxis = new Vector3(-1, 0, 0);
+            var zAxis = new Vector3(0, 1, 0);
+            var transform = new Transform(origin, xAxis, zAxis);
+
+            var inverted = new Transform(transform);
+            inverted.Invert();
+
+            Assert.Equal(transform, inverted);
+        }
+
 
         [Fact]
         public void Transform_ScaleAboutPoint()

--- a/test/Elements.Tests/TransformTests.cs
+++ b/test/Elements.Tests/TransformTests.cs
@@ -47,9 +47,9 @@ namespace Elements.Tests
         }
 
         [Fact]
-        public void Involute_Transform_Inverse() 
+        public void Involutary_Transform_Inverse() 
         {
-            // our library should handle involute matrices well
+            // our library should handle involutary matrices well
             // https://en.wikipedia.org/wiki/Involutory_matrix 
             var origin = new Vector3(0, 0);
             var xAxis = new Vector3(-1, 0, 0);


### PR DESCRIPTION
BACKGROUND:
transforms were not inverting when they should be able to

DESCRIPTION:
It fixes the determinant calculation (which had a typo) so that the `Inverse()` method doesn't throw erroneous errors

TESTING:
There is a new test called Involutory_Transform_Inverse
  
FUTURE WORK:
maybe a dedicated Determinant test


