### PR TITLE
Change fixes to links.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## 0.7.0
 ### Fixed
-- #271
-- #284
-- #285
-- #265
-- #221
-- #229
+- [#271](https://github.com/hypar-io/Elements/issues/271)
+- [#284](https://github.com/hypar-io/Elements/issues/284)
+- [#285](https://github.com/hypar-io/Elements/issues/285)
+- [#265](https://github.com/hypar-io/Elements/issues/265)
+- [#221](https://github.com/hypar-io/Elements/issues/221)
+- [#229](https://github.com/hypar-io/Elements/issues/229)
+- [#189](https://github.com/hypar-io/Elements/issues/189)
 
 ### Added
 - `Curve.ToPolyline(int divisions = 10)`


### PR DESCRIPTION
The fixes were listed with the shorthand #xxx, which is typically turned into a link in issues and PRs, but is not for other markdown documents. Here we replace those shorthand with proper links.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/304)
<!-- Reviewable:end -->
