### PR TITLE
Add a duplicate constructor for Grid1d and Grid2d

### DIFF
--- a/src/Elements/Spatial/Grid1d.cs
+++ b/src/Elements/Spatial/Grid1d.cs
@@ -651,6 +651,10 @@ namespace Elements.Spatial
         /// <returns>A list of all the bottom-level cells / child cells of this grid.</returns>
         public List<Grid1d> GetCells()
         {
+            if (IsSingleCell)
+            {
+                return new List<Grid1d> { this };
+            }
             List<Grid1d> resultCells = new List<Grid1d>();
             foreach (var cell in Cells)
             {

--- a/src/Elements/Spatial/Grid1d.cs
+++ b/src/Elements/Spatial/Grid1d.cs
@@ -239,6 +239,19 @@ namespace Elements.Spatial
         }
 
         /// <summary>
+        /// Split a cell at a list of relative positions measured from its domain start or end. 
+        /// </summary>
+        /// <param name="positions">The relative positions at which to split.</param>
+        /// <param name="fromEnd">If true, measure the position from the end rather than the start</param>
+        public void SplitAtOffsets(IEnumerable<double> positions, bool fromEnd = false)
+        {
+            foreach (var position in positions)
+            {
+                SplitAtOffset(position, fromEnd);
+            }
+        }
+
+        /// <summary>
         /// Split the grid at a list of fixed positions from the start or end
         /// </summary>
         /// <param name="positions">The lengths along the grid at which to split.</param>
@@ -694,7 +707,7 @@ namespace Elements.Spatial
 
         private void UpdateParent()
         {
-           this.parent?.ChildUpdated();
+            this.parent?.ChildUpdated();
         }
 
         #endregion

--- a/src/Elements/Spatial/Grid1d.cs
+++ b/src/Elements/Spatial/Grid1d.cs
@@ -64,6 +64,14 @@ namespace Elements.Spatial
 
         }
 
+        public Grid1d(Grid1d other) {
+            this.curve = other.curve;
+            this.curveDomain = other.curveDomain;
+            this.Domain = other.Domain;
+            this.Cells = other.Cells.Select(c => new Grid1d(c)).ToList();
+            this.Type = other.Type;
+        }
+
         /// <summary>
         /// Construct a 1D grid from a numerical domain. The geometry will be assumed to lie along the X axis.
         /// </summary>

--- a/src/Elements/Spatial/Grid1d.cs
+++ b/src/Elements/Spatial/Grid1d.cs
@@ -690,7 +690,7 @@ namespace Elements.Spatial
 
          private void UpdateParent()
         {
-           this.parent.ChildUpdated();
+           this.parent?.ChildUpdated();
         }
 
         #endregion

--- a/src/Elements/Spatial/Grid1d.cs
+++ b/src/Elements/Spatial/Grid1d.cs
@@ -71,11 +71,15 @@ namespace Elements.Spatial
         /// Construct a 1D Grid from another 1D Grid
         /// </summary>
         /// <param name="other"></param>
-        public Grid1d(Grid1d other) {
+        public Grid1d(Grid1d other)
+        {
             this.curve = other.curve;
             this.curveDomain = other.curveDomain;
             this.Domain = other.Domain;
-            this.Cells = other.Cells.Select(c => new Grid1d(c)).ToList();
+            if (other.Cells != null)
+            {
+                this.Cells = other.Cells.Select(c => new Grid1d(c)).ToList();
+            }
             this.Type = other.Type;
         }
 
@@ -278,7 +282,7 @@ namespace Elements.Spatial
         /// <param name="divisionMode">Whether to permit any size cell, or only larger or smaller cells by rounding up or down.</param>
         public void DivideByApproximateLength(double targetLength, EvenDivisionMode divisionMode = EvenDivisionMode.Nearest)
         {
-            if(targetLength <= Vector3.EPSILON)
+            if (targetLength <= Vector3.EPSILON)
             {
                 throw new ArgumentException($"Unable to divide. Target Length {targetLength} is too small.");
             }
@@ -417,7 +421,7 @@ namespace Elements.Spatial
         /// <param name="divisionMode">How to handle leftover/remainder length</param>
         public void DivideByPattern(IList<(string typeName, double length)> lengthPattern, PatternMode patternMode = PatternMode.Cycle, FixedDivisionMode divisionMode = FixedDivisionMode.RemainderAtEnd)
         {
-            if(lengthPattern.Any(p => p.length <= Vector3.EPSILON))
+            if (lengthPattern.Any(p => p.length <= Vector3.EPSILON))
             {
                 throw new ArgumentException("One or more of the pattern segments is too small.");
             }
@@ -473,7 +477,7 @@ namespace Elements.Spatial
 
         internal void SetParent(Grid2d grid2d)
         {
-           this.parent = grid2d;
+            this.parent = grid2d;
         }
 
 
@@ -605,7 +609,7 @@ namespace Elements.Spatial
 
         private List<double> DomainsToSequence(bool recursive = false)
         {
-            if(IsSingleCell)
+            if (IsSingleCell)
             {
                 return new List<double> { Domain.Min, Domain.Max };
             }
@@ -688,7 +692,7 @@ namespace Elements.Spatial
             return Domain.IsCloseToBoundary(pos);
         }
 
-         private void UpdateParent()
+        private void UpdateParent()
         {
            this.parent?.ChildUpdated();
         }

--- a/src/Elements/Spatial/Grid1d.cs
+++ b/src/Elements/Spatial/Grid1d.cs
@@ -64,6 +64,10 @@ namespace Elements.Spatial
 
         }
 
+        /// <summary>
+        /// Construct a 1D Grid from another 1D Grid
+        /// </summary>
+        /// <param name="other"></param>
         public Grid1d(Grid1d other) {
             this.curve = other.curve;
             this.curveDomain = other.curveDomain;

--- a/src/Elements/Spatial/Grid1d.cs
+++ b/src/Elements/Spatial/Grid1d.cs
@@ -51,6 +51,9 @@ namespace Elements.Spatial
         // domain back to the original curve.
         private Domain1d curveDomain;
 
+        // if this 1d grid is the axis of a 2d grid, this is where we store that reference. If not, it will be null
+        private Grid2d parent;
+
         #endregion
 
         #region Constructors
@@ -208,7 +211,7 @@ namespace Elements.Spatial
                     }
                 }
             }
-            OnTopLevelGridChange();
+            UpdateParent();
 
         }
 
@@ -264,7 +267,7 @@ namespace Elements.Spatial
 
             var newDomains = Domain.DivideByCount(n);
             Cells = new List<Grid1d>(newDomains.Select(d => new Grid1d(curve, d, curveDomain)));
-            OnTopLevelGridChange();
+            UpdateParent();
         }
 
         /// <summary>
@@ -468,6 +471,11 @@ namespace Elements.Spatial
 
         }
 
+        internal void SetParent(Grid2d grid2d)
+        {
+           this.parent = grid2d;
+        }
+
 
         /// <summary>
         /// Divide by a list of named lengths and an offset from start, used by the DivideByPattern function.
@@ -494,7 +502,7 @@ namespace Elements.Spatial
             // This is necessary because otherwise name changes don't propogate back to a parent 2d grid.
             // TODO: find a better system than this to manage 1d/2d synchronization — this one involves
             // a lot of unnecessary regeneration. 
-            OnTopLevelGridChange();
+            UpdateParent();
 
         }
 
@@ -680,31 +688,14 @@ namespace Elements.Spatial
             return Domain.IsCloseToBoundary(pos);
         }
 
-        #endregion
-
-        #region Events
-        /// <summary>
-        /// Handler for a grid event
-        /// </summary>
-        /// <param name="sender">The Grid1d that spawned this event</param>
-        /// <param name="e">Event args</param>
-        public delegate void Grid1dEventHandler(Grid1d sender, EventArgs e);
-
-
-        /// <summary>
-        /// Fired when the cells of this grid change
-        /// </summary>
-        public event Grid1dEventHandler TopLevelGridChange;
-
-        /// <summary>
-        /// Fired when the cells of this grid change
-        /// </summary>
-        protected virtual void OnTopLevelGridChange()
+         private void UpdateParent()
         {
-            Grid1dEventHandler handler = TopLevelGridChange;
-            handler?.Invoke(this, new EventArgs());
+           this.parent.ChildUpdated();
         }
+
         #endregion
+
+
 
     }
 

--- a/src/Elements/Spatial/Grid2d.cs
+++ b/src/Elements/Spatial/Grid2d.cs
@@ -78,9 +78,9 @@ namespace Elements.Spatial
         /// <param name="other"></param>
         public Grid2d(Grid2d other) {
             this.U = new Grid1d(other.U);
-            this.U.TopLevelGridChange += TopLevelGridChange;
+            this.U.SetParent(this);
             this.V = new Grid1d(other.V);
-            this.V.TopLevelGridChange += TopLevelGridChange;
+            this.V.SetParent(this);
             this.Type = other.Type;
             this.boundariesInGridSpace = other.boundariesInGridSpace;
         }
@@ -463,19 +463,23 @@ namespace Elements.Spatial
         private void InitializeUV(Domain1d uDomain, Domain1d vDomain)
         {
             U = new Grid1d(uDomain);
-            U.TopLevelGridChange += TopLevelGridChange;
+            U.SetParent(this);
             V = new Grid1d(vDomain);
-            V.TopLevelGridChange += TopLevelGridChange;
+            V.SetParent(this);
         }
 
         /// <summary>
-        /// Update the 2d grid cells of this grid when its U or V 1d cells change.
+        /// Get the base rectangle of this cell in grid coordinates.
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void TopLevelGridChange(Grid1d sender, EventArgs e)
+        /// <returns></returns>
+        private Polygon GetBaseRectangle()
         {
-            if (CellsFlat.Any(c => !c.IsSingleCell))
+            return Polygon.Rectangle(new Vector3(U.Domain.Min, V.Domain.Min), new Vector3(U.Domain.Max, V.Domain.Max));
+        }
+
+        internal void ChildUpdated()
+        {
+           if (CellsFlat.Any(c => !c.IsSingleCell))
             {
                 throw new Exception("You are trying to modify the U / V dimensions of a grid that already has subdivisions. This is not allowed.");
             }
@@ -511,15 +515,6 @@ namespace Elements.Spatial
                 }
                 Cells.Add(column);
             }
-        }
-
-        /// <summary>
-        /// Get the base rectangle of this cell in grid coordinates.
-        /// </summary>
-        /// <returns></returns>
-        private Polygon GetBaseRectangle()
-        {
-            return Polygon.Rectangle(new Vector3(U.Domain.Min, V.Domain.Min), new Vector3(U.Domain.Max, V.Domain.Max));
         }
 
         #endregion

--- a/src/Elements/Spatial/Grid2d.cs
+++ b/src/Elements/Spatial/Grid2d.cs
@@ -73,6 +73,19 @@ namespace Elements.Spatial
         }
 
         /// <summary>
+        /// Construct a Grid2d from another Grid2d
+        /// </summary>
+        /// <param name="other"></param>
+        public Grid2d(Grid2d other) {
+            this.U = new Grid1d(other.U);
+            this.U.TopLevelGridChange += TopLevelGridChange;
+            this.V = new Grid1d(other.V);
+            this.V.TopLevelGridChange += TopLevelGridChange;
+            this.Type = other.Type;
+            this.boundariesInGridSpace = other.boundariesInGridSpace;
+        }
+
+        /// <summary>
         /// Construct a 2d grid with two 1d domains
         /// </summary>
         /// <param name="uDomain">The domain along the U axis</param>


### PR DESCRIPTION
BACKGROUND:
- In order to support Grid functionality in grasshopper, it needs to be easy to make a deep copy of Grid types (so that changes to an object in a downstream component don't change the object upstream)

DESCRIPTION:
- Adds a Grid1d(Grid1d other) constructor
- Adds a Grid2d(Grid2d other) constructor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/318)
<!-- Reviewable:end -->
