### PR TITLE
support tolerance for Vector3.IsParallelTo

### DIFF
--- a/src/Elements/Geometry/Vector3.cs
+++ b/src/Elements/Geometry/Vector3.cs
@@ -297,8 +297,8 @@ namespace Elements.Geometry
         /// <returns>True if the vectors are parallel, otherwise false.</returns>
         public bool IsParallelTo(Vector3 v)
         {
-            var result = Math.Abs(Dot(v));
-            return result == 1.0;
+            var result = Math.Abs(this.Unitized().Dot(v.Unitized()));
+            return result.ApproximatelyEquals(1);
         }
 
         /// <summary>

--- a/test/Elements.Tests/VectorTests.cs
+++ b/test/Elements.Tests/VectorTests.cs
@@ -42,6 +42,18 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void Vector3_Parallel_WithTolerance()
+        {
+            var a = new Vector3(12, 0, 0);
+            var b = Vector3.XAxis;
+            Assert.True(a.IsParallelTo(b));
+
+            var c = a.Negate();
+            var d = new Vector3(12, 0.0001, 0);
+            Assert.True(d.IsParallelTo(c));
+        }
+
+        [Fact]
         public void Project()
         {
             var p = new Plane(new Vector3(0,0,5), Vector3.ZAxis);


### PR DESCRIPTION
BACKGROUND:
- Julio Sarachaga from Lagersoft pointed out that Vector3.IsParallelTo was failing on two vectors one could reasonably expect to be parallel

DESCRIPTION:
- Adds a tolerance to the check, and unitizes vectors to ensure length is not a factor

TESTING:
- added a new test to verify this behavior (was breaking before in two ways, new test covers both) 
