### PR TITLE
Deprecate Polygon.Circle.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 ## 0.7.0
 ### Fixed
 - #271
+- #265
+
+### Added
+- `Curve.ToPolyline(...)`
+- `Circle.ToPolygon(...)`
+- Implicit conversion `Curve` -> `Polyline`.
+- Implcit conversion `Circle` -> `Polygon`.
+
+### Deprecated
+- `Polygon.Circle(...)`
 
 ## 0.6.2
 ### Added

--- a/src/Elements/Geometry/Arc.cs
+++ b/src/Elements/Geometry/Arc.cs
@@ -193,11 +193,5 @@ namespace Elements.Geometry
             }
             return new Arc(this.Center, this.Radius, newStart, newEnd);
         }
-
-        /// <summary>
-        /// Convert an arc to a polyline.
-        /// </summary>
-        /// <param name="a">The arc to convert.</param>
-        public static implicit operator Polyline(Arc a) => a.ToPolyline(10);
     }
 }

--- a/src/Elements/Geometry/Arc.cs
+++ b/src/Elements/Geometry/Arc.cs
@@ -14,6 +14,21 @@ namespace Elements.Geometry
     public partial class Arc : ICurve, IEquatable<Arc>
     {
         /// <summary>
+        /// Construct an arc.
+        /// </summary>
+        /// <param name="radius">The radius of the arc.</param>
+        /// <param name="startAngle">The angle from 0.0, in degrees, at which the arc will start with respect to the positive X axis.</param>
+        /// <param name="endAngle">The angle from 0.0, in degrees, at which the arc will end with respect to the positive X axis.</param>
+        public Arc(double radius, double startAngle, double endAngle)
+            : base()
+        {
+            this.Center = Vector3.Origin;
+            this.Radius = radius;
+            this.StartAngle = startAngle;
+            this.EndAngle = endAngle;
+        }
+
+        /// <summary>
         /// Calculate the length of the arc.
         /// </summary>
         public override double Length()
@@ -55,7 +70,7 @@ namespace Elements.Geometry
             var theta = DegToRad(angle);
             var x = this.Center.X + this.Radius * Math.Cos(theta);
             var y = this.Center.Y + this.Radius * Math.Sin(theta);
-            return new Vector3(x,y);
+            return new Vector3(x, y);
         }
 
         /// <summary>
@@ -66,7 +81,7 @@ namespace Elements.Geometry
         public override Transform TransformAt(double u)
         {
             var p = PointAt(u);
-            var x = (p-this.Center).Unitized();
+            var x = (p - this.Center).Unitized();
             var y = Vector3.ZAxis;
             return new Transform(p, x, x.Cross(y));
         }
@@ -125,12 +140,12 @@ namespace Elements.Geometry
             var d = MinimumChordLength;
             var r = this.Radius;
             var t = 2 * Math.Asin(d / (2 * r));
-            var div = (int)Math.Ceiling((DegToRad(partialAngleSpan))/t);
+            var div = (int)Math.Ceiling((DegToRad(partialAngleSpan)) / t);
 
-            var parameters = new double[div+1];
+            var parameters = new double[div + 1];
             for (var i = 0; i <= div; i++)
             {
-                var u = startSetback + i * (parameterSpan/div);
+                var u = startSetback + i * (parameterSpan / div);
                 parameters[i] = u;
             }
             return parameters;
@@ -143,7 +158,7 @@ namespace Elements.Geometry
         {
             var parameters = GetSampleParameters();
             var vertices = new List<Vector3>();
-            foreach(var p in parameters)
+            foreach (var p in parameters)
             {
                 vertices.Add(PointAt(p));
             }
@@ -157,13 +172,13 @@ namespace Elements.Geometry
         /// <returns>Returns true if the two arcs are equal, otherwise false.</returns>
         public bool Equals(Arc other)
         {
-            if(other == null)
+            if (other == null)
             {
                 return false;
             }
             return this.Center.Equals(other.Center) && this.StartAngle == other.StartAngle && this.EndAngle == other.EndAngle;
         }
-        
+
         /// <summary>
         /// Return the arc which is the complement of this arc.
         /// </summary>
@@ -172,11 +187,17 @@ namespace Elements.Geometry
             var complementSpan = 360.0 - (this.EndAngle - this.StartAngle);
             var newEnd = this.StartAngle;
             var newStart = this.EndAngle;
-            if(newStart > newEnd)
+            if (newStart > newEnd)
             {
                 newStart = newStart - 360.0;
             }
             return new Arc(this.Center, this.Radius, newStart, newEnd);
         }
+
+        /// <summary>
+        /// Convert an arc to a polyline.
+        /// </summary>
+        /// <param name="a">The arc to convert.</param>
+        public static implicit operator Polyline(Arc a) => a.ToPolyline(10);
     }
 }

--- a/src/Elements/Geometry/Circle.cs
+++ b/src/Elements/Geometry/Circle.cs
@@ -36,11 +36,5 @@ namespace Elements.Geometry
             }
             return new Polygon(pts);
         }
-
-        /// <summary>
-        /// Convert a circle to a polygon
-        /// </summary>
-        /// <param name="c">The circle to convert.</param>
-        public static implicit operator Polygon(Circle c) => c.ToPolygon(10);
     }
 }

--- a/src/Elements/Geometry/Circle.cs
+++ b/src/Elements/Geometry/Circle.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace Elements.Geometry
 {
     /// <summary>
@@ -11,6 +13,34 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="center">The center of the circle.</param>
         /// <param name="radius">The radius of the circle.</param>
-        public Circle(Vector3 center, double radius = 1.0) : base(center, radius, 0.0, 360.0){}
+        [JsonConstructor]
+        public Circle(Vector3 center, double radius = 1.0) : base(center, radius, 0.0, 360.0) { }
+
+        /// <summary>
+        /// Construct a circle.
+        /// </summary>
+        /// <param name="radius">The radius of the circle.</param>
+        public Circle(double radius = 1.0) : base(Vector3.Origin, radius, 0.0, 360.0) { }
+
+        /// <summary>
+        /// Create a polygon through a set of points along the arc.
+        /// </summary>
+        /// <param name="divisions">The number of divisions of the arc.</param>
+        /// <returns>A polyline.</returns>
+        public Polygon ToPolygon(int divisions = 10)
+        {
+            var pts = new Vector3[divisions];
+            for (int i = 0; i < divisions; i++)
+            {
+                pts[i] = this.PointAt((double)i / (double)divisions);
+            }
+            return new Polygon(pts);
+        }
+
+        /// <summary>
+        /// Convert a circle to a polygon
+        /// </summary>
+        /// <param name="c">The circle to convert.</param>
+        public static implicit operator Polygon(Circle c) => c.ToPolygon(10);
     }
 }

--- a/src/Elements/Geometry/Curve.cs
+++ b/src/Elements/Geometry/Curve.cs
@@ -61,6 +61,21 @@ namespace Elements.Geometry
         /// <returns>A transform.</returns>
         public abstract Transform TransformAt(double u);
 
+        /// <summary>
+        /// Create a polyline through a set of points along the curve.
+        /// </summary>
+        /// <param name="divisions">The number of divisions of the curve.</param>
+        /// <returns>A polyline.</returns>
+        public virtual Polyline ToPolyline(int divisions = 10)
+        {
+            var pts = new Vector3[divisions + 1];
+            for (int i = 0; i <= divisions; i++)
+            {
+                pts[i] = this.PointAt((double)i / (double)divisions);
+            }
+            return new Polyline(pts);
+        }
+
         internal virtual double[] GetSampleParameters(double startSetback = 0.0, double endSetback = 0.0)
         {
             return new[] { startSetback, 1.0 - endSetback };

--- a/src/Elements/Geometry/Polygons.cs
+++ b/src/Elements/Geometry/Polygons.cs
@@ -46,6 +46,7 @@ namespace Elements.Geometry
         /// <param name="radius">The radius of the circle.</param>
         /// <param name="divisions">The number of divisions of the circle.</param>
         /// <returns>A circle as a Polygon tessellated into the specified number of divisions.</returns>
+        [Obsolete("Please use Elements.Geometry.Circle.ToPolygon() instead.")]
         public static Polygon Circle(double radius = 1.0, int divisions = 10)
         {
             var verts = new Vector3[divisions];

--- a/src/Elements/Geometry/Profile.cs
+++ b/src/Elements/Geometry/Profile.cs
@@ -19,7 +19,10 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Construct a profile from a list of polygons. Inner polygons will be treated as voids.
+        /// Construct a profile from a collection of polygons.
+        /// If the collection contains more than one polygon, the first polygon
+        /// will be used as the perimeter and any remaining polygons will 
+        /// be used as voids.
         /// </summary>
         /// <param name="polygons">The polygons bounding this profile.</param>
         public Profile(IList<Polygon> polygons) : base(Guid.NewGuid(), null)
@@ -57,7 +60,7 @@ namespace Elements.Geometry
             {
                 throw new ArgumentException("Unable to construct a profile. More than one of the polygons supplied are not contained by any other.");
             }
-            if(outerMostIndices.Count() == 0)
+            if (outerMostIndices.Count() == 0)
             {
                 throw new ArgumentException("Unable to construct a profile. All the supplied polygons are inside other supplied polygons. Sounds like a geometric paradox!");
             }
@@ -73,10 +76,10 @@ namespace Elements.Geometry
         /// Construct a profile.
         /// </summary>
         /// <param name="perimeter">The perimeter of the profile.</param>
-        /// <param name="singleVoid">A void in the profile.</param>
+        /// <param name="void">A void in the profile.</param>
         public Profile(Polygon perimeter,
-                       Polygon singleVoid) :
-            this(perimeter, new[] { singleVoid }, Guid.NewGuid(), null)
+                       Polygon @void) :
+            this(perimeter, new[] { @void }, Guid.NewGuid(), null)
         { }
 
         /// <summary>
@@ -121,6 +124,7 @@ namespace Elements.Geometry
                 this.Voids[i].Transform(t);
             }
         }
+
         /// <summary>
         /// Return a new profile that is this profile scaled about the origin by the desired amount.
         /// </summary>

--- a/src/Elements/Geometry/Profiles/HSSPipeProfile.cs
+++ b/src/Elements/Geometry/Profiles/HSSPipeProfile.cs
@@ -6,38 +6,38 @@ namespace Elements.Geometry.Profiles
 {
     public class HSSPipeProfile : Profile
     {
-        public double OuterDiam {get; internal set;}
-        public double InnerDiam {get; internal set;}
-        public double t {get; internal set;}
+        public double OuterDiam { get; internal set; }
+        public double InnerDiam { get; internal set; }
+        public double t { get; internal set; }
 
         [JsonIgnore]
-        public double wt {get; internal set;}
+        public double wt { get; internal set; }
 
         [JsonIgnore]
-        public double A {get;internal set;}
+        public double A { get; internal set; }
 
         [JsonIgnore]
-        public double I {get;internal set;}
+        public double I { get; internal set; }
 
         [JsonIgnore]
-        public double S {get;internal set;}
+        public double S { get; internal set; }
 
         [JsonIgnore]
-        public double r {get;internal set;}
+        public double r { get; internal set; }
 
         [JsonIgnore]
-        public double J {get;internal set;}
+        public double J { get; internal set; }
 
         public HSSPipeProfile(string name,
                               Guid id,
                               double outerDiam,
                               double innerDiam,
-                              double t) : 
-            base(Polygon.Circle(outerDiam), new Polygon[]{Polygon.Circle(innerDiam).Reversed()}, id, name)
-            {
-                this.OuterDiam = outerDiam;
-                this.InnerDiam = innerDiam;
-                this.t = t;
-            }
+                              double t) :
+            base(new Circle(outerDiam).ToPolygon(10), new Polygon[] { new Circle(innerDiam).ToPolygon(10).Reversed() }, id, name)
+        {
+            this.OuterDiam = outerDiam;
+            this.InnerDiam = innerDiam;
+            this.t = t;
+        }
     }
 }

--- a/src/Elements/Serialization/IFC/IFCExtensions.cs
+++ b/src/Elements/Serialization/IFC/IFCExtensions.cs
@@ -16,7 +16,7 @@ namespace Elements.Serialization.IFC
         internal static Beam ToBeam(this IfcBeam beam)
         {
             var elementTransform = beam.ObjectPlacement.ToTransform();
-            
+
             var solid = beam.RepresentationsOfType<IfcExtrudedAreaSolid>().FirstOrDefault();
 
             // foreach (var cis in beam.ContainedInStructure)
@@ -24,14 +24,14 @@ namespace Elements.Serialization.IFC
             //     cis.RelatingStructure.ObjectPlacement.ToTransform().Concatenate(transform);
             // }
 
-            if(solid != null)
+            if (solid != null)
             {
                 var solidTransform = solid.Position.ToTransform();
 
                 var c = solid.SweptArea.ToCurve();
-                if(c is Polygon)
+                if (c is Polygon)
                 {
-                    var cl = new Line(Vector3.Origin, 
+                    var cl = new Line(Vector3.Origin,
                         solid.ExtrudedDirection.ToVector3(), (IfcLengthMeasure)solid.Depth);
                     var result = new Beam(solidTransform.OfLine(cl),
                                           new Profile((Polygon)c),
@@ -43,7 +43,7 @@ namespace Elements.Serialization.IFC
                                           false,
                                           IfcGuid.FromIfcGUID(beam.GlobalId),
                                           beam.Name);
-                    return result; 
+                    return result;
                 }
             }
             return null;
@@ -52,14 +52,14 @@ namespace Elements.Serialization.IFC
         internal static Column ToColumn(this IfcColumn column)
         {
             var elementTransform = column.ObjectPlacement.ToTransform();
-            
+
             var solid = column.RepresentationsOfType<IfcExtrudedAreaSolid>().FirstOrDefault();
             foreach (var cis in column.ContainedInStructure)
             {
                 cis.RelatingStructure.ObjectPlacement.ToTransform().Concatenate(elementTransform);
             }
 
-            if(solid != null)
+            if (solid != null)
             {
                 var solidTransform = solid.Position.ToTransform();
                 var c = solid.SweptArea.ToCurve();
@@ -91,7 +91,7 @@ namespace Elements.Serialization.IFC
 
             var localPlacement = space.ObjectPlacement.ToTransform();
             transform.Concatenate(localPlacement);
-            
+
             var foundSolid = repItems.First();
             var material = new Material("space", new Color(1.0f, 0.0f, 1.0f, 0.5f), 0.0f, 0.0f);
             if (foundSolid.GetType() == typeof(IfcExtrudedAreaSolid))
@@ -109,7 +109,7 @@ namespace Elements.Serialization.IFC
                 var solid = (IfcFacetedBrep)foundSolid;
                 var shell = solid.Outer;
                 var newSolid = new Solid();
-                for(var i=0; i< shell.CfsFaces.Count; i++)
+                for (var i = 0; i < shell.CfsFaces.Count; i++)
                 {
                     var f = shell.CfsFaces[i];
                     foreach (var b in f.Bounds)
@@ -155,15 +155,15 @@ namespace Elements.Serialization.IFC
             var solidTransform = solid.Position.ToTransform();
 
             solidTransform.Concatenate(transform);
-            var floor = new Floor(new Profile(outline), (IfcLengthMeasure)solid.Depth, 
+            var floor = new Floor(new Profile(outline), (IfcLengthMeasure)solid.Depth,
                 solidTransform, BuiltInMaterials.Concrete, null, false, IfcGuid.FromIfcGUID(slab.GlobalId));
 
-            floor.Openings.AddRange(openings.Select(o=>o.ToOpening()));
+            floor.Openings.AddRange(openings.Select(o => o.ToOpening()));
 
             return floor;
         }
-    
-        internal static Wall ToWall(this IfcWallStandardCase wall, 
+
+        internal static Wall ToWall(this IfcWallStandardCase wall,
             IEnumerable<IfcOpeningElement> openings)
         {
             var transform = new Transform();
@@ -171,16 +171,16 @@ namespace Elements.Serialization.IFC
 
             // An extruded face solid.
             var solid = wall.RepresentationsOfType<IfcExtrudedAreaSolid>().FirstOrDefault();
-            if(solid == null)
+            if (solid == null)
             {
                 // It's possible that the rep is a boolean.
                 var boolean = wall.RepresentationsOfType<IfcBooleanClippingResult>().FirstOrDefault();
-                if(boolean != null)
+                if (boolean != null)
                 {
                     solid = boolean.FirstOperand.Choice as IfcExtrudedAreaSolid;
-                    if(solid == null)
+                    if (solid == null)
                     {
-                        solid = boolean.SecondOperand.Choice as IfcExtrudedAreaSolid; 
+                        solid = boolean.SecondOperand.Choice as IfcExtrudedAreaSolid;
                     }
                 }
 
@@ -189,10 +189,10 @@ namespace Elements.Serialization.IFC
                 //     throw new Exception("No usable solid was found when converting an IfcWallStandardCase to a Wall.");
                 // }
             }
-            
+
             // A centerline wall with material layers.
             // var axis = (Polyline)wall.RepresentationsOfType<IfcPolyline>().FirstOrDefault().ToICurve(false);
-            
+
             foreach (var cis in wall.ContainedInStructure)
             {
                 cis.RelatingStructure.ObjectPlacement.ToTransform().Concatenate(transform);
@@ -200,10 +200,10 @@ namespace Elements.Serialization.IFC
 
             // var os = openings.Select(o=>o.ToOpening()).ToArray();
 
-            if(solid != null)
+            if (solid != null)
             {
                 var c = solid.SweptArea.ToCurve();
-                if(c is Polygon)
+                if (c is Polygon)
                 {
                     transform.Concatenate(solid.Position.ToTransform());
                     var result = new Wall((Polygon)c,
@@ -219,18 +219,18 @@ namespace Elements.Serialization.IFC
             }
             return null;
         }
-    
+
         internal static Opening ToOpening(this IfcOpeningElement opening)
         {
             var openingTransform = opening.ObjectPlacement.ToTransform();
             var s = opening.RepresentationsOfType<IfcExtrudedAreaSolid>().FirstOrDefault();
-            if(s != null)
+            if (s != null)
             {
                 var solidTransform = s.Position.ToTransform();
                 solidTransform.Concatenate(openingTransform);
                 var profile = (Polygon)s.SweptArea.ToCurve();
                 // Console.WriteLine($"Opening profile:\n{profile.ToString()}\n");
-                
+
                 var newOpening = new Opening(profile,
                                              (IfcLengthMeasure)s.Depth,
                                              solidTransform,
@@ -243,23 +243,23 @@ namespace Elements.Serialization.IFC
         }
 
         private static Solid Representations(this IfcProduct product)
-        {   
-            var reps = product.Representation.Representations.SelectMany(r=>r.Items);
-            foreach(var r in reps)
+        {
+            var reps = product.Representation.Representations.SelectMany(r => r.Items);
+            foreach (var r in reps)
             {
-                if(r is IfcSurfaceCurveSweptAreaSolid)
+                if (r is IfcSurfaceCurveSweptAreaSolid)
                 {
                     throw new Exception("IfcSurfaceCurveSweptAreaSolid is not supported yet.");
                 }
-                if(r is IfcRevolvedAreaSolid)
+                if (r is IfcRevolvedAreaSolid)
                 {
                     throw new Exception("IfcRevolvedAreaSolid is not supported yet.");
                 }
-                if(r is IfcSweptDiskSolid)
+                if (r is IfcSweptDiskSolid)
                 {
                     throw new Exception("IfcSweptDiskSolid is not supported yet.");
                 }
-                else if(r is IfcExtrudedAreaSolid)
+                else if (r is IfcExtrudedAreaSolid)
                 {
                     var eas = (IfcExtrudedAreaSolid)r;
                     var profileDef = (IfcArbitraryClosedProfileDef)eas.SweptArea;
@@ -267,13 +267,13 @@ namespace Elements.Serialization.IFC
                     var outline = pline.ToPolygon(true);
                     var solid = Solid.SweepFace(outline, null, (IfcLengthMeasure)eas.Depth);
                 }
-                else if(r is IfcFacetedBrep)
+                else if (r is IfcFacetedBrep)
                 {
                     var solid = new Solid();
                     var fbr = (IfcFacetedBrep)r;
                     var shell = fbr.Outer;
                     var faces = new Face[shell.CfsFaces.Count];
-                    for(var i=0; i< shell.CfsFaces.Count; i++)
+                    for (var i = 0; i < shell.CfsFaces.Count; i++)
                     {
                         var f = shell.CfsFaces[i];
                         var boundCount = 0;
@@ -283,13 +283,13 @@ namespace Elements.Serialization.IFC
                         {
                             var loop = (IfcPolyLoop)b.Bound;
                             var newLoop = loop.Polygon.ToLoop(solid);
-                            if(boundCount == 0)
+                            if (boundCount == 0)
                             {
                                 outer = newLoop;
                             }
                             else
                             {
-                                inner[boundCount-1] = newLoop;
+                                inner[boundCount - 1] = newLoop;
                             }
                             boundCount++;
                         }
@@ -297,7 +297,7 @@ namespace Elements.Serialization.IFC
                     }
                     return solid;
                 }
-                else if(r is IfcFacetedBrepWithVoids)
+                else if (r is IfcFacetedBrepWithVoids)
                 {
                     throw new Exception("IfcFacetedBrepWithVoids is not supported yet.");
                 }
@@ -305,10 +305,10 @@ namespace Elements.Serialization.IFC
             return null;
         }
 
-        private static IEnumerable<T> RepresentationsOfType<T>(this IfcProduct product) where T: IfcGeometricRepresentationItem
+        private static IEnumerable<T> RepresentationsOfType<T>(this IfcProduct product) where T : IfcGeometricRepresentationItem
         {
-            var reps = product.Representation.Representations.SelectMany(r=>r.Items);
-            if(reps.Any())
+            var reps = product.Representation.Representations.SelectMany(r => r.Items);
+            if (reps.Any())
             {
                 return reps.OfType<T>();
             }
@@ -321,7 +321,7 @@ namespace Elements.Serialization.IFC
         //     // We use the Z extrude direction because the direction is 
         //     // relative to the local placement, which is a transform at the
         //     // beam's end with the Z axis pointing along the direction.
-            
+
         //     // var extrudeDirection = opening.ExtrudeDirection.ToIfcDirection();
         //     // var position = new Transform().ToIfcAxis2Placement3D(doc);
         //     // var solid = new IfcExtrudedAreaSolid(sweptArea, position, 
@@ -335,7 +335,7 @@ namespace Elements.Serialization.IFC
         //     var productRep = new IfcProductDefinitionShape(new List<IfcRepresentation>{shape});
 
         //     var ifcOpening = new IfcOpeningElement(IfcGuid.ToIfcGuid(opening.Id), null, null, null, null, localPlacement, productRep, null);
-            
+
         //     // doc.AddEntity(sweptArea);
         //     // doc.AddEntity(extrudeDirection);
         //     // doc.AddEntity(position);
@@ -351,31 +351,33 @@ namespace Elements.Serialization.IFC
 
         private static ICurve ToCurve(this IfcProfileDef profile)
         {
-            if(profile is IfcCircleProfileDef)
+            if (profile is IfcCircleProfileDef)
             {
                 var cpd = (IfcCircleProfileDef)profile;
-                return Polygon.Circle((IfcLengthMeasure)cpd.Radius);
+                // TODO: Remove this conversion to a polygon when downstream
+                // functions support arcs and circles.
+                return new Circle((IfcLengthMeasure)cpd.Radius).ToPolygon(10);
             }
-            else if(profile is IfcParameterizedProfileDef)
+            else if (profile is IfcParameterizedProfileDef)
             {
                 var ipd = (IfcParameterizedProfileDef)profile;
                 return ipd.ToCurve();
             }
-            else if(profile is IfcArbitraryOpenProfileDef)
+            else if (profile is IfcArbitraryOpenProfileDef)
             {
                 var aopd = (IfcArbitraryOpenProfileDef)profile;
                 return aopd.ToCurve();
             }
-            else if(profile is IfcArbitraryClosedProfileDef)
+            else if (profile is IfcArbitraryClosedProfileDef)
             {
                 var acpd = (IfcArbitraryClosedProfileDef)profile;
                 return acpd.ToCurve();
             }
-            else if(profile is IfcCompositeProfileDef)
+            else if (profile is IfcCompositeProfileDef)
             {
                 throw new Exception("IfcCompositeProfileDef is not supported yet.");
             }
-            else if(profile is IfcDerivedProfileDef)
+            else if (profile is IfcDerivedProfileDef)
             {
                 throw new Exception("IfcDerivedProfileDef is not supported yet.");
             }
@@ -384,17 +386,17 @@ namespace Elements.Serialization.IFC
 
         private static ICurve ToCurve(this IfcParameterizedProfileDef profile)
         {
-            if(profile is IfcRectangleProfileDef)
+            if (profile is IfcRectangleProfileDef)
             {
                 var rect = (IfcRectangleProfileDef)profile;
                 var p = Polygon.Rectangle((IfcLengthMeasure)rect.XDim, (IfcLengthMeasure)rect.YDim);
                 var t = new Transform(rect.Position.Location.ToVector3());
                 return t.OfPolygon(p);
             }
-            else if(profile is IfcCircleProfileDef)
+            else if (profile is IfcCircleProfileDef)
             {
                 var circle = (IfcCircleProfileDef)profile;
-                return Polygon.Circle((IfcLengthMeasure)circle.Radius);
+                return new Circle((IfcLengthMeasure)circle.Radius);
             }
             else
             {
@@ -414,16 +416,16 @@ namespace Elements.Serialization.IFC
 
         private static ICurve ToCurve(this IfcCurve curve, bool closed)
         {
-            if(curve is IfcBoundedCurve)
+            if (curve is IfcBoundedCurve)
             {
-                if(curve is IfcCompositeCurve)
+                if (curve is IfcCompositeCurve)
                 {
                     throw new Exception("IfcCompositeCurve is not supported yet.");
                 }
-                else if(curve is IfcPolyline)
+                else if (curve is IfcPolyline)
                 {
                     var pl = (IfcPolyline)curve;
-                    if(closed)
+                    if (closed)
                     {
                         return pl.ToPolygon(true);
                     }
@@ -432,7 +434,7 @@ namespace Elements.Serialization.IFC
                         return pl.ToPolyline();
                     }
                 }
-                else if(curve is IfcTrimmedCurve)
+                else if (curve is IfcTrimmedCurve)
                 {
                     throw new Exception("IfcTrimmedCurve is not supported yet.");
                 }
@@ -441,15 +443,15 @@ namespace Elements.Serialization.IFC
                     throw new Exception("IfcBSplineCurve is not supported yet.");
                 }
             }
-            else if(curve is IfcConic)
+            else if (curve is IfcConic)
             {
                 throw new Exception("IfcConic is not supported yet.");
             }
-            else if(curve is IfcOffsetCurve2D)
+            else if (curve is IfcOffsetCurve2D)
             {
                 throw new Exception("IfcOffsetCurve2D is not supported yet.");
             }
-            else if(curve is IfcOffsetCurve3D)
+            else if (curve is IfcOffsetCurve3D)
             {
                 throw new Exception("IfcOffsetCurve3D is not supported yet.");
             }
@@ -491,22 +493,22 @@ namespace Elements.Serialization.IFC
 
         private static Polyline ToPolyline(this IfcPolyline polyline)
         {
-            var verts = polyline.Points.Select(p=>p.ToVector3()).ToArray();
+            var verts = polyline.Points.Select(p => p.ToVector3()).ToArray();
             return new Polyline(verts);
         }
 
         private static bool IsClosed(this IfcPolyline pline)
         {
             var start = pline.Points[0];
-            var end = pline.Points[pline.Points.Count-1];
+            var end = pline.Points[pline.Points.Count - 1];
             return start.Equals(end);
         }
 
         private static bool Equals(this IfcCartesianPoint point, IfcCartesianPoint other)
         {
-            for(var i=0; i<point.Coordinates.Count; i++)
+            for (var i = 0; i < point.Coordinates.Count; i++)
             {
-                if(point.Coordinates[i] != other.Coordinates[i])
+                if (point.Coordinates[i] != other.Coordinates[i])
                 {
                     return false;
                 }
@@ -560,7 +562,7 @@ namespace Elements.Serialization.IFC
         private static Transform ToTransform(this IfcLocalPlacement placement)
         {
             var t = placement.RelativePlacement.ToTransform();
-            if(placement.PlacementRelTo != null)
+            if (placement.PlacementRelTo != null)
             {
                 var tr = placement.PlacementRelTo.ToTransform();
                 t.Concatenate(tr);

--- a/test/Elements.Tests/ArcTests.cs
+++ b/test/Elements.Tests/ArcTests.cs
@@ -96,5 +96,21 @@ namespace Hypar.Tests
             Assert.Equal(-350, comp.StartAngle);
             Assert.Equal(-10, comp.EndAngle);
         }
+
+        [Fact]
+        public void ToPolyline()
+        {
+            var arc = new Arc(Vector3.Origin, 1, 10, 20);
+            var p = arc.ToPolyline(10);
+            Assert.Equal(10, p.Segments().Length);
+        }
+
+        [Fact]
+        public void ToPolygon()
+        {
+            var c = new Circle(Vector3.Origin, 1);
+            var p = c.ToPolygon(10);
+            Assert.Equal(10, p.Segments().Length);
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
See #190.

DESCRIPTION:
This PR deprecates the `Polygon.Circle` method and adds `Circle.ToPolygon(...)` as well as a number of other useful implicit conversions between arcs and polylines and circles and polygons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/288)
<!-- Reviewable:end -->
