### PR TITLE
first stab at meshSolid implementation

### DIFF
--- a/src/Elements/Geometry/Kernel.cs
+++ b/src/Elements/Geometry/Kernel.cs
@@ -1,3 +1,4 @@
+using System;
 using Elements.Geometry.Solids;
 
 namespace Elements.Geometry
@@ -23,7 +24,17 @@ namespace Elements.Geometry
                 return _instance;
             }
         }
-        
+
+        /// <summary>
+        /// Create a solid from a mesh.
+        /// </summary>
+        /// <param name="mesh"></param>
+        /// <returns>A solid.</returns>
+        public Solid CreateMeshSolid(Mesh mesh)
+        {
+            return Solid.CreateMesh(mesh);
+        }
+
         /// <summary>
         /// Create a sweep along a curve.
         /// </summary>

--- a/src/Elements/Geometry/Solids/MeshSolid.cs
+++ b/src/Elements/Geometry/Solids/MeshSolid.cs
@@ -1,0 +1,32 @@
+﻿using System;
+namespace Elements.Geometry.Solids
+{
+    /// <summary>
+    /// A Solid Operation based on a mesh. 
+    /// </summary>
+    public class MeshSolid : SolidOperation
+    {
+        /// <summary>
+        /// The internal Mesh
+        /// </summary>
+        public Mesh Mesh { get; }
+
+        /// <summary>
+        /// Create a MeshSolid.
+        /// </summary>
+        /// <param name="mesh"></param>
+        public MeshSolid(Mesh mesh) : base(false)
+        {
+            Mesh = mesh;
+        }
+
+        /// <summary>
+        /// Get the updated solid representation of the mesh.
+        /// </summary>
+        /// <returns></returns>
+        internal override Solid GetSolid()
+        {
+            return Kernel.Instance.CreateMeshSolid(this.Mesh);
+        }
+    }
+}


### PR DESCRIPTION
BACKGROUND:
- In order to support the Isovist workflow using a mesh as representation rather than a Lamina, @ikeough suggested: 
>A more flexible solution might be to create another type of SolidOperation that holds a mesh.

I am fairly new to the solid code so I expect I will have made some mistakes or invalid assumptions in my implementation. If this seems like the wrong interpretation of the above idea I am happy to scrap all of this in favor of a different direction. 

DESCRIPTION:
- Implement a new solid class called MeshSolid that wraps a mesh.
- Implement a new Solid from Mesh generator on the Kernel

TESTING:
- How should a reviewer observe the behavior desired by this pull request?
  
FUTURE WORK:
- It seems like the moment this "solid" gets tesselated back into a mesh, we're doing a bunch of unnecessary work. Maybe there's a way to have the MeshSolid have special behavior on tesselation? 
