### PR TITLE
Add test for #170 and convenience transform methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 ### Fixed
 - #271
 
+### Added
+- `Transform.Move(double x, double y, double z)`
+- `Transform.Rotate(double angle)`
+
 ## 0.6.2
 ### Added
 - `Material.Unlit`

--- a/src/Elements/Geometry/Transform.cs
+++ b/src/Elements/Geometry/Transform.cs
@@ -43,13 +43,14 @@ namespace Elements.Geometry
         {
             this.Matrix = new Matrix();
         }
-        
+
         /// <summary>
         /// Create a transform by copying another transform.
         /// </summary>
         /// <param name="t">The transform to copy.</param>
-        public Transform(Transform t): 
-            this(new Matrix(new Vector3(t.XAxis), new Vector3(t.YAxis), new Vector3(t.ZAxis), new Vector3(t.Origin))){}
+        public Transform(Transform t) :
+            this(new Matrix(new Vector3(t.XAxis), new Vector3(t.YAxis), new Vector3(t.ZAxis), new Vector3(t.Origin)))
+        { }
 
         /// <summary>
         /// Create a transform with a translation.
@@ -89,22 +90,22 @@ namespace Elements.Geometry
             Vector3 x = Vector3.XAxis;
             Vector3 y = Vector3.YAxis;
 
-            if(!z.IsParallelTo(Vector3.ZAxis))
-            {   
+            if (!z.IsParallelTo(Vector3.ZAxis))
+            {
                 // Project up onto the ortho plane
                 var p = new Plane(origin, z);
                 var test = Vector3.ZAxis.Project(p);
                 x = test.Cross(z).Unitized();
-                y = x.Cross(z.Negate()).Unitized(); 
+                y = x.Cross(z.Negate()).Unitized();
             }
-            
+
             this.Matrix = new Matrix(x, y, z, Vector3.Origin);
             ApplyRotationAndTranslation(rotation, z, origin);
         }
 
         private void ApplyRotationAndTranslation(double rotation, Vector3 axis, Vector3 translation)
         {
-            if(rotation != 0.0)
+            if (rotation != 0.0)
             {
                 this.Rotate(axis, rotation);
             }
@@ -171,9 +172,9 @@ namespace Elements.Geometry
         {
             var m = new Matrix(this.XAxis, this.YAxis, this.ZAxis, this.Origin);
             return new Vector3(
-                vector.X*m.XAxis.X + vector.Y*YAxis.X + vector.Z*ZAxis.X + this.Origin.X,
-                vector.X*m.XAxis.Y + vector.Y*YAxis.Y + vector.Z*ZAxis.Y + this.Origin.Y,
-                vector.X*m.XAxis.Z + vector.Y*YAxis.Z + vector.Z*ZAxis.Z + this.Origin.Z
+                vector.X * m.XAxis.X + vector.Y * YAxis.X + vector.Z * ZAxis.X + this.Origin.X,
+                vector.X * m.XAxis.Y + vector.Y * YAxis.Y + vector.Z * ZAxis.Y + this.Origin.Y,
+                vector.X * m.XAxis.Z + vector.Y * YAxis.Z + vector.Z * ZAxis.Z + this.Origin.Z
             );
         }
 
@@ -201,7 +202,7 @@ namespace Elements.Geometry
         public Polygon[] OfPolygons(IList<Polygon> polygons)
         {
             var result = new Polygon[polygons.Count];
-            for(var i=0; i<polygons.Count; i++)
+            for (var i = 0; i < polygons.Count; i++)
             {
                 result[i] = OfPolygon(polygons[i]);
             }
@@ -259,7 +260,7 @@ namespace Elements.Geometry
         public Bezier OfBezier(Bezier bezier)
         {
             var newCtrlPoints = new List<Vector3>();
-            foreach(var vp in bezier.ControlPoints)
+            foreach (var vp in bezier.ControlPoints)
             {
                 newCtrlPoints.Add(OfPoint(vp));
             }
@@ -295,6 +296,17 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Apply a translation to the transform.
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <param name="z"></param>
+        public void Move(double x = 0.0, double y = 0.0, double z = 0.0)
+        {
+            Move(new Vector3(x, y, z));
+        }
+
+        /// <summary>
         /// Apply a rotation to the transform.
         /// </summary>
         /// <param name="axis">The axis of rotation.</param>
@@ -304,6 +316,15 @@ namespace Elements.Geometry
             var m = new Matrix();
             m.SetupRotate(axis, angle * (Math.PI / 180.0));
             this.Matrix = this.Matrix * m;
+        }
+
+        /// <summary>
+        /// Apply a rotation to the transform around the Z axis.
+        /// </summary>
+        /// <param name="angle">The angle of rotation in degrees.</param>
+        public void Rotate(double angle)
+        {
+            Rotate(Vector3.ZAxis, angle);
         }
 
         /// <summary>
@@ -367,7 +388,7 @@ namespace Elements.Geometry
         public void Scale(double factor, Vector3 origin)
         {
             Scale(factor);
-            Move(origin * (1-factor));
+            Move(origin * (1 - factor));
         }
 
         /// <summary>
@@ -392,7 +413,7 @@ namespace Elements.Geometry
         /// <returns>True if the two transforms are equal, otherwise false.</returns>
         public bool Equals(Transform other)
         {
-            if(other == null)
+            if (other == null)
             {
                 return false;
             }

--- a/src/Elements/Model.cs
+++ b/src/Elements/Model.cs
@@ -99,6 +99,18 @@ namespace Elements
         }
 
         /// <summary>
+        /// Add elements to the model.
+        /// </summary>
+        /// <param name="elements">The elements to add to the model.</param>
+        public void AddElements(params Element[] elements)
+        {
+            foreach (var e in elements)
+            {
+                AddElement(e);
+            }
+        }
+
+        /// <summary>
         /// Get an entity by id from the Model.
         /// </summary>
         /// <param name="id">The identifier of the element.</param>

--- a/test/Elements.Tests/ColumnTest.cs
+++ b/test/Elements.Tests/ColumnTest.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace Elements.Tests
 {
     public class ColumnTest : ModelTest
-    {        
+    {
         [Fact, Trait("Category", "Examples")]
         public void Example()
         {
@@ -20,6 +20,21 @@ namespace Elements.Tests
             // </example>
 
             this.Model.AddElement(column);
+        }
+
+        [Fact]
+        public void Transform()
+        {
+            this.Name = "ColumnTransform";
+            var profile = WideFlangeProfileServer.Instance.GetProfileByType(WideFlangeProfileType.W10x100);
+            var t = new Transform();
+            t.Rotate(45);
+            t.Move(2.0);
+            var column1 = new Column(Vector3.Origin, 3.0, profile, BuiltInMaterials.Steel);
+            var column2 = new Column(Vector3.Origin, 3.0, profile, BuiltInMaterials.Steel, t);
+            Assert.Equal(new Vector3(5, 5).Unitized(), column2.Transform.XAxis);
+            Assert.Equal(2.0, column2.Transform.Origin.X);
+            this.Model.AddElements(column1, column2);
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
See #170.

DESCRIPTION:
#170 was filed before we had done a big round of cleanup on our built in element constructors. The error there could not be reproduced. In writing a test to validate that this was no longer a problem, I added to convenience methods that make it easier to transform elements.

In the image below, the column on the left is created with a default transform and the column on the right is created with a transform including translation and rotation supplied in its constructor.
![image](https://user-images.githubusercontent.com/1139788/79491956-1e844280-7fd4-11ea-825f-bb57af388f3f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/293)
<!-- Reviewable:end -->
