### PR TITLE
Multitargeting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: csharp
 solution: ./hypar.sln
 dist: trusty
 mono: none
-dotnet: 3.1.201
+dotnet: 3.1
+install:
+  - dotnet restore
 script:
   - dotnet build ./Elements.sln
   - dotnet test ./test/Elements.Tests/Elements.Tests.csproj

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 solution: ./hypar.sln
 dist: trusty
 mono: none
-dotnet: 2.1.502
+dotnet: 3.1.201
 script:
   - dotnet build ./Elements.sln
   - dotnet test ./test/Elements.Tests/Elements.Tests.csproj

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dotnet: 3.1
 install:
   - dotnet restore
 script:
-  - dotnet build ./Elements.sln
+  - dotnet build ./Elements.sln --framework=netcoreapp3.1
   - dotnet test ./test/Elements.Tests/Elements.Tests.csproj
 env:
   - TRAVIS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 solution: ./hypar.sln
-dist: trusty
+dist: xenial
 mono: none
 dotnet: 3.1
 install:

--- a/src/Elements/Elements.csproj
+++ b/src/Elements/Elements.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Hypar.Elements</AssemblyName>
     <PackageTitle>Hypar Elements</PackageTitle>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Elements/Elements.csproj
+++ b/src/Elements/Elements.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <AssemblyName>Hypar.Elements</AssemblyName>
     <PackageTitle>Hypar Elements</PackageTitle>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Elements/Elements.csproj
+++ b/src/Elements/Elements.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;netcoreapp3.1;</TargetFrameworks>
     <AssemblyName>Hypar.Elements</AssemblyName>
     <PackageTitle>Hypar Elements</PackageTitle>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Elements/Elements.csproj
+++ b/src/Elements/Elements.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <AssemblyName>Hypar.Elements</AssemblyName>
     <PackageTitle>Hypar Elements</PackageTitle>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Elements/Elements.csproj
+++ b/src/Elements/Elements.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;netcoreapp2.1</TargetFrameworks>
     <AssemblyName>Hypar.Elements</AssemblyName>
     <PackageTitle>Hypar Elements</PackageTitle>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Elements/Serialization/IFC/IFCElementExtensions.cs
+++ b/src/Elements/Serialization/IFC/IFCElementExtensions.cs
@@ -24,7 +24,7 @@ namespace Elements.Serialization.IFC
             IfcProductDefinitionShape shape = null;
             GeometricElement geoElement = null;
             Transform trans = null;
-            Guid id;
+            Guid id = default(Guid);
 
             if (e is ElementInstance)
             {

--- a/test/Elements.Tests/Elements.Tests.csproj
+++ b/test/Elements.Tests/Elements.Tests.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>Hypar.Elements.Tests</AssemblyName>
-    <TargetFrameworks>netstandard2.0; netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Elements</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Elements.Tests/Elements.Tests.csproj
+++ b/test/Elements.Tests/Elements.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>Hypar.Elements.Tests</AssemblyName>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Elements</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Elements.Tests/Elements.Tests.csproj
+++ b/test/Elements.Tests/Elements.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>Hypar.Elements.Tests</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>Elements</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Elements.Tests/Elements.Tests.csproj
+++ b/test/Elements.Tests/Elements.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>Hypar.Elements.Tests</AssemblyName>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0; netcoreapp3.1;net472</TargetFrameworks>
     <RootNamespace>Elements</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Elements\Elements.csproj" />
+    <ProjectReference Properties="TargetFramework=netstandard2.0" Include="..\..\src\Elements\Elements.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Elements.Tests/Elements.Tests.csproj
+++ b/test/Elements.Tests/Elements.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>Hypar.Elements.Tests</AssemblyName>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Elements</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
BACKGROUND:
- Picking back up #276
- In order to support the Grasshopper plug-in and other .NET Framework applications, Elements is expanded to target multiple frameworks

COMMENTS:
- Though the intention is to target only netstandard2.0 and net472, the project targets involve a few additional frameworks / framework changes:
**Elements.csproj** - netstandard2.0;net472;netcoreapp3.1;netcoreapp2.1
- without netcoreapp3.1 targeted in elements.csproj, the test project would not build on mac
- without netcoreapp2.1 targeted in elements.csproj, the test project would not build on windows.
**Elements.Tests.csproj** - netcoreapp3.1
- without this bump, I could not get the test project to build on mac. 

Long story short, I tried every combination under the sun, and this is the only configuration that would build AND test on both mac and windows. 

DESCRIPTION:
- sets up Elements to target multiple frameworks
- explicitly tells Elements.Tests which version of Elements to use
- fixes one minor bug that was throwing a build error 
- updates travis configuration to use dotnet 3.1

TESTING:
- Please do test this with your own build configuration to ensure it's compatible. If you have any errors at all, delete `bin` and `obj` from both the Elements and the Elements.Test project directories, and then rebuild. 
  
FUTURE WORK:
- Some functional changes are necessary to fold in the necessary changes to the .net framework build in order to get it to work with grasshopper
- currently only the netstandard build is tested — getting tests that run for framework will require additional work.  
- travis builds are currently failing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/317)
<!-- Reviewable:end -->
