### PR TITLE
add profile union method and tests

### DIFF
--- a/src/Elements/Geometry/Profile.cs
+++ b/src/Elements/Geometry/Profile.cs
@@ -67,7 +67,6 @@ namespace Elements.Geometry
             var voids = indices.Except(outerMostIndices).Select(i => polygons[i]);
             this.Perimeter = perimeter;
             this.Voids = voids.ToList();
-
         }
 
         /// <summary>
@@ -122,6 +121,7 @@ namespace Elements.Geometry
                 this.Voids[i].Transform(t);
             }
         }
+
         /// <summary>
         /// Return a new profile that is this profile scaled about the origin by the desired amount.
         /// </summary>
@@ -155,7 +155,6 @@ namespace Elements.Geometry
             clipper.Execute(ClipType.ctUnion, solution);
             return new Profile(solution.Select(s => s.ToPolygon()).ToList());
         }
-
 
         /// <summary>
         /// Default constructor for profile.
@@ -288,6 +287,5 @@ namespace Elements.Geometry
             }
             return Polygon.Contains(allLines, point, out containment);
         }
-
     }
 }

--- a/src/Elements/Geometry/Profile.cs
+++ b/src/Elements/Geometry/Profile.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ClipperLib;
 
 namespace Elements.Geometry
 {
@@ -57,7 +58,7 @@ namespace Elements.Geometry
             {
                 throw new ArgumentException("Unable to construct a profile. More than one of the polygons supplied are not contained by any other.");
             }
-            if(outerMostIndices.Count() == 0)
+            if (outerMostIndices.Count() == 0)
             {
                 throw new ArgumentException("Unable to construct a profile. All the supplied polygons are inside other supplied polygons. Sounds like a geometric paradox!");
             }
@@ -131,6 +132,30 @@ namespace Elements.Geometry
 
             return transform.OfProfile(this);
         }
+
+        /// <summary>
+        /// Perform a union operation, returning a new profile that is the union of the current profile with the other profile
+        /// <param name="profile">The profile with which to create a union.</param>
+        /// </summary>
+        public Profile Union(Profile profile)
+        {
+            var clipper = new ClipperLib.Clipper();
+            clipper.AddPath(this.Perimeter.ToClipperPath(), PolyType.ptSubject, true);
+            clipper.AddPath(profile.Perimeter.ToClipperPath(), PolyType.ptClip, true);
+
+            if (this.Voids != null && this.Voids.Count > 0)
+            {
+                clipper.AddPaths(this.Voids.Select(v => v.ToClipperPath()).ToList(), PolyType.ptSubject, true);
+            }
+            if (profile.Voids != null && profile.Voids.Count > 0)
+            {
+                clipper.AddPaths(profile.Voids.Select(v => v.ToClipperPath()).ToList(), PolyType.ptClip, true);
+            }
+            var solution = new List<List<ClipperLib.IntPoint>>();
+            clipper.Execute(ClipType.ctUnion, solution);
+            return new Profile(solution[0].ToPolygon(), solution.Skip(1).Select(s => s.ToPolygon()).ToList(), Guid.NewGuid(), "");
+        }
+
 
         /// <summary>
         /// Default constructor for profile.

--- a/src/Elements/Geometry/Profile.cs
+++ b/src/Elements/Geometry/Profile.cs
@@ -153,7 +153,7 @@ namespace Elements.Geometry
             }
             var solution = new List<List<ClipperLib.IntPoint>>();
             clipper.Execute(ClipType.ctUnion, solution);
-            return new Profile(solution[0].ToPolygon(), solution.Skip(1).Select(s => s.ToPolygon()).ToList(), Guid.NewGuid(), "");
+            return new Profile(solution.Select(s => s.ToPolygon()).ToList());
         }
 
 

--- a/test/Elements.Tests/ProfileTests.cs
+++ b/test/Elements.Tests/ProfileTests.cs
@@ -16,15 +16,18 @@ namespace Elements.Geometry.Tests
             // small grid of rough circles is unioned
             // 2x3 grid shoud produce 2 openings
             var circle = Polygon.Circle(3, 4);
-            var seed = new Profile(circle);
-            var originals = new List<Profile> { seed };
+            var smallCircle = Polygon.Circle(1, 4);
+
+            var seed = new Profile(circle, new List<Polygon> { smallCircle }, Guid.NewGuid(), "");
             for (int i = 0; i < 3; i++)
             {
                 for (int j = 0; j < 2; j++)
                 {
                     Transform t = new Transform(5 * i, 5 * j, 0);
-                    var newCircle = new Profile(new Polygon(circle.Vertices.Select(v => t.OfPoint(v)).ToArray()));
-                    originals.Add(newCircle);
+                    var newCircle = new Profile(new Polygon(circle.Vertices.Select(v => t.OfPoint(v)).ToArray()),
+                                                new List<Polygon> { new Polygon(smallCircle.Vertices.Select(v => t.OfPoint(v)).ToArray()) },
+                                                Guid.NewGuid(),
+                                                "");
 
                     seed = seed.Union(newCircle);
 
@@ -34,26 +37,7 @@ namespace Elements.Geometry.Tests
             var floor = new Floor(seed, 1);
             this.Model.AddElement(floor);
 
-            Assert.Equal(2, seed.Voids.Count());
-        }
-
-        [Fact]
-        public void ProfileUnion()
-        {
-            this.Name = "ProfileUnion";
-            var largeCirc = Polygon.Circle(3, 4);
-            var smallCirc = Polygon.Circle(1, 4);
-            var firstProfile = new Profile(largeCirc, new List<Polygon> { smallCirc }, Guid.NewGuid(), "");
-
-            var transform = new Transform(new Vector3(4.5, 0, 0));
-            var secondProfile = transform.OfProfile(firstProfile);
-
-            var unionProfile = firstProfile.Union(secondProfile);
-
-            var floor = new Floor(unionProfile, 1);
-            this.Model.AddElement(floor);
-
-            Assert.Equal(2, unionProfile.Voids.Count());
+            Assert.Equal(8, seed.Voids.Count());
         }
     }
 }

--- a/test/Elements.Tests/ProfileTests.cs
+++ b/test/Elements.Tests/ProfileTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using Xunit;
-using Elements.Serialization.glTF;
 using System.Collections.Generic;
 using Elements.Tests;
 

--- a/test/Elements.Tests/ProfileTests.cs
+++ b/test/Elements.Tests/ProfileTests.cs
@@ -36,6 +36,7 @@ namespace Elements.Geometry.Tests
 
             Assert.Equal(2, seed.Voids.Count());
         }
+
         [Fact]
         public void ProfileUnion()
         {

--- a/test/Elements.Tests/ProfileTests.cs
+++ b/test/Elements.Tests/ProfileTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Linq;
+using Xunit;
+using Elements.Serialization.glTF;
+using System.Collections.Generic;
+using Elements.Tests;
+
+namespace Elements.Geometry.Tests
+{
+    public class ProfileTests : ModelTest
+    {
+        [Fact]
+        public void ProfileMultipleUnion()
+        {
+            this.Name = "MultipleProfileUnion";
+            // small grid of rough circles is unioned
+            // 2x3 grid shoud produce 2 openings
+            var circle = Polygon.Circle(3, 4);
+            var seed = new Profile(circle);
+            var originals = new List<Profile> { seed };
+            for (int i = 0; i < 3; i++)
+            {
+                for (int j = 0; j < 2; j++)
+                {
+                    Transform t = new Transform(5 * i, 5 * j, 0);
+                    var newCircle = new Profile(new Polygon(circle.Vertices.Select(v => t.OfPoint(v)).ToArray()));
+                    originals.Add(newCircle);
+
+                    seed = seed.Union(newCircle);
+
+                    if (seed == null) throw new Exception("Making union failed");
+                }
+            }
+            var floor = new Floor(seed, 1);
+            this.Model.AddElement(floor);
+
+            Assert.Equal(2, seed.Voids.Count());
+        }
+        [Fact]
+        public void ProfileUnion()
+        {
+            this.Name = "ProfileUnion";
+            var largeCirc = Polygon.Circle(3, 4);
+            var smallCirc = Polygon.Circle(1, 4);
+            var firstProfile = new Profile(largeCirc, new List<Polygon> { smallCirc }, Guid.NewGuid(), "");
+
+            var transform = new Transform(new Vector3(4.5, 0, 0));
+            var secondProfile = transform.OfProfile(firstProfile);
+
+            var unionProfile = firstProfile.Union(secondProfile);
+
+            var floor = new Floor(unionProfile, 1);
+            this.Model.AddElement(floor);
+
+            Assert.Equal(2, unionProfile.Voids.Count());
+        }
+    }
+}


### PR DESCRIPTION
BACKGROUND:
- Lagarsoft and past Eric both had reason to union profiles

DESCRIPTION:
- Add a union profile method
- Add two tests, that ensure voids are created correctly when profiles are unioned.

TESTING:
- can run profile tests and view resulting glb for visual inspection
  
FUTURE WORK:
- There are other boolean operations that it might be nice to support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/292)
<!-- Reviewable:end -->
