### PR TITLE
Add unit types.

### DIFF
--- a/src/Elements/Units.cs
+++ b/src/Elements/Units.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace Elements
 {
@@ -79,7 +80,7 @@ namespace Elements
         public static double GetConversionToMeters(LengthUnit from)
         {
             var conversion = 1.0;
-            switch(from)
+            switch (from)
             {
                 case LengthUnit.Kilometer:
                     conversion = 1000.0;
@@ -156,6 +157,58 @@ namespace Elements
             /// West
             /// </summary>
             West
+        }
+
+        /// <summary>
+        /// Unit types.
+        /// </summary>        
+        public enum UnitType
+        {
+            /// <summary>
+            /// None
+            /// </summary>
+            [EnumMember(Value = "none")]
+            None,
+            /// <summary>
+            /// Area
+            /// </summary>
+            [EnumMember(Value = "area")]
+            Area,
+            /// <summary>
+            /// Force
+            /// </summary>
+            [EnumMember(Value = "force")]
+            Force,
+            /// <summary>
+            /// Length
+            /// </summary>
+            [EnumMember(Value = "length")]
+            Length,
+            /// <summary>
+            /// Mass
+            /// </summary>
+            [EnumMember(Value = "mass")]
+            Mass,
+            /// <summary>
+            /// Plane Angle
+            /// </summary>
+            [EnumMember(Value = "plane_angle")]
+            PlaneAngle,
+            /// <summary>
+            /// Pressure
+            /// </summary>
+            [EnumMember(Value = "pressure")]
+            Pressure,
+            /// <summary>
+            /// Time
+            /// </summary>
+            [EnumMember(Value = "time")]
+            Time,
+            /// <summary>
+            /// Volume
+            /// </summary>
+            [EnumMember(Value = "volume")]
+            Volume,
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
In 0.7.0 of the `Hypar.Functions` we added the ability to add unit types to function inputs and outputs. The unit types enumeration should live in `Elements.Units`.

DESCRIPTION:
This PR adds the `UnitType` enumeration used by `Hypar.Functions`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/281)
<!-- Reviewable:end -->
