### PR TITLE
Make solid operations use INotifyPropertyChanged.

### DIFF
--- a/src/Elements/Analysis/AnalysisMesh.cs
+++ b/src/Elements/Analysis/AnalysisMesh.cs
@@ -20,7 +20,7 @@ namespace Elements.Analysis
         private Grid2d _grid;
         private Func<Vector3, double> _analyze;
 
-        private List<Tuple<Polygon, double>> _results;
+        private List<(Polygon cell, double result)> _results;
         private double _min;
         private double _max;
         
@@ -105,11 +105,16 @@ namespace Elements.Analysis
         /// <param name="mesh"></param>
         public void Tessellate(ref Mesh mesh)
         {
+            if(this._results == null || this._results.Count == 0)
+            {
+                return;
+            }
+            
             var span = this._max - this._min;
             for (var i = 0; i < this._results.Count; i++)
             {
-                var cell = this._results[i].Item1;
-                var result = this._results[i].Item2;
+                var cell = this._results[i].cell;
+                var result = this._results[i].result;
 
                 var tess = new Tess();
                 tess.NoEmptyPolygons = true;
@@ -137,7 +142,7 @@ namespace Elements.Analysis
         /// </summary>
         public void Analyze()
         {
-            this._results = new List<Tuple<Polygon, double>>();
+            this._results = new List<(Polygon cell, double result)>();
             this._min = double.MaxValue;
             this._max = double.MinValue;
 
@@ -155,7 +160,7 @@ namespace Elements.Analysis
                 {
                     var center = innerCell.Centroid();
                     var result = this._analyze(center);
-                    this._results.Add(new Tuple<Polygon, double>(innerCell, result));
+                    this._results.Add((innerCell, result));
                     this._min = Math.Min(this._min, result);
                     this._max = Math.Max(this._max, result);
                 }

--- a/src/Elements/Generate/Element.g.cs
+++ b/src/Elements/Generate/Element.g.cs
@@ -30,11 +30,16 @@ namespace Elements
             var validator = Validator.Instance.GetFirstValidatorForType<Element>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @id, @name});
+                validator.PreConstruct(new object[]{ @id, @name});
             }
         
             this.Id = @id;
             this.Name = @name;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>A unique id.</summary>

--- a/src/Elements/Generate/GeoJSON/Position.g.cs
+++ b/src/Elements/Generate/GeoJSON/Position.g.cs
@@ -29,11 +29,16 @@ namespace Elements.GeoJSON
             var validator = Validator.Instance.GetFirstValidatorForType<Position>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @latitude, @longitude});
+                validator.PreConstruct(new object[]{ @latitude, @longitude});
             }
         
             this.Latitude = @latitude;
             this.Longitude = @longitude;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The latitude in decimal degrees.</summary>

--- a/src/Elements/Generate/GeometricElement.g.cs
+++ b/src/Elements/Generate/GeometricElement.g.cs
@@ -31,13 +31,18 @@ namespace Elements
             var validator = Validator.Instance.GetFirstValidatorForType<GeometricElement>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @transform, @material, @representation, @isElementDefinition, @id, @name});
+                validator.PreConstruct(new object[]{ @transform, @material, @representation, @isElementDefinition, @id, @name});
             }
         
             this.Transform = @transform;
             this.Material = @material;
             this.Representation = @representation;
             this.IsElementDefinition = @isElementDefinition;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The element's transform.</summary>

--- a/src/Elements/Generate/Geometry/Arc.g.cs
+++ b/src/Elements/Generate/Geometry/Arc.g.cs
@@ -30,13 +30,18 @@ namespace Elements.Geometry
             var validator = Validator.Instance.GetFirstValidatorForType<Arc>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @center, @radius, @startAngle, @endAngle});
+                validator.PreConstruct(new object[]{ @center, @radius, @startAngle, @endAngle});
             }
         
             this.Center = @center;
             this.Radius = @radius;
             this.StartAngle = @startAngle;
             this.EndAngle = @endAngle;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The center of the arc.</summary>

--- a/src/Elements/Generate/Geometry/Color.g.cs
+++ b/src/Elements/Generate/Geometry/Color.g.cs
@@ -29,13 +29,18 @@ namespace Elements.Geometry
             var validator = Validator.Instance.GetFirstValidatorForType<Color>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @red, @green, @blue, @alpha});
+                validator.PreConstruct(new object[]{ @red, @green, @blue, @alpha});
             }
         
             this.Red = @red;
             this.Green = @green;
             this.Blue = @blue;
             this.Alpha = @alpha;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The red component of the color between 0.0 and 1.0.</summary>

--- a/src/Elements/Generate/Geometry/Curve.g.cs
+++ b/src/Elements/Generate/Geometry/Curve.g.cs
@@ -30,9 +30,14 @@ namespace Elements.Geometry
             var validator = Validator.Instance.GetFirstValidatorForType<Curve>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ });
+                validator.PreConstruct(new object[]{ });
             }
         
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
     

--- a/src/Elements/Generate/Geometry/Line.g.cs
+++ b/src/Elements/Generate/Geometry/Line.g.cs
@@ -30,11 +30,16 @@ namespace Elements.Geometry
             var validator = Validator.Instance.GetFirstValidatorForType<Line>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @start, @end});
+                validator.PreConstruct(new object[]{ @start, @end});
             }
         
             this.Start = @start;
             this.End = @end;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The start of the line.</summary>

--- a/src/Elements/Generate/Geometry/Matrix.g.cs
+++ b/src/Elements/Generate/Geometry/Matrix.g.cs
@@ -29,10 +29,15 @@ namespace Elements.Geometry
             var validator = Validator.Instance.GetFirstValidatorForType<Matrix>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @components});
+                validator.PreConstruct(new object[]{ @components});
             }
         
             this.Components = @components;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The components of the matrix.</summary>

--- a/src/Elements/Generate/Geometry/Plane.g.cs
+++ b/src/Elements/Generate/Geometry/Plane.g.cs
@@ -29,11 +29,16 @@ namespace Elements.Geometry
             var validator = Validator.Instance.GetFirstValidatorForType<Plane>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @origin, @normal});
+                validator.PreConstruct(new object[]{ @origin, @normal});
             }
         
             this.Origin = @origin;
             this.Normal = @normal;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The origin of the plane.</summary>

--- a/src/Elements/Generate/Geometry/Polygon.g.cs
+++ b/src/Elements/Generate/Geometry/Polygon.g.cs
@@ -30,9 +30,14 @@ namespace Elements.Geometry
             var validator = Validator.Instance.GetFirstValidatorForType<Polygon>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @vertices});
+                validator.PreConstruct(new object[]{ @vertices});
             }
         
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
     

--- a/src/Elements/Generate/Geometry/Polyline.g.cs
+++ b/src/Elements/Generate/Geometry/Polyline.g.cs
@@ -30,10 +30,15 @@ namespace Elements.Geometry
             var validator = Validator.Instance.GetFirstValidatorForType<Polyline>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @vertices});
+                validator.PreConstruct(new object[]{ @vertices});
             }
         
             this.Vertices = @vertices;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The vertices of the polygon.</summary>

--- a/src/Elements/Generate/Geometry/Profile.g.cs
+++ b/src/Elements/Generate/Geometry/Profile.g.cs
@@ -30,11 +30,16 @@ namespace Elements.Geometry
             var validator = Validator.Instance.GetFirstValidatorForType<Profile>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @perimeter, @voids, @id, @name});
+                validator.PreConstruct(new object[]{ @perimeter, @voids, @id, @name});
             }
         
             this.Perimeter = @perimeter;
             this.Voids = @voids;
+
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The perimeter of the profile.</summary>

--- a/src/Elements/Generate/Geometry/Representation.g.cs
+++ b/src/Elements/Generate/Geometry/Representation.g.cs
@@ -29,10 +29,15 @@ namespace Elements.Geometry
             var validator = Validator.Instance.GetFirstValidatorForType<Representation>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @solidOperations});
+                validator.PreConstruct(new object[]{ @solidOperations});
             }
         
             this.SolidOperations = @solidOperations;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>A collection of solid operations.</summary>

--- a/src/Elements/Generate/Geometry/Solids/Extrude.g.cs
+++ b/src/Elements/Generate/Geometry/Solids/Extrude.g.cs
@@ -21,8 +21,12 @@ namespace Elements.Geometry.Solids
 
     /// <summary>An extrusion of a profile, in a direction, to a height.</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.4.0 (Newtonsoft.Json v12.0.0.0)")]
-    public partial class Extrude : SolidOperation
+    public partial class Extrude : SolidOperation, System.ComponentModel.INotifyPropertyChanged
     {
+        private Profile _profile;
+        private double _height;
+        private Vector3 _direction;
+    
         [Newtonsoft.Json.JsonConstructor]
         public Extrude(Profile @profile, double @height, Vector3 @direction, bool @isVoid)
             : base(isVoid)
@@ -30,27 +34,74 @@ namespace Elements.Geometry.Solids
             var validator = Validator.Instance.GetFirstValidatorForType<Extrude>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @profile, @height, @direction, @isVoid});
+                validator.PreConstruct(new object[]{ @profile, @height, @direction, @isVoid});
             }
         
             this.Profile = @profile;
             this.Height = @height;
             this.Direction = @direction;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The id of the profile to extrude.</summary>
         [Newtonsoft.Json.JsonProperty("Profile", Required = Newtonsoft.Json.Required.AllowNull)]
-        public Profile Profile { get; set; }
+        public Profile Profile
+        {
+            get { return _profile; }
+            set 
+            {
+                if (_profile != value)
+                {
+                    _profile = value; 
+                    RaisePropertyChanged();
+                }
+            }
+        }
     
         /// <summary>The height of the extrusion.</summary>
         [Newtonsoft.Json.JsonProperty("Height", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Range(0D, double.MaxValue)]
-        public double Height { get; set; }
+        public double Height
+        {
+            get { return _height; }
+            set 
+            {
+                if (_height != value)
+                {
+                    _height = value; 
+                    RaisePropertyChanged();
+                }
+            }
+        }
     
         /// <summary>The direction in which to extrude.</summary>
         [Newtonsoft.Json.JsonProperty("Direction", Required = Newtonsoft.Json.Required.AllowNull)]
-        public Vector3 Direction { get; set; }
+        public Vector3 Direction
+        {
+            get { return _direction; }
+            set 
+            {
+                if (_direction != value)
+                {
+                    _direction = value; 
+                    RaisePropertyChanged();
+                }
+            }
+        }
     
+    
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        
+        protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
+        {
+            var handler = PropertyChanged;
+            if (handler != null) 
+                handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+        }
     
     }
 }

--- a/src/Elements/Generate/Geometry/Solids/Lamina.g.cs
+++ b/src/Elements/Generate/Geometry/Solids/Lamina.g.cs
@@ -21,8 +21,10 @@ namespace Elements.Geometry.Solids
 
     /// <summary>A zero-thickness solid defined by a profile.</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.4.0 (Newtonsoft.Json v12.0.0.0)")]
-    public partial class Lamina : SolidOperation
+    public partial class Lamina : SolidOperation, System.ComponentModel.INotifyPropertyChanged
     {
+        private Polygon _perimeter;
+    
         [Newtonsoft.Json.JsonConstructor]
         public Lamina(Polygon @perimeter, bool @isVoid)
             : base(isVoid)
@@ -30,16 +32,41 @@ namespace Elements.Geometry.Solids
             var validator = Validator.Instance.GetFirstValidatorForType<Lamina>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @perimeter, @isVoid});
+                validator.PreConstruct(new object[]{ @perimeter, @isVoid});
             }
         
             this.Perimeter = @perimeter;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The perimeter.</summary>
         [Newtonsoft.Json.JsonProperty("Perimeter", Required = Newtonsoft.Json.Required.AllowNull)]
-        public Polygon Perimeter { get; set; }
+        public Polygon Perimeter
+        {
+            get { return _perimeter; }
+            set 
+            {
+                if (_perimeter != value)
+                {
+                    _perimeter = value; 
+                    RaisePropertyChanged();
+                }
+            }
+        }
     
+    
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        
+        protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
+        {
+            var handler = PropertyChanged;
+            if (handler != null) 
+                handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+        }
     
     }
 }

--- a/src/Elements/Generate/Geometry/Solids/SolidOperation.g.cs
+++ b/src/Elements/Generate/Geometry/Solids/SolidOperation.g.cs
@@ -30,10 +30,15 @@ namespace Elements.Geometry.Solids
             var validator = Validator.Instance.GetFirstValidatorForType<SolidOperation>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @isVoid});
+                validator.PreConstruct(new object[]{ @isVoid});
             }
         
             this.IsVoid = @isVoid;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>Is the solid operation a void operation?</summary>

--- a/src/Elements/Generate/Geometry/Solids/Sweep.g.cs
+++ b/src/Elements/Generate/Geometry/Solids/Sweep.g.cs
@@ -21,8 +21,13 @@ namespace Elements.Geometry.Solids
 
     /// <summary>A sweep of a profile along a curve.</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.4.0 (Newtonsoft.Json v12.0.0.0)")]
-    public partial class Sweep : SolidOperation
+    public partial class Sweep : SolidOperation, System.ComponentModel.INotifyPropertyChanged
     {
+        private Profile _profile;
+        private Curve _curve;
+        private double _startSetback;
+        private double _endSetback;
+    
         [Newtonsoft.Json.JsonConstructor]
         public Sweep(Profile @profile, Curve @curve, double @startSetback, double @endSetback, bool @isVoid)
             : base(isVoid)
@@ -30,31 +35,89 @@ namespace Elements.Geometry.Solids
             var validator = Validator.Instance.GetFirstValidatorForType<Sweep>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @profile, @curve, @startSetback, @endSetback, @isVoid});
+                validator.PreConstruct(new object[]{ @profile, @curve, @startSetback, @endSetback, @isVoid});
             }
         
             this.Profile = @profile;
             this.Curve = @curve;
             this.StartSetback = @startSetback;
             this.EndSetback = @endSetback;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The id of the profile to be swept along the curve.</summary>
         [Newtonsoft.Json.JsonProperty("Profile", Required = Newtonsoft.Json.Required.AllowNull)]
-        public Profile Profile { get; set; }
+        public Profile Profile
+        {
+            get { return _profile; }
+            set 
+            {
+                if (_profile != value)
+                {
+                    _profile = value; 
+                    RaisePropertyChanged();
+                }
+            }
+        }
     
         /// <summary>The curve along which the profile will be swept.</summary>
         [Newtonsoft.Json.JsonProperty("Curve", Required = Newtonsoft.Json.Required.AllowNull)]
-        public Curve Curve { get; set; }
+        public Curve Curve
+        {
+            get { return _curve; }
+            set 
+            {
+                if (_curve != value)
+                {
+                    _curve = value; 
+                    RaisePropertyChanged();
+                }
+            }
+        }
     
         /// <summary>The amount to set back the resulting solid from the start of the curve.</summary>
         [Newtonsoft.Json.JsonProperty("StartSetback", Required = Newtonsoft.Json.Required.Always)]
-        public double StartSetback { get; set; }
+        public double StartSetback
+        {
+            get { return _startSetback; }
+            set 
+            {
+                if (_startSetback != value)
+                {
+                    _startSetback = value; 
+                    RaisePropertyChanged();
+                }
+            }
+        }
     
         /// <summary>The amount to set back the resulting solid from the end of the curve.</summary>
         [Newtonsoft.Json.JsonProperty("EndSetback", Required = Newtonsoft.Json.Required.Always)]
-        public double EndSetback { get; set; }
+        public double EndSetback
+        {
+            get { return _endSetback; }
+            set 
+            {
+                if (_endSetback != value)
+                {
+                    _endSetback = value; 
+                    RaisePropertyChanged();
+                }
+            }
+        }
     
+    
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        
+        protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
+        {
+            var handler = PropertyChanged;
+            if (handler != null) 
+                handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+        }
     
     }
 }

--- a/src/Elements/Generate/Geometry/Transform.g.cs
+++ b/src/Elements/Generate/Geometry/Transform.g.cs
@@ -29,10 +29,15 @@ namespace Elements.Geometry
             var validator = Validator.Instance.GetFirstValidatorForType<Transform>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @matrix});
+                validator.PreConstruct(new object[]{ @matrix});
             }
         
             this.Matrix = @matrix;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The transform's matrix.</summary>

--- a/src/Elements/Generate/Geometry/Vector3.g.cs
+++ b/src/Elements/Generate/Geometry/Vector3.g.cs
@@ -29,12 +29,17 @@ namespace Elements.Geometry
             var validator = Validator.Instance.GetFirstValidatorForType<Vector3>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @x, @y, @z});
+                validator.PreConstruct(new object[]{ @x, @y, @z});
             }
         
             this.X = @x;
             this.Y = @y;
             this.Z = @z;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The X component of the vector.</summary>

--- a/src/Elements/Generate/Material.g.cs
+++ b/src/Elements/Generate/Material.g.cs
@@ -30,12 +30,17 @@ namespace Elements
             var validator = Validator.Instance.GetFirstValidatorForType<Material>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @color, @specularFactor, @glossinessFactor, @id, @name});
+                validator.PreConstruct(new object[]{ @color, @specularFactor, @glossinessFactor, @id, @name});
             }
         
             this.Color = @color;
             this.SpecularFactor = @specularFactor;
             this.GlossinessFactor = @glossinessFactor;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The material's color.</summary>

--- a/src/Elements/Generate/Model.g.cs
+++ b/src/Elements/Generate/Model.g.cs
@@ -29,12 +29,17 @@ namespace Elements
             var validator = Validator.Instance.GetFirstValidatorForType<Model>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @origin, @transform, @elements});
+                validator.PreConstruct(new object[]{ @origin, @transform, @elements});
             }
         
             this.Origin = @origin;
             this.Transform = @transform;
             this.Elements = @elements;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The origin of the model.</summary>

--- a/src/Elements/Generate/Properties/NumericProperty.g.cs
+++ b/src/Elements/Generate/Properties/NumericProperty.g.cs
@@ -29,11 +29,16 @@ namespace Elements.Properties
             var validator = Validator.Instance.GetFirstValidatorForType<NumericProperty>();
             if(validator != null)
             {
-                validator.Validate(new object[]{ @value, @unitType});
+                validator.PreConstruct(new object[]{ @value, @unitType});
             }
         
             this.Value = @value;
             this.UnitType = @unitType;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
         }
     
         /// <summary>The property's value</summary>

--- a/src/Elements/Generate/TypeGenerator.cs
+++ b/src/Elements/Generate/TypeGenerator.cs
@@ -24,7 +24,7 @@ namespace Elements.Generate
         public string Generate(JsonSchema schema, string typeNameHint, IEnumerable<string> reservedTypeNames)
         {
             // Console.WriteLine(typeNameHint + ":" + schema.InheritedSchema ?? "none");
-            if(schema.IsEnumeration)
+            if (schema.IsEnumeration)
             {
                 return typeNameHint;
             }
@@ -70,7 +70,7 @@ namespace Elements.Generate
 
         private const string NAMESPACE_PROPERTY = "x-namespace";
         private static string[] _coreTypeNames;
-        
+
         /// <summary>
         /// Generate a user-defined type in a .cs file from a schema.
         /// </summary>
@@ -82,19 +82,19 @@ namespace Elements.Generate
             var schema = GetSchema(uri);
 
             string ns;
-            if(!GetNamespace(schema, out ns))
+            if (!GetNamespace(schema, out ns))
             {
                 return;
             }
 
             var typeName = schema.Title;
             var filePath = Path.Combine(outputBaseDir, GetFileNameFromTypeName(typeName));
-            if(_coreTypeNames == null)
+            if (_coreTypeNames == null)
             {
                 _coreTypeNames = GetCoreTypeNames();
             }
-            var localExcludes = _coreTypeNames.Where(n=>n != typeName).ToArray();
-            
+            var localExcludes = _coreTypeNames.Where(n => n != typeName).ToArray();
+
             WriteTypeFromSchemaToDisk(schema, filePath, typeName, ns, isUserElement, localExcludes);
         }
 
@@ -108,26 +108,26 @@ namespace Elements.Generate
             // https://docs.microsoft.com/en-us/archive/msdn-magazine/2017/may/net-core-cross-platform-code-generation-with-roslyn-and-net-core
 
             var code = new List<string>();
-            foreach(var uri in uris)
+            foreach (var uri in uris)
             {
                 try
                 {
                     var schema = GetSchema(uri);
 
                     string ns;
-                    if(!GetNamespace(schema, out ns))
+                    if (!GetNamespace(schema, out ns))
                     {
                         return null;
                     }
 
                     var typeName = schema.Title;
-                    if(_coreTypeNames == null)
+                    if (_coreTypeNames == null)
                     {
                         _coreTypeNames = GetCoreTypeNames();
                     }
-                    var localExcludes = _coreTypeNames.Where(n=>n != typeName).ToArray();
+                    var localExcludes = _coreTypeNames.Where(n => n != typeName).ToArray();
 
-                    var csharp = WriteTypeFromSchema(schema, typeName, ns,  true, localExcludes);
+                    var csharp = WriteTypeFromSchema(schema, typeName, ns, true, localExcludes);
                     code.Add(csharp);
                 }
                 catch
@@ -141,11 +141,11 @@ namespace Elements.Generate
                                                  kind: Microsoft.CodeAnalysis.SourceCodeKind.Regular,
                                                  documentationMode: Microsoft.CodeAnalysis.DocumentationMode.Diagnose);
             var syntaxTrees = new List<Microsoft.CodeAnalysis.SyntaxTree>();
-            foreach(var cs in code)
+            foreach (var cs in code)
             {
                 var tree = CSharpSyntaxTree.ParseText(cs, options);
                 syntaxTrees.Add(tree);
-                
+
             }
 
             var assemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location);
@@ -173,19 +173,19 @@ namespace Elements.Generate
                                                        syntaxTrees,
                                                        defaultReferences,
                                                        compileOptions);
-            
+
             Assembly assembly = null;
-            using(var ms = new MemoryStream())
+            using (var ms = new MemoryStream())
             {
                 var emitResult = compilation.Emit(ms);
-                if(emitResult.Success)
+                if (emitResult.Success)
                 {
                     ms.Seek(0, SeekOrigin.Begin);
                     assembly = Assembly.Load(ms.ToArray());
                 }
                 else
                 {
-                    foreach(var d in emitResult.Diagnostics)
+                    foreach (var d in emitResult.Diagnostics)
                     {
                         Console.WriteLine(d.ToString());
                     }
@@ -201,13 +201,13 @@ namespace Elements.Generate
         /// <param name="outputBaseDir">The root directory into which generated files will be written.</param>
         public static void GenerateElementTypes(string outputBaseDir)
         {
-            var typeNames = _hyparSchemas.Select(u=>u.Split(new[]{"/"}, StringSplitOptions.RemoveEmptyEntries).Last().Replace(".json", "")).ToList();
+            var typeNames = _hyparSchemas.Select(u => u.Split(new[] { "/" }, StringSplitOptions.RemoveEmptyEntries).Last().Replace(".json", "")).ToList();
 
-            foreach(var uri in _hyparSchemas)
+            foreach (var uri in _hyparSchemas)
             {
-                var split = uri.Split(new[]{"/"}, StringSplitOptions.RemoveEmptyEntries).Skip(3);
-                var outDir = Path.Combine(outputBaseDir, string.Join("/", split.Take(split.Count()-1)).TrimEnd('.'));
-                if(!Directory.Exists(outDir))
+                var split = uri.Split(new[] { "/" }, StringSplitOptions.RemoveEmptyEntries).Skip(3);
+                var outDir = Path.Combine(outputBaseDir, string.Join("/", split.Take(split.Count() - 1)).TrimEnd('.'));
+                if (!Directory.Exists(outDir))
                 {
                     Directory.CreateDirectory(outDir);
                 }
@@ -218,7 +218,7 @@ namespace Elements.Generate
 
         private static string[] GetCoreTypeNames()
         {
-            return _hyparSchemas.Select(u=>u.Split(new[]{"/"}, StringSplitOptions.RemoveEmptyEntries).Last().Replace(".json", "")).ToArray();
+            return _hyparSchemas.Select(u => u.Split(new[] { "/" }, StringSplitOptions.RemoveEmptyEntries).Last().Replace(".json", "")).ToArray();
         }
 
         private static string GetFileNameFromTypeName(string typeName)
@@ -228,27 +228,27 @@ namespace Elements.Generate
 
         private static JsonSchema GetSchema(string uri)
         {
-            if(uri.StartsWith("http://") || uri.StartsWith("https://"))
+            if (uri.StartsWith("http://") || uri.StartsWith("https://"))
             {
-                return Task.Run(()=>JsonSchema.FromUrlAsync(uri)).Result;;
+                return Task.Run(() => JsonSchema.FromUrlAsync(uri)).Result; ;
             }
             else
             {
                 var path = Path.GetFullPath(Path.Combine(System.Environment.CurrentDirectory, uri));
-                if(!File.Exists(path))
+                if (!File.Exists(path))
                 {
                     throw new Exception($"The specified schema, {uri}, can not be found as a relative file or a url.");
                 }
-                return Task.Run(()=> JsonSchema.FromJsonAsync(File.ReadAllText(path))).Result;;
+                return Task.Run(() => JsonSchema.FromJsonAsync(File.ReadAllText(path))).Result; ;
             }
         }
 
         private static bool GetNamespace(JsonSchema schema, out string @namespace)
         {
-            if(!schema.ExtensionData.ContainsKey(NAMESPACE_PROPERTY))
+            if (!schema.ExtensionData.ContainsKey(NAMESPACE_PROPERTY))
             {
                 Console.WriteLine($"The provided schema does not contain the required 'x-namespace' property.");
-                @namespace  = null;
+                @namespace = null;
                 return false;
             }
             @namespace = (string)schema.ExtensionData[NAMESPACE_PROPERTY];
@@ -258,20 +258,28 @@ namespace Elements.Generate
         private static string WriteTypeFromSchema(JsonSchema schema, string typeName, string ns, bool isUserElement = false, string[] excludedTypes = null)
         {
             var templates = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "./Templates"));
-            
-            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings(){
-                Namespace = ns, 
+
+            var structTypes = new[] { "Color", "Vector3" };
+
+            // A limited set of the solid operation types. This will be used
+            // to add INotifyPropertyChanged logic, so we don't add the
+            // base class SolidOperation, or the Import class.
+            var solidOpTypes = new[] { "Extrude", "Sweep", "Lamina"};
+
+            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings()
+            {
+                Namespace = ns,
                 ArrayType = "IList",
                 ArrayInstanceType = "List",
-                ExcludedTypeNames = excludedTypes == null ? new string[]{} : excludedTypes,
+                ExcludedTypeNames = excludedTypes == null ? new string[] { } : excludedTypes,
                 TemplateDirectory = templates,
                 GenerateJsonMethods = false,
-                ClassStyle = CSharpClassStyle.Poco, // Use pocos but with constructors. 
+                ClassStyle = solidOpTypes.Contains(typeName) ? CSharpClassStyle.Inpc : CSharpClassStyle.Poco,
                 TypeNameGenerator = new ElementsTypeNameGenerator()
             });
             var file = generator.GenerateFile();
 
-            if(isUserElement)
+            if (isUserElement)
             {
                 // Insert the UserElement attribute directly before
                 // 'public partial class <typeName>'
@@ -279,7 +287,7 @@ namespace Elements.Generate
                 file = file.Insert(start, $"[UserElement]\n\t");
             }
 
-            if(typeName == "Model")
+            if (typeName == "Model")
             {
                 // JSON schema only allows us to generate Dictionary<string,Element>
                 // Replace those entries here with Dictionary<Guid,Element>.
@@ -290,11 +298,11 @@ namespace Elements.Generate
                 file = file.Replace("public Position Origin { get; set; }", "[Obsolete(\"Use Transform instead.\")]\n\t\tpublic Position Origin { get; set; }");
             }
             // Convert some classes to structs.
-            else if(typeName == "Color" || typeName == "Vector3")
+            else if (structTypes.Contains(typeName))
             {
                 file = file.Replace($"public partial class {typeName}", $"public partial struct {typeName}");
             }
-            
+
             return file;
         }
 

--- a/src/Elements/Geometry/Ray.cs
+++ b/src/Elements/Geometry/Ray.cs
@@ -88,7 +88,7 @@ namespace Elements.Geometry
         /// <returns>True if an intersection occurs, otherwise false. If true, check the intersection result for the location of the intersection.</returns>
         public bool Intersects(SolidOperation solidOp, out List<Vector3> result)
         {
-            var intersects = Intersects(solidOp.GetSolid(), out List<Vector3> tempResult);
+            var intersects = Intersects(solidOp.Solid, out List<Vector3> tempResult);
             result = tempResult;
             return intersects;
         }

--- a/src/Elements/Geometry/Solids/Edge.cs
+++ b/src/Elements/Geometry/Solids/Edge.cs
@@ -3,7 +3,7 @@ namespace Elements.Geometry.Solids
     /// <summary>
     /// A Solid Edge.
     /// </summary>
-    internal class Edge
+    public class Edge
     {
         /// <summary>
         /// The Id of the Edge.

--- a/src/Elements/Geometry/Solids/Face.cs
+++ b/src/Elements/Geometry/Solids/Face.cs
@@ -6,7 +6,7 @@ namespace Elements.Geometry.Solids
     /// <summary>
     /// A Solid Face.
     /// </summary>
-    internal class Face
+    public class Face
     {
         /// <summary>
         /// The Id of the Face.

--- a/src/Elements/Geometry/Solids/HalfEdge.cs
+++ b/src/Elements/Geometry/Solids/HalfEdge.cs
@@ -3,7 +3,7 @@ namespace Elements.Geometry.Solids
     /// <summary>
     /// One half of the directional components of an Edge.
     /// </summary>
-    internal class HalfEdge
+    public class HalfEdge
     {
         /// <summary>
         /// The Edge of which this is one half.

--- a/src/Elements/Geometry/Solids/Import.cs
+++ b/src/Elements/Geometry/Solids/Import.cs
@@ -1,11 +1,7 @@
-using System.Collections.Generic;
-
 namespace Elements.Geometry.Solids
 {
     internal class Import : SolidOperation
     {
-        private Solid _solid;
-
         /// <summary>
         /// Create an import solid.
         /// </summary>
@@ -14,7 +10,6 @@ namespace Elements.Geometry.Solids
         public Import(Solid solid, bool isVoid = false): base(isVoid)
         {
             this._solid = solid;
-            this.IsVoid = isVoid;
         }
 
         internal override Solid GetSolid()

--- a/src/Elements/Geometry/Solids/Loop.cs
+++ b/src/Elements/Geometry/Solids/Loop.cs
@@ -6,7 +6,7 @@ namespace Elements.Geometry.Solids
     /// <summary>
     /// A Loop of HalfEdges which bound a Face.
     /// </summary>
-    internal class Loop
+    public class Loop
     {
         /// <summary>
         /// The Face to which this Loop corresponds.
@@ -40,6 +40,9 @@ namespace Elements.Geometry.Solids
             }
         }
 
+        /// <summary>
+        /// Convert this loop to a polygon.
+        /// </summary>
         public Polygon ToPolygon()
         {
             return new Polygon(

--- a/src/Elements/Geometry/Solids/Solid.cs
+++ b/src/Elements/Geometry/Solids/Solid.cs
@@ -15,7 +15,7 @@ namespace Elements.Geometry.Solids
     /// <summary>
     /// A boundary representation of a solid.
     /// </summary>
-    internal class Solid : ITessellate
+    public class Solid : ITessellate
     {
         private long _faceId;
         private long _edgeId = 10000;

--- a/src/Elements/Geometry/Solids/SolidOperation.cs
+++ b/src/Elements/Geometry/Solids/SolidOperation.cs
@@ -1,4 +1,5 @@
 using Elements.Serialization.JSON;
+using Newtonsoft.Json;
 
 namespace Elements.Geometry.Solids
 {
@@ -10,6 +11,18 @@ namespace Elements.Geometry.Solids
     [JsonInheritanceAttribute("Elements.Geometry.Solids.Lamina", typeof(Lamina))]
     public abstract partial class SolidOperation
     {
+        internal Solid _solid;
+
+        /// <summary>
+        /// The solid operation's solid. To update this
+        /// cached representation, call GetSolid().
+        /// </summary>
+        [JsonIgnore]
+        public Solid Solid
+        {
+            get {return _solid;}
+        }
+
         /// <summary>
         /// Get the updated solid for this operation.
         /// </summary>

--- a/src/Elements/Geometry/Solids/Vertex.cs
+++ b/src/Elements/Geometry/Solids/Vertex.cs
@@ -3,7 +3,7 @@ namespace Elements.Geometry.Solids
     /// <summary>
     /// A Solid Vertex.
     /// </summary>
-    internal class Vertex
+    public class Vertex
     {
         /// <summary>
         /// The Id of the Vertex.

--- a/src/Elements/Geometry/Vector3.cs
+++ b/src/Elements/Geometry/Vector3.cs
@@ -271,6 +271,26 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Are the two vectors the same within Epsilon?
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        public static bool operator ==(Vector3 a, Vector3 b)
+        {
+            return a.Equals(b);
+        }
+
+        /// <summary>
+        /// Are the two vectors not the same within Epsilon?
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        public static bool operator !=(Vector3 a, Vector3 b)
+        {
+            return !a.Equals(b);
+        }
+
+        /// <summary>
         /// Determine whether this vector is parallel to v.
         /// </summary>
         /// <param name="v">The vector to compare to this vector.</param>

--- a/src/Elements/Model.cs
+++ b/src/Elements/Model.cs
@@ -36,7 +36,7 @@ namespace Elements
             var validator = Validator.Instance.GetFirstValidatorForType<Model>();
             if (validator != null)
             {
-                validator.Validate(new object[] { @transform, @elements });
+                validator.PreConstruct(new object[] { @transform, @elements });
             }
 
             this.Transform = @transform;

--- a/src/Elements/Serialization/glTF/GltfExtensions.cs
+++ b/src/Elements/Serialization/glTF/GltfExtensions.cs
@@ -682,7 +682,7 @@ namespace Elements.Serialization.glTF
             var elements = model.Elements.Where(e =>
             {
                 return e.Value is GeometricElement || e.Value is ElementInstance;
-            }).Select(e => e.Value);
+            }).Select(e => e.Value).ToList();
 
             // Lines are stored in a list of lists
             // according to the max available index size.
@@ -770,10 +770,9 @@ namespace Elements.Serialization.glTF
                 {
                     foreach (var solidOp in geom.Representation.SolidOperations)
                     {
-                        var solid = solidOp.GetSolid();
-                        if (solid != null)
+                        if (solidOp.Solid != null)
                         {
-                            meshId = ProcessSolid(solid,
+                            meshId = ProcessSolid(solidOp.Solid,
                                                   e.Id.ToString(),
                                                   materialName,
                                                   ref gltf,
@@ -815,10 +814,9 @@ namespace Elements.Serialization.glTF
                     {
                         foreach(var solidOp in geom.Representation.SolidOperations)
                         {
-                            var solid = solidOp.GetSolid();
-                            if (solid != null)
+                            if (solidOp.Solid != null)
                             {
-                                foreach (var edge in solid.Edges.Values)
+                                foreach (var edge in solidOp.Solid.Edges.Values)
                                 {
                                     lines.AddRange(new[] { i.Transform.OfVector(edge.Left.Vertex.Point), i.Transform.OfVector(edge.Right.Vertex.Point) });
                                 }

--- a/src/Elements/Templates/Class.Constructor.Record.liquid
+++ b/src/Elements/Templates/Class.Constructor.Record.liquid
@@ -19,10 +19,15 @@
     if(validator != null)
     {
         {% assign skipComma = true -%}
-validator.Validate(new object[]{ {% for property in AllProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%}@{{ property.Name | lowercamelcase }}{% endfor -%} });
+validator.PreConstruct(new object[]{ {% for property in AllProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%}@{{ property.Name | lowercamelcase }}{% endfor -%} });
     }
 
 {% for property in Properties -%}
     this.{{property.PropertyName}} = @{{property.Name | lowercamelcase}};
 {% endfor -%}
+
+    if(validator != null)
+    {
+        validator.PostConstruct(this);
+    }
 }

--- a/src/Elements/Validators/Validator.cs
+++ b/src/Elements/Validators/Validator.cs
@@ -17,10 +17,16 @@ namespace Elements.Validators
         Type ValidatesType {get;}
 
         /// <summary>
-        /// Validate the type with the provided arguments.
+        /// Validate the object with the provided arguments.
         /// </summary>
         /// <param name="args"></param>
-        void Validate(object[] args);
+        void PreConstruct(object[] args);
+
+        /// <summary>
+        /// Post construction logic.
+        /// </summary>
+        /// <param name="obj">The constructed object.</param>
+        void PostConstruct(object obj);
     }
 
     /// <summary>

--- a/src/Elements/Validators/Validators.cs
+++ b/src/Elements/Validators/Validators.cs
@@ -11,7 +11,12 @@ namespace Elements.Validators
     {
         public Type ValidatesType => typeof(Arc);
 
-        public void Validate(object[] args)
+        public void PostConstruct(object obj)
+        {
+            return;
+        }
+
+        public void PreConstruct(object[] args)
         {
             //Vector3 @center, double @radius, double @startAngle, double @endAngle
             var center = (Vector3)args[0];
@@ -40,7 +45,12 @@ namespace Elements.Validators
     {
         public Type ValidatesType => typeof(Line);
 
-        public void Validate(object[] args)
+        public void PostConstruct(object obj)
+        {
+            return;
+        }
+
+        public void PreConstruct(object[] args)
         {
             var start= (Vector3)args[0];
             var end = (Vector3)args[1];
@@ -56,7 +66,12 @@ namespace Elements.Validators
     {
         public Type ValidatesType => typeof(Profile);
 
-        public void Validate(object[] args)
+        public void PostConstruct(object obj)
+        {
+            return;
+        }
+
+        public void PreConstruct(object[] args)
         {
             var perimeter = (Polygon)args[0];
             if (perimeter != null && !perimeter.Vertices.AreCoplanar())
@@ -70,7 +85,12 @@ namespace Elements.Validators
     {
         public Type ValidatesType => typeof(Material);
 
-        public void Validate(object[] args)
+        public void PostConstruct(object obj)
+        {
+            return;
+        }
+
+        public void PreConstruct(object[] args)
         {
             var red = (Color)args[0];
             var specularFactor = (double)args[1];
@@ -94,7 +114,12 @@ namespace Elements.Validators
     {
         public Type ValidatesType => typeof(Plane);
 
-        public void Validate(object[] args)
+        public void PostConstruct(object obj)
+        {
+            return;
+        }
+
+        public void PreConstruct(object[] args)
         {
             var origin = (Vector3)args[0];
             var normal = (Vector3)args[1];
@@ -110,7 +135,12 @@ namespace Elements.Validators
     {
         public Type ValidatesType => typeof(Vector3);
 
-        public void Validate(object[] args)
+        public void PostConstruct(object obj)
+        {
+            return;
+        }
+
+        public void PreConstruct(object[] args)
         {
             var x = (double)args[0];
             var y = (double)args[1];
@@ -132,7 +162,12 @@ namespace Elements.Validators
     {
         public Type ValidatesType => typeof(Color);
 
-        public void Validate(object[] args)
+        public void PostConstruct(object obj)
+        {
+            return;
+        }
+
+        public void PreConstruct(object[] args)
         {
             var red = (double)args[0];
             var green = (double)args[1];
@@ -155,7 +190,14 @@ namespace Elements.Validators
     {
         public Type ValidatesType => typeof(Extrude);
 
-        public void Validate(object[] args)
+        public void PostConstruct(object obj)
+        {
+            var extrude = (Extrude)obj;
+            extrude.PropertyChanged += (sender, args) => { extrude._solid = extrude.GetSolid(); };
+            extrude._solid = extrude.GetSolid();
+        }
+
+        public void PreConstruct(object[] args)
         {
             var profile = (Profile)args[0];
             var height = (double)args[1];
@@ -169,11 +211,50 @@ namespace Elements.Validators
         }
     }
 
+    public class SweepValidator : IValidator
+    {
+        public Type ValidatesType => typeof(Sweep);
+
+        public void PostConstruct(object obj)
+        {
+            var sweep = (Sweep)obj;
+            sweep.PropertyChanged += (sender, args) => { sweep._solid = sweep.GetSolid(); };
+            sweep._solid = sweep.GetSolid();
+        }
+
+        public void PreConstruct(object[] args)
+        {
+            return;
+        }
+    }
+
+    public class LaminaValidator : IValidator
+    {
+        public Type ValidatesType => typeof(Lamina);
+
+        public void PostConstruct(object obj)
+        {
+            var lamina = (Lamina)obj;
+            lamina.PropertyChanged += (sender, args) => { lamina._solid = lamina.GetSolid(); };
+            lamina._solid = lamina.GetSolid();
+        }
+
+        public void PreConstruct(object[] args)
+        {
+            return;
+        }
+    }
+
     public class MatrixValidator : IValidator
     {
         public Type ValidatesType => typeof(Matrix);
 
-        public void Validate(object[] args)
+        public void PostConstruct(object obj)
+        {
+            return;
+        }
+
+        public void PreConstruct(object[] args)
         {
             var components = (IList<double>)args[0];
             if(components.Count != 12)
@@ -187,7 +268,12 @@ namespace Elements.Validators
     {
         public Type ValidatesType => typeof(Polyline);
 
-        public void Validate(object[] args)
+        public void PostConstruct(object obj)
+        {
+            return;
+        }
+
+        public void PreConstruct(object[] args)
         {
             var vertices = (IList<Vector3>)args[0];
 
@@ -205,7 +291,12 @@ namespace Elements.Validators
     {
         public Type ValidatesType => typeof(Polygon);
 
-        public void Validate(object[] args)
+        public void PostConstruct(object obj)
+        {
+            return;
+        }
+
+        public void PreConstruct(object[] args)
         {
             var vertices = (IList<Vector3>)args[0];
 

--- a/test/Elements.Tests/AnalysisMeshTests.cs
+++ b/test/Elements.Tests/AnalysisMeshTests.cs
@@ -37,6 +37,7 @@ namespace Elements.Tests
             var colorScale = new ColorScale(new List<Color>(){Colors.Cyan, Colors.Purple, Colors.Orange}, 10);
 
             var analysisMesh = new AnalysisMesh(perimeter, 0.2, 0.2, colorScale, analyze);
+            analysisMesh.Analyze();
             // </example>
 
             this.Model.AddElement(analysisMesh);

--- a/test/Elements.Tests/StructuralFramingTests.cs
+++ b/test/Elements.Tests/StructuralFramingTests.cs
@@ -206,7 +206,7 @@ namespace Elements.Tests
                 var line = new Line(new Vector3(x, 0, z), new Vector3(x,3,z));
                 var beam = new Beam(line, profile, BuiltInMaterials.Steel);
                 beam.UpdateRepresentations();
-                beam.Representation.SolidOperations.First().GetSolid().Tessellate(ref mesh);
+                beam.Representation.SolidOperations.First().Solid.Tessellate(ref mesh);
                 x += 2.0;
                 if (x > 20.0)
                 {


### PR DESCRIPTION
BACKGROUND:
While testing ray intersections with solids, we noticed that solid intersections were calling `GetSolid()`, which is an expensive operation because it creates the extrude, sweep, lamina, etc. We needed a way to compute the solid only when properties were changed that would affect the solid, and to cache that solid for future use.

DESCRIPTION:
- This PR implements `INotifyPropertyChanged` for all solid operation types.
- It adds `PreConstruct` and `PostConstruct` methods to auto-generated classes to allow developers to inject behavior into these classes. 
- It uses the `PostConstruct` method on solid operations to hook the property change notifications and compute a new solid which is cached.
- It adds the `SolidOperation.Solid` property which returns the cached solid.


