### PR TITLE
deploy on build and make method internal

### DIFF
--- a/src/Dynamo/src/HyparDynamo/HyparDynamo.csproj
+++ b/src/Dynamo/src/HyparDynamo/HyparDynamo.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
@@ -34,12 +34,12 @@
   </ItemGroup>
 
   <ItemGroup>
-      <NodeLibraries Include="$(TargetDir)publish\*.*" />
+    <NodeLibraries Include="$(TargetDir)*.*" />
   </ItemGroup>
 
 
-  <Target Name="BuildPackage" AfterTargets="Publish">
-    <RemoveDir Directories="..\..\deploy\HyparDynamo\bin\" />     
+  <Target Name="BuildPackage" AfterTargets="AfterBuild">
+    <RemoveDir Directories="..\..\deploy\HyparDynamo\bin\" />
     <Copy SourceFiles="@(NodeLibraries)" DestinationFolder="..\..\deploy\HyparDynamo\bin\" ContinueOnError="true" />
     <Copy SourceFiles=".\HyparDynamo_DynamoCustomization.xml" DestinationFolder="..\..\deploy\HyparDynamo\bin\" ContinueOnError="true" />
   </Target>

--- a/src/Revit/RevitHyparTools/RevitExtensions.cs
+++ b/src/Revit/RevitHyparTools/RevitExtensions.cs
@@ -40,7 +40,7 @@ namespace Hypar.Revit
         /// </summary>
         /// <param name="solid">The revit Solid</param>
         /// <param name="verticalThreshold">The angle (in degrees) that represents the threshold for a face to be considered facing up.  A completely horizontal face will have an angle of 0.  A face that does not face up or down at all will have an angle of 90.</param>
-        private static PlanarFace[] GetMostLikelyTopFaces(this Solid solid, double verticalThreshold = 30)
+        internal static PlanarFace[] GetMostLikelyTopFaces(this Solid solid, double verticalThreshold = 30)
         {
             var faces = new List<PlanarFace>();
             foreach (PlanarFace face in solid.Faces)


### PR DESCRIPTION
BACKGROUND:
publishing a dynamo package

DESCRIPTION:
- switch a method to internal that was private.  
- switch the target of our package target so that the package is built on `build` not only on publish.

TESTING:
- this is the setup that was used to deploy the currently published dynamo package
  