### PR TITLE
fix TrimTo in 3d

### DIFF
--- a/src/Elements/Geometry/Line.cs
+++ b/src/Elements/Geometry/Line.cs
@@ -131,6 +131,7 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="p">The plane.</param>
         /// <param name="result">The location of intersection.</param>
+        /// <param name="infinite">If true, line will be treated as infinite. (False by default)</param>
         /// <returns>True if the line intersects the plane, false if no intersection occurs.</returns>
         public bool Intersects(Plane p, out Vector3 result, bool infinite = false)
         {

--- a/src/Elements/Geometry/Line.cs
+++ b/src/Elements/Geometry/Line.cs
@@ -402,7 +402,7 @@ namespace Elements.Geometry
         /// Extend this line to the trimming curve.
         /// </summary>
         /// <param name="line">The curve to which to extend.</param>
-        /// <returns>A new line, or null if this line does not intersect the trimming line.</returns>
+        /// <returns>A new line, or null if these lines would never intersect if extended infinitely.</returns>
         public Line ExtendTo(Line line)
         {
             if (!Intersects(line, out var intersection, true))

--- a/src/Elements/Geometry/Plane.cs
+++ b/src/Elements/Geometry/Plane.cs
@@ -47,6 +47,32 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Find the closest point on this plane from a given sample point.
+        /// </summary>
+        /// <param name="point">The sample point.</param>
+        /// <returns>The closest point to the sample point on this plane.</returns>
+        public Vector3 ClosestPoint(Vector3 point)
+        {
+            var fromPointToOrigin = Origin - point;
+            var projectionVector = fromPointToOrigin.Dot(Normal) * Normal;
+            return point + projectionVector;
+            
+        }
+
+        /// <summary>
+        /// Find the signed distance from a sample point to a plane.
+        /// If positive, the point is on the "Normal" side of the plane,
+        /// otherwise it is on the opposite side. 
+        /// </summary>
+        /// <param name="point">The sample point.</param>
+        /// <returns>The signed distance between this plane and the sample point.</returns>
+        public double SignedDistanceTo(Vector3 point)
+        {
+            var fromOriginToPoint = point - Origin;
+            return fromOriginToPoint.Dot(Normal);
+        }
+
+        /// <summary>
         /// Is this plane equal to the provided plane?
         /// </summary>
         /// <param name="other">The plane to test.</param>

--- a/src/Elements/Geometry/Vector3.cs
+++ b/src/Elements/Geometry/Vector3.cs
@@ -103,12 +103,12 @@ namespace Elements.Geometry
         /// <exception>Thrown if any components of the vector are NaN or Infinity.</exception>
         public Vector3(double x, double y)
         {
-            if(Double.IsNaN(x) || Double.IsNaN(y))
+            if (Double.IsNaN(x) || Double.IsNaN(y))
             {
                 throw new ArgumentOutOfRangeException("The vector could not be created. One or more of the components was NaN.");
             }
 
-            if(Double.IsInfinity(x) || Double.IsInfinity(y))
+            if (Double.IsInfinity(x) || Double.IsInfinity(y))
             {
                 throw new ArgumentOutOfRangeException("The vector could not be created. One or more of the components was infinity.");
             }
@@ -514,6 +514,28 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Are the provided points along the same line?
+        /// </summary>
+        /// <param name="points"></param>
+        public static bool AreCollinear(this IList<Vector3> points)
+        {
+            if (points.Count < 3)
+            {
+                return true;
+            }
+            var testVector = (points[1] - points[0]).Unitized();
+            for (int i = 2; i < points.Count; i++)
+            {
+                var nextVector = (points[i] - points[i - 1]).Unitized();
+                if (Math.Abs(nextVector.Dot(testVector)) < (1 - Vector3.EPSILON))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
         /// Compute a transform with the origin at points[0], with
         /// an X axis along points[1]->points[0], and a normal
         /// computed using the vectors points[2]->points[1] and 
@@ -529,11 +551,11 @@ namespace Elements.Geometry
             // found that's not parallel to the first, you'll 
             // get a zero-length normal.
             Vector3 b = new Vector3();
-            for(var i=2; i<points.Count; i++)
+            for (var i = 2; i < points.Count; i++)
             {
                 b = (points[i] - points[1]).Unitized();
                 var dot = b.Dot(a);
-                if(dot > -1 && dot < 1)
+                if (dot > -1 && dot < 1)
                 {
                     // Console.WriteLine("Found valid second vector.");
                     break;

--- a/src/Elements/Geometry/Vector3.cs
+++ b/src/Elements/Geometry/Vector3.cs
@@ -519,6 +519,10 @@ namespace Elements.Geometry
         /// <param name="points"></param>
         public static bool AreCollinear(this IList<Vector3> points)
         {
+            if (points == null || points.Count == 0)
+            {
+                throw new ArgumentException("Cannot test collinearity of an empty list");
+            }
             if (points.Count < 3)
             {
                 return true;

--- a/test/Elements.Tests/LineTests.cs
+++ b/test/Elements.Tests/LineTests.cs
@@ -18,8 +18,8 @@ namespace Elements.Geometry.Tests
 
             // <example>
             var a = new Vector3();
-            var b = new Vector3(5,5,5);
-            var l = new Line(a,b);
+            var b = new Vector3(5, 5, 5);
+            var l = new Line(a, b);
             // </example>
 
             this.Model.AddElement(new ModelCurve(l));
@@ -30,24 +30,24 @@ namespace Elements.Geometry.Tests
         {
             var a = new Vector3();
             var b = new Vector3(1, 0);
-            var l = new Line(a,b);
+            var l = new Line(a, b);
             Assert.Equal(1.0, l.Length());
-            Assert.Equal(new Vector3(0.5,0), l.PointAt(0.5));
+            Assert.Equal(new Vector3(0.5, 0), l.PointAt(0.5));
         }
 
         [Fact]
         public void ZeroLength_ThrowsException()
         {
             var a = new Vector3();
-            Assert.Throws<ArgumentException>(()=>new Line(a,a));
+            Assert.Throws<ArgumentException>(() => new Line(a, a));
         }
 
         [Fact]
         public void Intersects()
         {
-            var line = new Line(Vector3.Origin, new Vector3(5.0,0,0));
-            var plane = new Plane(new Vector3(2.5,0,0), Vector3.XAxis);
-            if(line.Intersects(plane, out Vector3 result))
+            var line = new Line(Vector3.Origin, new Vector3(5.0, 0, 0));
+            var plane = new Plane(new Vector3(2.5, 0, 0), Vector3.XAxis);
+            if (line.Intersects(plane, out Vector3 result))
             {
                 Assert.True(result.Equals(plane.Origin));
             }
@@ -57,7 +57,7 @@ namespace Elements.Geometry.Tests
         public void LineParallelToPlaneDoesNotIntersect()
         {
             var line = new Line(Vector3.Origin, Vector3.ZAxis);
-            var plane = new Plane(new Vector3(5.1,0,0), Vector3.XAxis);
+            var plane = new Plane(new Vector3(5.1, 0, 0), Vector3.XAxis);
             Assert.False(line.Intersects(plane, out Vector3 result));
         }
 
@@ -72,7 +72,7 @@ namespace Elements.Geometry.Tests
         [Fact]
         public void LineInPlaneDoesNotIntersect()
         {
-            var line = new Line(Vector3.Origin, new Vector3(5,0,0));
+            var line = new Line(Vector3.Origin, new Vector3(5, 0, 0));
             var plane = new Plane(Vector3.Origin, Vector3.ZAxis);
             Assert.False(line.Intersects(plane, out Vector3 result));
         }
@@ -80,18 +80,18 @@ namespace Elements.Geometry.Tests
         [Fact]
         public void LineTooFarDoesNotIntersect()
         {
-            var line = new Line(Vector3.Origin, new Vector3(5.0,0,0));
-            var plane = new Plane(new Vector3(5.1,0,0), Vector3.XAxis);
+            var line = new Line(Vector3.Origin, new Vector3(5.0, 0, 0));
+            var plane = new Plane(new Vector3(5.1, 0, 0), Vector3.XAxis);
             Assert.False(line.Intersects(plane, out Vector3 result));
         }
 
         [Fact]
         public void IntersectsQuick()
         {
-            var l1 = new Line(Vector3.Origin, new Vector3(5,0,0));
-            var l2 = new Line(new Vector3(2.5, -2.5, 0), new Vector3(2.5,2.5,0));
-            var l3 = new Line(new Vector3(0,-1,0), new Vector3(5,-1,0));
-            var l4 = new Line(new Vector3(5,0,0), new Vector3(10,0,0));
+            var l1 = new Line(Vector3.Origin, new Vector3(5, 0, 0));
+            var l2 = new Line(new Vector3(2.5, -2.5, 0), new Vector3(2.5, 2.5, 0));
+            var l3 = new Line(new Vector3(0, -1, 0), new Vector3(5, -1, 0));
+            var l4 = new Line(new Vector3(5, 0, 0), new Vector3(10, 0, 0));
             Assert.True(l1.Intersects2D(l2));     // Intersecting.
             Assert.False(l1.Intersects2D(l3));    // Not intersecting.
             Assert.False(l1.Intersects2D(l4));    // Coincident.
@@ -100,19 +100,19 @@ namespace Elements.Geometry.Tests
         [Fact]
         public void DivideByCount()
         {
-            var l = new Line(Vector3.Origin, new Vector3(5,0));
+            var l = new Line(Vector3.Origin, new Vector3(5, 0));
             var segments = l.DivideByCount(5);
             var len = l.Length();
-            foreach(var s in segments)
+            foreach (var s in segments)
             {
-                Assert.Equal(s.Length(), len/6, 5);
+                Assert.Equal(s.Length(), len / 6, 5);
             }
         }
 
         [Fact]
         public void DivideByLength()
         {
-            var l = new Line(Vector3.Origin, new Vector3(5,0));
+            var l = new Line(Vector3.Origin, new Vector3(5, 0));
             var segments = l.DivideByLength(1.1, true);
             Assert.Equal(4, segments.Count);
 
@@ -124,7 +124,7 @@ namespace Elements.Geometry.Tests
         public void DivideByLengthFromCenter()
         {
             // 5 whole size panels.
-            var l = new Line(Vector3.Origin, new Vector3(5,0));
+            var l = new Line(Vector3.Origin, new Vector3(5, 0));
             var segments = l.DivideByLengthFromCenter(1);
             Assert.Equal(5, segments.Count);
 
@@ -141,8 +141,8 @@ namespace Elements.Geometry.Tests
         [Fact]
         public void Trim()
         {
-            var l1 = new Line(Vector3.Origin, new Vector3(5,0));
-            var l2 = new Line(new Vector3(4,-2), new Vector3(4, 2));
+            var l1 = new Line(Vector3.Origin, new Vector3(5, 0));
+            var l2 = new Line(new Vector3(4, -2), new Vector3(4, 2));
             var result = l1.TrimTo(l2);
             Assert.Equal(4, result.Length());
 
@@ -153,14 +153,25 @@ namespace Elements.Geometry.Tests
         [Fact]
         public void Extend()
         {
-            var l1 = new Line(Vector3.Origin, new Vector3(5,0));
-            var l2 = new Line(new Vector3(6,-2), new Vector3(6, 2));
+            var l1 = new Line(Vector3.Origin, new Vector3(5, 0));
+            var l2 = new Line(new Vector3(6, -2), new Vector3(6, 2));
             var result = l1.ExtendTo(l2);
             Assert.Equal(6, result.Length());
 
             l2 = new Line(new Vector3(-1, -2), new Vector3(-1, 2));
             result = l1.ExtendTo(l2);
             Assert.Equal(6, result.Length());
+        }
+
+        [Fact]
+        public void LineTrimToInYZ()
+        {
+            Line l1 = new Line(new Vector3(0, 0, 0), new Vector3(0, 0, 10));
+            Line l2 = new Line(new Vector3(0, 5, 2), new Vector3(0, -5, 2));
+
+            Line l3 = l1.TrimTo(l2);
+
+            Assert.NotNull(l3);
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- #307 

DESCRIPTION:
- In order to fix #307, a number of changes needed to be made:
  - Extend `Line.Intersects(Plane p)` to support infinite lines
  - Add a `Line.Intersects(Line l)` to support 3d line intersections
  - Edit `Line.TrimTo(line l)` to use the new Line.Intersects() method
  - Edit `Line.ExtendTo(line l)` to use the new Line.Intersects() method
  - Add `Plane.ClosestPoint(Vector3 p)`
  - Add `Plane.SignedDistanceTo(Vector3 p)`

TESTING:
- Run `LineTests.Extend` and `LineTests.LineTrimToInYZ`
  
FUTURE WORK:
- There are probably more concise ways to do 3d line/line intersection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/308)
<!-- Reviewable:end -->
