### PR TITLE
Remove dependency on Grid2d from AnalysisGrid.

### DIFF
--- a/src/Elements/Geometry/BBox3.cs
+++ b/src/Elements/Geometry/BBox3.cs
@@ -5,7 +5,7 @@ namespace Elements.Geometry
     /// <summary>
     /// An axis-aligned bounding box.
     /// </summary>
-    public class BBox3
+    public struct BBox3
     {
         /// <summary>
         /// The maximum extent of the bounding box.
@@ -25,7 +25,7 @@ namespace Elements.Geometry
         {
             this.Min = new Vector3(double.MaxValue, double.MaxValue, double.MaxValue);
             this.Max = new Vector3(double.MinValue, double.MinValue, double.MinValue);
-            for(var i=0;i<points.Count; i++)
+            for (var i = 0; i < points.Count; i++)
             {
                 this.Extend(points[i]);
             }
@@ -38,7 +38,7 @@ namespace Elements.Geometry
             if (v.Y < this.Min.Y) newMin.Y = v.Y;
             if (v.Z < this.Min.Z) newMin.Z = v.Z;
             this.Min = newMin;
-            
+
             var newMax = new Vector3(Max.X, Max.Y, Max.Z);
             if (v.X > this.Max.X) newMax.X = v.X;
             if (v.Y > this.Max.Y) newMax.Y = v.Y;
@@ -54,15 +54,15 @@ namespace Elements.Geometry
         {
             this.Min = new Vector3(double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity);
             this.Max = new Vector3(double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity);
-            for(var i=0;i<profile.Perimeter.Vertices.Count; i++)
+            for (var i = 0; i < profile.Perimeter.Vertices.Count; i++)
             {
                 this.Extend(profile.Perimeter.Vertices[i]);
             }
 
-            for(var i=0; i<profile.Voids.Count; i++)
+            for (var i = 0; i < profile.Voids.Count; i++)
             {
                 var v = profile.Voids[i];
-                for(var j=0;j<v.Vertices.Count; j++)
+                for (var j = 0; j < v.Vertices.Count; j++)
                 {
                     this.Extend(v.Vertices[j]);
                 }
@@ -95,6 +95,15 @@ namespace Elements.Geometry
         {
             this.Min = min;
             this.Max = max;
+        }
+
+        /// <summary>
+        /// Get the center of the bounding box.
+        /// </summary>
+        /// <returns>The center of the bounding box.</returns>
+        public Vector3 Center()
+        {
+            return this.Max.Average(this.Min);
         }
     }
 }

--- a/src/Elements/Geometry/Mesh.cs
+++ b/src/Elements/Geometry/Mesh.cs
@@ -235,31 +235,31 @@ namespace Elements.Geometry
             var mesh = new Mesh();
 
             var conversion = Units.GetConversionToMeters(unit);
-            
-            using(var reader = new StreamReader(stlPath))
+
+            using (var reader = new StreamReader(stlPath))
             {
                 string line;
-                while((line = reader.ReadLine()) != null)  
-                {  
+                while ((line = reader.ReadLine()) != null)
+                {
                     line = line.TrimStart();
 
-                    if(line.StartsWith("facet"))
+                    if (line.StartsWith("facet"))
                     {
                         vertexCache.Clear();
                     }
 
-                    if(line.StartsWith("vertex"))
+                    if (line.StartsWith("vertex"))
                     {
                         var splits = line.Split(' ');
                         var x = double.Parse(splits[1]) * conversion;
                         var y = double.Parse(splits[2]) * conversion;
                         var z = double.Parse(splits[3]) * conversion;
-                        var v = new Vertex(new Vector3(x,y,z));
+                        var v = new Vertex(new Vector3(x, y, z));
                         mesh.AddVertex(v);
                         vertexCache.Add(v);
                     }
 
-                    if(line.StartsWith("endfacet"))
+                    if (line.StartsWith("endfacet"))
                     {
                         var t = new Triangle(vertexCache[0], vertexCache[1], vertexCache[2]);
                         mesh.AddTriangle(t);
@@ -268,7 +268,7 @@ namespace Elements.Geometry
             }
             mesh.ComputeNormals();
             return mesh;
-        } 
+        }
 
         /// <summary>
         /// Get a string representation of the mesh.
@@ -422,7 +422,7 @@ Triangles:{_triangles.Count}";
             this._triangles.Add(t);
             return t;
         }
-        
+
         /// <summary>
         /// Add a triangle to the mesh.
         /// </summary>
@@ -441,7 +441,7 @@ Triangles:{_triangles.Count}";
         /// <param name="color">The vertex's color.</param>
         /// <param name="uv">The texture coordinate of the vertex.</param>
         /// <returns>The newly created vertex.</returns>
-        public Vertex AddVertex(Vector3 position, UV uv, Vector3 normal = default(Vector3), Color color = default(Color))
+        public Vertex AddVertex(Vector3 position, UV uv = default(UV), Vector3 normal = default(Vector3), Color color = default(Color))
         {
             var v = new Vertex(position, normal, color);
             v.UV = uv;

--- a/test/Elements.Tests/AnalysisMeshTests.cs
+++ b/test/Elements.Tests/AnalysisMeshTests.cs
@@ -16,25 +16,28 @@ namespace Elements.Tests
             // <example>
             var perimeter1 = Polygon.L(10, 10, 3);
             var perimeter2 = Polygon.Ngon(5, 5);
-            var move = new Transform(3,7,0);
+            var move = new Transform(3, 7, 0);
             var perimeter = perimeter1.Union(move.OfPolygon(perimeter2));
+            var mc = new ModelCurve(perimeter);
+            this.Model.AddElement(mc);
 
             // Construct a mass from which we will measure
             // distance to the analysis mesh's cells.
-            var attractor = new Vector3(10,5);
-            var mass = new Mass(Polygon.Rectangle(1,1));
-            mass.Transform.Move(attractor);
+            var center = perimeter.Centroid();
+            var mass = new Mass(Polygon.Rectangle(1, 1));
+            mass.Transform.Move(center);
             this.Model.AddElement(mass);
 
             // The analyze function computes the distance
             // to the attractor.
-            var analyze = new Func<Vector3,double>((v) => {
-                return attractor.DistanceTo(v);
+            var analyze = new Func<Vector3, double>((v) =>
+            {
+                return center.DistanceTo(v);
             });
 
             // Construct a color scale from a small number
             // of colors.
-            var colorScale = new ColorScale(new List<Color>(){Colors.Cyan, Colors.Purple, Colors.Orange}, 10);
+            var colorScale = new ColorScale(new List<Color>() { Colors.Cyan, Colors.Purple, Colors.Orange }, 10);
 
             var analysisMesh = new AnalysisMesh(perimeter, 0.2, 0.2, colorScale, analyze);
             analysisMesh.Analyze();


### PR DESCRIPTION
BACKGROUND:
- When testing against the work @andrewheumann is doing in #273, it was found that the analysis grid was really slow. We tracked this down to the analysis grid using `Grid2d` to support clipped analysis grids. This was allocating way too much stuff just to support grids that weren't square. 

DESCRIPTION:
- This PR makes analysis grids square. The grid is fit to the bounds of the perimeter polygon supplied. Analysis results within the perimeter are given a value and the vertices of the mesh are colored, otherwise the vertices are set to white.
- This PR changes `BBox3` to a struct and updates the tuple which stores results in `AnalysisGrid` to use a "cell" that is a `BBox3`. This reduces allocation.
- This PR tweaks the `AddVertex(...)` method making the `uv` parameter optional. 
- This PR fixes an issue with `AnalysisMesh` where the normals were not set on the vertices. It does this by calling "ComputeNormals()` after the mesh is created.

![image](https://user-images.githubusercontent.com/1139788/77808680-9a304680-7049-11ea-8ced-759947878420.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/275)
<!-- Reviewable:end -->
