### PR TITLE
Further fix of #253.

### DIFF
--- a/src/Elements/Serialization/IFC/IFCElementExtensions.cs
+++ b/src/Elements/Serialization/IFC/IFCElementExtensions.cs
@@ -17,7 +17,7 @@ namespace Elements.Serialization.IFC
         internal static List<IfcProduct> ToIfcProducts(this Element e,
                                                        IfcRepresentationContext context,
                                                        Document doc,
-                                                       Dictionary<string, List<IfcStyleAssignmentSelect>> styleAssignments)
+                                                       Dictionary<Guid, List<IfcStyleAssignmentSelect>> styleAssignments)
         {
             var products = new List<IfcProduct>();
 
@@ -152,7 +152,7 @@ namespace Elements.Serialization.IFC
 
             foreach(var geom in geoms)
             {
-                var styledItem = new IfcStyledItem(geom, styleAssignments[geoElement.Material.Name], null);
+                var styledItem = new IfcStyledItem(geom, styleAssignments[geoElement.Material.Id], null);
                 doc.AddEntity(styledItem);
             }
 

--- a/src/Elements/Serialization/IFC/IFCModelExtensions.cs
+++ b/src/Elements/Serialization/IFC/IFCModelExtensions.cs
@@ -147,7 +147,7 @@ namespace Elements.Serialization.IFC
             // IfcRelAssociatesMaterial
             // IfcMaterialDefinitionRepresentation
             // https://forums.buildingsmart.org/t/where-and-how-will-my-colors-be-saved-in-ifc/1806/12
-            var styleAssignments = new Dictionary<string, List<IfcStyleAssignmentSelect>>();
+            var styleAssignments = new Dictionary<Guid, List<IfcStyleAssignmentSelect>>();
 
             var white = Colors.White.ToIfcColourRgb();
             ifc.AddEntity(white);
@@ -175,7 +175,7 @@ namespace Elements.Serialization.IFC
 
                 var styleAssign = new IfcStyleAssignmentSelect(surfaceStyle);
                 var assignments = new List<IfcStyleAssignmentSelect>(){styleAssign};
-                styleAssignments.Add(m.Name, assignments);
+                styleAssignments.Add(m.Id, assignments);
             }
 
 


### PR DESCRIPTION
This PR add to the previous fix for #253 by removing all uses of the material's name as a dictionary key.
