### PR TITLE
Fix #271

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0
+### Fixed
+- #271
+
 ## 0.6.2
 ### Added
 - `Material.Unlit`

--- a/src/Elements/ElementInstance.cs
+++ b/src/Elements/ElementInstance.cs
@@ -1,5 +1,6 @@
 using System;
 using Elements.Geometry;
+using Newtonsoft.Json;
 
 namespace Elements
 {
@@ -30,7 +31,8 @@ namespace Elements
         /// <param name="transform">The transform of the instance.</param>
         /// <param name="name">The name of the instance.</param>
         /// <param name="id">The id of the instance.</param>
-        public ElementInstance(GeometricElement baseDefinition,
+        [JsonConstructor]
+        internal ElementInstance(GeometricElement baseDefinition,
                                Transform transform,
                                string name = null,
                                Guid id = default(Guid)) : base(id == default(Guid) ? Guid.NewGuid() : id, name)


### PR DESCRIPTION
BACKGROUND:
We shouldn't be able to create `ElementInstance` directly. They should only be created through `GeometricElement.CreateInstance`.

DESCRIPTION:
This PR makes the `ElementInstance` constructor internal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/282)
<!-- Reviewable:end -->
