### PR TITLE
Elements compatibility with Grasshopper library

### DIFF
--- a/src/Elements/Generate/TypeGenerator.cs
+++ b/src/Elements/Generate/TypeGenerator.cs
@@ -312,7 +312,7 @@ namespace Elements.Generate
         /// <summary>
         /// Get the currently loaded UserElement types
         /// </summary>
-        /// <param name="userElementTypesOnly">If true, only return types wit the UserElement attribute.</param>
+        /// <param name="userElementTypesOnly">If true, only return types with the UserElement attribute.</param>
         /// <returns>A list of the loaded types with the UserElement attribute.</returns>
         public static List<Type> GetLoadedElementTypes(bool userElementTypesOnly = false)
         {

--- a/src/Elements/Generate/TypeGenerator.cs
+++ b/src/Elements/Generate/TypeGenerator.cs
@@ -37,11 +37,11 @@ namespace Elements.Generate
     public struct GenerationResult
     {
         /// <summary>
-        /// True if the code was generated successfully
+        /// True if the code was generated successfully.
         /// </summary>
         public bool Success;
         /// <summary>
-        /// The file path to the generated code
+        /// The file path to the generated code.
         /// </summary>
         public string FilePath;
         /// <summary>

--- a/src/Elements/Generate/TypeGenerator.cs
+++ b/src/Elements/Generate/TypeGenerator.cs
@@ -12,18 +12,41 @@ using NJsonSchema.CodeGeneration.CSharp;
 
 namespace Elements.Generate
 {
-
+    /// <summary>
+    /// The result of a compilation.
+    /// </summary>
     public struct CompilationResult
     {
+        /// <summary>
+        /// True if the compilation succeeded.
+        /// </summary>
         public bool Success;
+        /// <summary>
+        /// The Assembly loaded from the compilation, if successful.
+        /// </summary>
         public Assembly Assembly;
+        /// <summary>
+        /// Any messages or errors that arose during compilation.
+        /// </summary>
         public string[] DiagnosticResults;
     }
 
+    /// <summary>
+    /// The result of code generation.
+    /// </summary>
     public struct GenerationResult
     {
+        /// <summary>
+        /// True if the code was generated successfully
+        /// </summary>
         public bool Success;
+        /// <summary>
+        /// The file path to the generated code
+        /// </summary>
         public string FilePath;
+        /// <summary>
+        /// Any messages or errors that arose during code generation.
+        /// </summary>
         public string[] DiagnosticResults;
     }
     class ElementsTypeNameGenerator : ITypeNameGenerator

--- a/src/Elements/Generate/TypeGenerator.cs
+++ b/src/Elements/Generate/TypeGenerator.cs
@@ -20,15 +20,14 @@ namespace Elements.Generate
         /// <summary>
         /// True if the compilation succeeded.
         /// </summary>
-        public bool Success;
-        /// <summary>
+        public bool Success { get; private set; }
         /// The Assembly loaded from the compilation, if successful.
         /// </summary>
-        public Assembly Assembly;
+        public Assembly Assembly { get; private set; }
         /// <summary>
         /// Any messages or errors that arose during compilation.
         /// </summary>
-        public string[] DiagnosticResults;
+        public string[] DiagnosticResults { get; private set; }
     }
 
     /// <summary>
@@ -39,15 +38,15 @@ namespace Elements.Generate
         /// <summary>
         /// True if the code was generated successfully.
         /// </summary>
-        public bool Success;
+        public bool Success { get; private set; }
         /// <summary>
         /// The file path to the generated code.
         /// </summary>
-        public string FilePath;
+        public string FilePath { get; private set; }
         /// <summary>
         /// Any messages or errors that arose during code generation.
         /// </summary>
-        public string[] DiagnosticResults;
+        public string[] DiagnosticResults { get; private set; }
     }
     class ElementsTypeNameGenerator : ITypeNameGenerator
     {

--- a/src/Elements/Generate/TypeGenerator.cs
+++ b/src/Elements/Generate/TypeGenerator.cs
@@ -70,6 +70,24 @@ namespace Elements.Generate
 
         private const string NAMESPACE_PROPERTY = "x-namespace";
         private static string[] _coreTypeNames;
+        private static string _templatesPath;
+
+        /// <summary>
+        /// The directory in which to find code templates. Some execution contexts require this to be overriden as the 
+        /// Executing Assembly is not necessarily in the same place as the templates (e.g. Headless Grasshopper Execution)
+        /// </summary>
+        public static string TemplatesPath
+        {
+            get
+            {
+                if (_templatesPath == null)
+                {
+                    _templatesPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "./Templates"));
+                }
+                return _templatesPath;
+            }
+            set => _templatesPath = value;
+        }
 
         /// <summary>
         /// Generate a user-defined type in a .g.cs file from a schema.
@@ -141,21 +159,11 @@ namespace Elements.Generate
                 try
                 {
                     var schema = await GetSchemaAsync(uri);
-
-                    string ns;
-                    if (!GetNamespace(schema, out ns))
+                    string csharp = GenerateCodeForSchema(schema);
+                    if (csharp == null)
                     {
-                        return null;
+                        continue;
                     }
-
-                    var typeName = schema.Title;
-                    if (_coreTypeNames == null)
-                    {
-                        _coreTypeNames = GetCoreTypeNames();
-                    }
-                    var localExcludes = _coreTypeNames.Where(n => n != typeName).ToArray();
-
-                    var csharp = WriteTypeFromSchema(schema, typeName, ns, true, localExcludes);
                     code.Add(csharp);
                 }
                 catch (Exception ex)
@@ -164,64 +172,10 @@ namespace Elements.Generate
                 }
             }
 
-            // Generate the assembly from the various code files.
-            var options = new CSharpParseOptions(LanguageVersion.CSharp7_3,
-                                                 kind: Microsoft.CodeAnalysis.SourceCodeKind.Regular,
-                                                 documentationMode: Microsoft.CodeAnalysis.DocumentationMode.Diagnose);
-            var syntaxTrees = new List<Microsoft.CodeAnalysis.SyntaxTree>();
-            foreach (var cs in code)
-            {
-                var tree = CSharpSyntaxTree.ParseText(cs, options);
-                syntaxTrees.Add(tree);
-
-            }
-
-            var assemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location);
-            var elementsAssemblyPath = Path.GetDirectoryName(typeof(Model).Assembly.Location);
-            var newtonSoftPath = Path.GetDirectoryName(typeof(JsonConverter).Assembly.Location);
-
-            IEnumerable<MetadataReference> defaultReferences = new[]
-            {
-                // MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "mscorlib.dll")),
-                // MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.dll")),
-                // MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Core.dll")),
-                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "netstandard.dll")),
-                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.ComponentModel.Annotations.dll")),
-                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Diagnostics.Tools.dll")),
-                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Runtime.dll")),
-                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Runtime.Serialization.Primitives.dll")),
-                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Private.CoreLib.dll")),
-                MetadataReference.CreateFromFile(Path.Combine(elementsAssemblyPath, "Hypar.Elements.dll")),
-                MetadataReference.CreateFromFile(Path.Combine(newtonSoftPath, "Newtonsoft.Json.dll"))
-            };
-
-            var compileOptions = new CSharpCompilationOptions(Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary,
-                                                              optimizationLevel: Microsoft.CodeAnalysis.OptimizationLevel.Release);
-            var compilation = CSharpCompilation.Create("UserElements",
-                                                       syntaxTrees,
-                                                       defaultReferences,
-                                                       compileOptions);
-
-            Assembly assembly = null;
-            using (var ms = new MemoryStream())
-            {
-                var emitResult = compilation.Emit(ms);
-                if (emitResult.Success)
-                {
-                    ms.Seek(0, SeekOrigin.Begin);
-                    assembly = Assembly.Load(ms.ToArray());
-                }
-                else
-                {
-                    foreach (var d in emitResult.Diagnostics)
-                    {
-                        Console.WriteLine(d.ToString());
-                    }
-                    throw new Exception("There was an error creating an assembly for the user defined types. See the console for more information.");
-                }
-            }
-            return assembly;
+            var compilation = GenerateCompilation(code);
+            return EmitAndLoad(compilation, out _);
         }
+
 
         /// <summary>
         /// Generate the core element types as .cs files to the specified output directory. 
@@ -259,6 +213,15 @@ namespace Elements.Generate
             return $"{typeName}.g.cs";
         }
 
+        /// <summary>
+        /// Get the Schema information for a given schema URI.
+        /// </summary>
+        /// <param name="uri">The web URL or file path to the schema JSON.</param>
+        public static JsonSchema GetSchema(string uri)
+        {
+            return Task.Run(() => GetSchemaAsync(uri)).Result;
+        }
+
         private static async Task<JsonSchema> GetSchemaAsync(string uri)
         {
             if (uri.StartsWith("http://") || uri.StartsWith("https://"))
@@ -290,7 +253,7 @@ namespace Elements.Generate
 
         private static string WriteTypeFromSchema(JsonSchema schema, string typeName, string ns, bool isUserElement = false, string[] excludedTypes = null)
         {
-            var templates = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "./Templates"));
+            var templates = TemplatesPath;
 
             var structTypes = new[] { "Color", "Vector3" };
 
@@ -344,6 +307,177 @@ namespace Elements.Generate
             Console.WriteLine($"Generating type {@ns}.{typeName} in {outPath}...");
             var type = WriteTypeFromSchema(schema, typeName, ns, isUserElement, excludedTypes);
             File.WriteAllText(outPath, type);
+        }
+
+        /// <summary>
+        /// Get the currently loaded UserElement types
+        /// </summary>
+        /// <returns>A list of the loaded types with the UserElement attribute.</returns>
+        public static List<Type> GetLoadedElementTypes()
+        {
+            List<Type> loadedTypes = new List<Type>();
+            var asms = AppDomain.CurrentDomain.GetAssemblies();
+            foreach (var asm in asms)
+            {
+                try
+                {
+                    var userTypes = asm.GetTypes().Where(t => t.GetCustomAttributes(typeof(UserElement), true).Length > 0);
+                    foreach (var ut in userTypes)
+                    {
+                        loadedTypes.Add(ut);
+                    }
+                }
+                catch
+                {
+                    continue;
+                }
+            }
+            return loadedTypes;
+        }
+
+        /// <summary>
+        /// For a given schema, generate code, compile an assembly, and write it to disk at the specified path.
+        /// </summary>
+        /// <param name="schema"></param>
+        /// <param name="dllPath"></param>
+        /// <param name="frameworkBuild"></param>
+        /// <returns></returns>
+        public static string GenerateAndSaveDllForSchema(JsonSchema schema, string dllPath, bool frameworkBuild = false)
+        {
+            var csharp = GenerateCodeForSchema(schema);
+            if (csharp == null)
+            {
+                return null;
+            }
+            var compilation = GenerateCompilation(new List<string> { csharp }, schema.Title, frameworkBuild);
+            var result = EmitAndSave(compilation, dllPath, out string[] diagnostics);
+            if (result == null)
+            {
+                foreach (var d in diagnostics)
+                {
+                    Console.WriteLine(d);
+                }
+                throw new Exception($"There was an error compiling the schema for {schema.Title}. Type generation will not continue.");
+            }
+            return result;
+        }
+
+        private static string GenerateCodeForSchema(JsonSchema schema)
+        {
+            string ns;
+            if (!GetNamespace(schema, out ns))
+            {
+                return null;
+            }
+
+            var typeName = schema.Title;
+            if (_coreTypeNames == null)
+            {
+                _coreTypeNames = GetCoreTypeNames();
+            }
+
+            var loadedTypes = GetLoadedElementTypes().Select(t => t.Name);
+            if (loadedTypes.Contains(typeName)) return null;
+            var localExcludes = _coreTypeNames.Where(n => n != typeName).ToArray();
+
+            return WriteTypeFromSchema(schema, typeName, ns, true, localExcludes);
+        }
+
+        private static CSharpCompilation GenerateCompilation(List<string> code, string compilationName = "UserElements", bool frameworkBuild = false)
+        {
+            // Generate the assembly from the various code files.
+            var options = new CSharpParseOptions(LanguageVersion.CSharp7_3,
+                                                 kind: Microsoft.CodeAnalysis.SourceCodeKind.Regular,
+                                                 documentationMode: Microsoft.CodeAnalysis.DocumentationMode.Diagnose);
+            var syntaxTrees = new List<Microsoft.CodeAnalysis.SyntaxTree>();
+            foreach (var cs in code)
+            {
+                var tree = CSharpSyntaxTree.ParseText(cs, options);
+                syntaxTrees.Add(tree);
+
+            }
+
+            var assemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location);
+            var elementsAssemblyPath = Path.GetDirectoryName(typeof(Model).Assembly.Location);
+            var newtonSoftPath = Path.GetDirectoryName(typeof(JsonConverter).Assembly.Location);
+
+            IEnumerable<MetadataReference> defaultReferences = new[]
+           {
+                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "netstandard.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.ComponentModel.Annotations.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Diagnostics.Tools.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Runtime.Serialization.Primitives.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(elementsAssemblyPath, "Hypar.Elements.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(newtonSoftPath, "Newtonsoft.Json.dll"))
+            };
+
+            // If we're building in a .net framework context, we need a different set of reference DLLs
+            if (frameworkBuild)
+            {
+                defaultReferences = defaultReferences.Union(new[]
+                {
+                    MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "mscorlib.dll")),
+                    MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.dll")),
+                    MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Core.dll")),
+                    MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Linq.dll")),
+                    MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.ObjectModel.dll")),
+                    MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Linq.Expressions.dll")),
+                    MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Runtime.Extensions.dll")),
+                    MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.ComponentModel.DataAnnotations.dll")),
+                });
+            }
+            else
+            {
+                defaultReferences = defaultReferences.Union(new[] { MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Private.CoreLib.dll")) });
+            }
+
+
+            var compileOptions = new CSharpCompilationOptions(Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary,
+                                                              optimizationLevel: Microsoft.CodeAnalysis.OptimizationLevel.Release);
+            return CSharpCompilation.Create(compilationName,
+                                                       syntaxTrees,
+                                                       defaultReferences,
+                                                       compileOptions);
+        }
+
+        private static string EmitAndSave(CSharpCompilation compilation, string outputPath, out string[] diagnosticMessages)
+        {
+            var emitResult = compilation.Emit(outputPath);
+            diagnosticMessages = emitResult.Diagnostics.Select(d => d.ToString()).ToArray();
+            if (!emitResult.Success)
+            {
+                File.Delete(outputPath);
+                return null;
+            }
+            else
+            {
+                return outputPath;
+            }
+        }
+
+        private static Assembly EmitAndLoad(CSharpCompilation compilation, out string[] diagnosticMessages)
+        {
+            Assembly assembly = null;
+            using (var ms = new MemoryStream())
+            {
+                var emitResult = compilation.Emit(ms);
+                diagnosticMessages = emitResult.Diagnostics.Select(d => d.ToString()).ToArray();
+                if (emitResult.Success)
+                {
+                    ms.Seek(0, SeekOrigin.Begin);
+                    assembly = Assembly.Load(ms.ToArray());
+                }
+                else
+                {
+                    foreach (var d in emitResult.Diagnostics)
+                    {
+                        Console.WriteLine(d.ToString());
+                    }
+                    throw new Exception("There was an error creating an assembly for the user defined types. See the console for more information.");
+                }
+            }
+            return assembly;
         }
     }
 }

--- a/src/Elements/Generate/TypeGenerator.cs
+++ b/src/Elements/Generate/TypeGenerator.cs
@@ -20,14 +20,15 @@ namespace Elements.Generate
         /// <summary>
         /// True if the compilation succeeded.
         /// </summary>
-        public bool Success { get; private set; }
+        public bool Success { get; internal set; }
+        /// <summary>
         /// The Assembly loaded from the compilation, if successful.
         /// </summary>
-        public Assembly Assembly { get; private set; }
+        public Assembly Assembly { get; internal set; }
         /// <summary>
         /// Any messages or errors that arose during compilation.
         /// </summary>
-        public string[] DiagnosticResults { get; private set; }
+        public string[] DiagnosticResults { get; internal set; }
     }
 
     /// <summary>
@@ -38,15 +39,15 @@ namespace Elements.Generate
         /// <summary>
         /// True if the code was generated successfully.
         /// </summary>
-        public bool Success { get; private set; }
+        public bool Success { get; internal set; }
         /// <summary>
         /// The file path to the generated code.
         /// </summary>
-        public string FilePath { get; private set; }
+        public string FilePath { get; internal set; }
         /// <summary>
         /// Any messages or errors that arose during code generation.
         /// </summary>
-        public string[] DiagnosticResults { get; private set; }
+        public string[] DiagnosticResults { get; internal set; }
     }
     class ElementsTypeNameGenerator : ITypeNameGenerator
     {

--- a/src/Elements/Serialization/IFC/IFCElementExtensions.cs
+++ b/src/Elements/Serialization/IFC/IFCElementExtensions.cs
@@ -24,7 +24,7 @@ namespace Elements.Serialization.IFC
             IfcProductDefinitionShape shape = null;
             GeometricElement geoElement = null;
             Transform trans = null;
-            Guid id;
+            Guid id = default(Guid);
 
             if (e is ElementInstance)
             {

--- a/src/Elements/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/src/Elements/Serialization/JSON/JsonInheritanceConverter.cs
@@ -20,7 +20,7 @@ namespace Elements.Serialization.JSON
         [System.ThreadStatic]
         private static bool _isWriting;
 
-        private Dictionary<string, Type> _typeCache;
+        private static Dictionary<string, Type> _typeCache;
 
         [System.ThreadStatic]
         private static Dictionary<Guid, Element> _elements;
@@ -49,7 +49,12 @@ namespace Elements.Serialization.JSON
             _typeCache = BuildUserElementTypeCache();
         }
 
-        private Dictionary<string, Type> BuildUserElementTypeCache()
+        public static void RefreshUserElementTypeCache()
+        {
+            _typeCache = BuildUserElementTypeCache();
+        }
+
+        private static Dictionary<string, Type> BuildUserElementTypeCache()
         {
             var typeCache = new Dictionary<string, Type>();
 

--- a/test/Elements.Tests/ModelTests.cs
+++ b/test/Elements.Tests/ModelTests.cs
@@ -96,9 +96,9 @@ namespace Elements.Tests
             };
 
             var asm = await TypeGenerator.GenerateInMemoryAssemblyFromUrisAndLoadAsync(schemas);
-            var facadePanelType = asm.GetType("Elements.FacadePanel");
+            var facadePanelType = asm.Assembly.GetType("Elements.FacadePanel");
             Assert.NotNull(facadePanelType);
-            var envelopeType = asm.GetType("Elements.Envelope");
+            var envelopeType = asm.Assembly.GetType("Elements.Envelope");
             Assert.NotNull(envelopeType);
             var model1 = JsonConvert.DeserializeObject<Model>(File.ReadAllText("../../../models/Merge/facade.json"));
             var count1 = model1.Elements.Count;

--- a/test/Elements.Tests/TypeGeneratorTests.cs
+++ b/test/Elements.Tests/TypeGeneratorTests.cs
@@ -114,8 +114,8 @@ namespace Elements.Tests
             var uris = new[]{"https://raw.githubusercontent.com/hypar-io/Schemas/master/FacadeAnchor.json",
                                 "https://raw.githubusercontent.com/hypar-io/Schemas/master/Mullion.json"};
             var asm = await TypeGenerator.GenerateInMemoryAssemblyFromUrisAndLoadAsync(uris);
-            var mullionType = asm.GetType("Test.Foo.Bar.Mullion");
-            var anchorType = asm.GetType("Test.Foo.Bar.FacadeAnchor");
+            var mullionType = asm.Assembly.GetType("Test.Foo.Bar.Mullion");
+            var anchorType = asm.Assembly.GetType("Test.Foo.Bar.FacadeAnchor");
             Assert.NotNull(mullionType);
             Assert.NotNull(anchorType);
             Assert.NotNull(mullionType.GetProperty("CenterLine"));

--- a/test/Elements.Tests/TypeGeneratorTests.cs
+++ b/test/Elements.Tests/TypeGeneratorTests.cs
@@ -133,11 +133,13 @@ namespace Elements.Tests
         }
 
         [IgnoreOnTravisFact]
-        public async Task ThrowsWithBadSchema()
+        public async Task FailsWithBadSchema()
         {
-            var uris = new[]{"https://raw.githubusercontent.com/hypar-io/Schemas/master/ThisDoesn'tExist.json",
+            var uris = new[]{"https://raw.githubusercontent.com/hypar-io/Schemas/master/ThisDoesntExist.json",
                                 "https://raw.githubusercontent.com/hypar-io/Schemas/master/Mullion.json"};
-            await Assert.ThrowsAsync<Exception>(async () => await TypeGenerator.GenerateInMemoryAssemblyFromUrisAndLoadAsync(uris));
+            var result = await TypeGenerator.GenerateInMemoryAssemblyFromUrisAndLoadAsync(uris);
+            Assert.False(result.Success);
+            Assert.NotEmpty(result.DiagnosticResults);
         }
 
         [Fact]


### PR DESCRIPTION
## BACKGROUND:
- After MUCH trial and error, I believe these to be the minimum changes necessary to bring the main Elements library up to speed with the modifications I made for the Grasshopper plug-in and Runner. 
- I have been running around since march trying various multi-targeting solutions — it appears these were not necessary, and the following changes are sufficient to get the library working with grasshopper.

## DESCRIPTION:
### JsonInheritanceConverter
- Makes the Type Cache on the `JsonInheritanceConverter` static, and exposes a public method to refresh it. In the grasshopper context, new types may have been dynamically loaded since the `JsonInheritanceConverter` was initialized, so it needs to be refreshed before deserializing a model.
### IFCElementExtensions
- Initializes the `id` variable before use. This was throwing errors back when I was trying to compile for .net framework, so I left it in out of pure superstition.
### TypeGenerator
- OK, this one's a doozy.
- Enables external overriding of the Templates path, as in GH's case the `Templates` folder is not in the same place as the executing assembly. 
- Exposes a public, synchronous method `GetSchema` to get a `JsonSchema` from uri (wrapping `GetSchemaAsync`)
- Refactors some of the internal processes of `GenerateInMemoryAssemblyFromUrisAndLoadAsync`:
    - `GenerateCodeFromSchema()` produces csharp from a schema, including generating the namespace, typename, and local excludes
    - `GenerateCompilation()` takes the csharp and compiles it, using a new optional flag `frameworkBuild` to designate whether it should load netstandard or net framework reference assemblies.  
    - `EmitAndLoad()` generates the assembly in memory and loads it into the app domain.
- Adds an `EmitAndSave()` method that generates the assembly and writes it to a .dll on disk
-  Adds a public `GenerateAndSaveDllForSchema()` method used by grasshopper that generates code from a schema, generates a compilation, and saves it to disk as a DLL.
-  Adds a public `GetLoadedElementTypes()` method used by grasshopper to list all the currently loaded element types. 
- 😅

## TESTING:
- I have tested that this builds, runs, and tests on mac, windows, and travis, and works with the Grasshopper plug-in as well as the remote Grasshopper Solver context. 
  
## FUTURE WORK:
- I hope I never have to look at any of this any again 😂

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/321)
<!-- Reviewable:end -->
