### PR TITLE
Added check for zero length line for short segments

### DIFF
--- a/src/Elements/Geometry/Line.cs
+++ b/src/Elements/Geometry/Line.cs
@@ -214,7 +214,10 @@ namespace Elements.Geometry
             if (total < len && !removeShortSegments)
             {
                 var a = this.Start + d * total;
-                lines.Add(new Line(a, End));
+                if (!a.IsAlmostEqualTo(End))
+                {
+                    lines.Add(new Line(a, End));
+                }
             }
             return lines;
         }


### PR DESCRIPTION
BACKGROUND:
Lagarsoft ran into an exception when submitted a line to DivideByLength:
https://discordapp.com/channels/688033618303516701/688086821904580726/700051407235055686

DESCRIPTION:
Catches a situation where two points for a line fall within identical location tolerance.

TESTING:
Supply a line and diving length to leave a zero segment.

FUTURE WORK:
No.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/290)
<!-- Reviewable:end -->
