### PR TITLE
Fix #151.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `Circle.ToPolygon(int divisions = 10)`
 - `Transform.Move(double x, double y, double z)`
 - `Transform.Rotate(double angle)`
+- `TypeGenerator.GenerateUserElementTypesFromUrisAsync(string[] uris, string outputBaseDir, bool isUserElement = false)`
 
 ### Deprecated
 - `Polygon.Circle(...)`

--- a/src/Elements/Generate/TypeGenerator.cs
+++ b/src/Elements/Generate/TypeGenerator.cs
@@ -229,7 +229,7 @@ namespace Elements.Generate
         /// <param name="outputBaseDir">The root directory into which generated files will be written.</param>
         public static async Task GenerateElementTypesAsync(string outputBaseDir)
         {
-            var typeNames = _hyparSchemas.Select(u => u.Split(new[] { "/" }, StringSplitOptions.RemoveEmptyEntries).Last().Replace(".json", "")).ToList();
+            var typeNames = _hyparSchemas.Select(u => GetTypeNameFromSchemaUri(u)).ToList();
 
             foreach (var uri in _hyparSchemas)
             {
@@ -251,7 +251,7 @@ namespace Elements.Generate
 
         private static string GetTypeNameFromSchemaUri(string uri)
         {
-            return uri.Split(new[] { "/" }, StringSplitOptions.RemoveEmptyEntries).Last().Replace(".json", "");
+            return Path.GetFileNameWithoutExtension(uri.Split(new[] { "/" }, StringSplitOptions.RemoveEmptyEntries).Last());
         }
 
         private static string GetFileNameFromTypeName(string typeName)

--- a/test/Elements.Tests/TypeGeneratorTests.cs
+++ b/test/Elements.Tests/TypeGeneratorTests.cs
@@ -10,6 +10,7 @@ using Elements.Geometry;
 using Elements.Geometry.Solids;
 using Elements.Properties;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Elements.Tests
 {
@@ -60,7 +61,7 @@ namespace Elements.Tests
 
     public class TypeGeneratorTests
     {
-        const string schema = @"{
+        const string beamSchema = @"{
     ""$id"": ""https://hypar.io/Schemas/Beam.json"",
     ""$schema"": ""http://json-schema.org/draft-07/schema#"",
     ""description"": ""A beam."",
@@ -81,6 +82,38 @@ namespace Elements.Tests
     },
     ""additionalProperties"": false
 }";
+
+        /// <summary>
+        /// The embeddedSchemaTest demonstrates a schema that has another 
+        /// schema that will be read at the same time specified for one of
+        /// its properties 
+        /// </summary>
+        const string embeddedSchemaTest = @"{
+    ""$id"": ""https://hypar.io/Schemas/Truss.json"",
+    ""$schema"": ""http://json-schema.org/draft-07/schema#"",
+    ""description"": ""A test of schema embedding."",
+    ""title"": ""EmbeddedSchemaTest"",
+    ""x-namespace"": ""Elements"",
+    ""type"": [""object"", ""null""],
+    ""allOf"": [{""$ref"": ""https://hypar.io/Schemas/GeometricElement.json""}],
+    ""required"": [""Panels""],
+    ""properties"": {
+        ""Panels"": {
+            ""type"": ""array"",
+            ""items"": {
+                ""$ref"": ""https://raw.githubusercontent.com/hypar-io/Schemas/master/FacadePanel.json""
+            }
+        }
+    },
+    ""additionalProperties"": false
+}";
+        private ITestOutputHelper output;
+
+        public TypeGeneratorTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
         // We've started ignoring these tests on mac because on 
         // Catalina we receive an System.Net.Http.CurlException : Login denied.
         [MultiFact(typeof(IgnoreOnMacFact), typeof(IgnoreOnTravisFact))]
@@ -88,7 +121,7 @@ namespace Elements.Tests
         {
             var tmpPath = Path.GetTempPath();
             var schemaPath = Path.Combine(tmpPath, "beam.json");
-            File.WriteAllText(schemaPath, schema);
+            File.WriteAllText(schemaPath, beamSchema);
             var relPath = Path.GetRelativePath(Assembly.GetExecutingAssembly().Location, schemaPath);
             await TypeGenerator.GenerateUserElementTypeFromUriAsync(relPath, tmpPath, true);
             var code = File.ReadAllText(Path.Combine(tmpPath, "beam.g.cs"));
@@ -124,6 +157,26 @@ namespace Elements.Tests
             var uris = new[]{"https://raw.githubusercontent.com/hypar-io/Schemas/master/ThisDoesn'tExist.json",
                                 "https://raw.githubusercontent.com/hypar-io/Schemas/master/Mullion.json"};
             await Assert.ThrowsAsync<Exception>(async () => await TypeGenerator.GenerateInMemoryAssemblyFromUrisAndLoadAsync(uris));
+        }
+
+        [Fact]
+        public async Task CodeGenerationOfTypeWithEmbeddedType()
+        {
+            var tmpPath = Path.Combine(Path.GetTempPath(), "HyparModels");
+            if (!Directory.Exists(tmpPath))
+            {
+                Directory.CreateDirectory(tmpPath);
+            }
+
+            var embeddedSchemaTestPath = Path.Combine(tmpPath, "embeddedSchemaTest.json");
+            var relEmbeddedSchemaTestPath = Path.GetRelativePath(Assembly.GetExecutingAssembly().Location, embeddedSchemaTestPath);
+            File.WriteAllText(embeddedSchemaTestPath, embeddedSchemaTest);
+
+            // Generate the truss type which contains the beam type
+            await TypeGenerator.GenerateUserElementTypesFromUrisAsync(new[] { relEmbeddedSchemaTestPath, "https://raw.githubusercontent.com/hypar-io/Schemas/master/FacadePanel.json" }, tmpPath, true);
+
+            // Ensure that there is only one beam.g.cs in the output.
+            Assert.Equal(2, Directory.GetFiles(tmpPath, "*.g.cs").Length);
         }
     }
 }

--- a/test/Elements.Tests/TypeGeneratorTests.cs
+++ b/test/Elements.Tests/TypeGeneratorTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Elements.Generate;
 using Elements.Geometry;
@@ -27,22 +26,6 @@ namespace Elements.Tests
         private static bool IsTravis()
         {
             return Environment.GetEnvironmentVariable("TRAVIS") != null;
-        }
-    }
-
-    public sealed class IgnoreOnMacFact : FactAttribute
-    {
-        public IgnoreOnMacFact()
-        {
-            if (IsMac())
-            {
-                Skip = "Ignore on mac.";
-            }
-        }
-
-        private static bool IsMac()
-        {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         }
     }
 
@@ -114,9 +97,7 @@ namespace Elements.Tests
             this.output = output;
         }
 
-        // We've started ignoring these tests on mac because on 
-        // Catalina we receive an System.Net.Http.CurlException : Login denied.
-        [MultiFact(typeof(IgnoreOnMacFact), typeof(IgnoreOnTravisFact))]
+        [MultiFact(typeof(IgnoreOnTravisFact))]
         public async Task GeneratesCodeFromSchema()
         {
             var tmpPath = Path.GetTempPath();
@@ -127,7 +108,7 @@ namespace Elements.Tests
             var code = File.ReadAllText(Path.Combine(tmpPath, "beam.g.cs"));
         }
 
-        [MultiFact(typeof(IgnoreOnMacFact), typeof(IgnoreOnTravisFact))]
+        [MultiFact(typeof(IgnoreOnTravisFact))]
         public async Task GeneratesInMemoryAssembly()
         {
             var uris = new[]{"https://raw.githubusercontent.com/hypar-io/Schemas/master/FacadeAnchor.json",
@@ -148,7 +129,7 @@ namespace Elements.Tests
             // Profile @profile, Line @centerLine, NumericProperty @length, Transform @transform, Material @material, Representation @representation, System.Guid @id, string @name
             var t = new Transform();
             var m = BuiltInMaterials.Steel;
-            var mullion = Activator.CreateInstance(mullionType, new object[] { profile, centerLine, new NumericProperty(0, NumericPropertyUnitType.Length), t, m, new Representation(new List<SolidOperation>()), Guid.NewGuid(), "Test Mullion" });
+            var mullion = Activator.CreateInstance(mullionType, new object[] { profile, centerLine, new NumericProperty(0, NumericPropertyUnitType.Length), t, m, new Representation(new List<SolidOperation>()), false, Guid.NewGuid(), "Test Mullion" });
         }
 
         [IgnoreOnTravisFact]


### PR DESCRIPTION
BACKGROUND:
See https://github.com/hypar-io/Hypar/issues/151.

DESCRIPTION:
This PR adds a new API `TypeGenerator.GenerateUserElementTypesFromUrisAsync(...)` which takes an array of uris from which to generate and generates a distinct list of types. Internally, this method loops over all the schemas, generating a class, and _not_ generating the embedded type for any types which are also in the list of schemas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/303)
<!-- Reviewable:end -->
