### PR TITLE
Transformed() methods for curve types

### DIFF
--- a/src/Elements/Geometry/Arc.cs
+++ b/src/Elements/Geometry/Arc.cs
@@ -193,5 +193,14 @@ namespace Elements.Geometry
             }
             return new Arc(this.Center, this.Radius, newStart, newEnd);
         }
+
+        /// <summary>
+        /// A transformed copy of this Arc.
+        /// </summary>
+        /// <param name="transform">The transform to apply.</param>
+        public override ICurve Transformed(Transform transform)
+        {
+            return new Arc(transform.OfPoint(Center), Radius, StartAngle, EndAngle);
+        }
     }
 }

--- a/src/Elements/Geometry/Arc.cs
+++ b/src/Elements/Geometry/Arc.cs
@@ -195,7 +195,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// A transformed copy of this Curve.
+        /// Construct a transformed copy of this Curve.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
         public override Curve Transformed(Transform transform)
@@ -204,7 +204,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// A transformed copy of this Arc.
+        /// Construct a transformed copy of this Arc.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
         public Arc TransformedArc(Transform transform)

--- a/src/Elements/Geometry/Arc.cs
+++ b/src/Elements/Geometry/Arc.cs
@@ -195,10 +195,19 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// A transformed copy of this Curve.
+        /// </summary>
+        /// <param name="transform">The transform to apply.</param>
+        public override Curve Transformed(Transform transform)
+        {
+            return TransformedArc(transform);
+        }
+
+        /// <summary>
         /// A transformed copy of this Arc.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
-        public override ICurve Transformed(Transform transform)
+        public Arc TransformedArc(Transform transform)
         {
             return new Arc(transform.OfPoint(Center), Radius, StartAngle, EndAngle);
         }

--- a/src/Elements/Geometry/Bezier.cs
+++ b/src/Elements/Geometry/Bezier.cs
@@ -1,3 +1,4 @@
+using Elements.Geometry.Interfaces;
 using System;
 using System.Collections.Generic;
 
@@ -255,6 +256,20 @@ namespace Elements.Geometry
                 vertices.Add(PointAt(i * 1.0 / _samples));
             }
             return vertices;
+        }
+
+        /// <summary>
+        /// A transformed copy of this Bezier.
+        /// </summary>
+        /// <param name="transform">The transform to apply.</param>
+        public override ICurve Transformed(Transform transform)
+        {
+            var newCtrlPoints = new List<Vector3>();
+            foreach (var vp in ControlPoints)
+            {
+                newCtrlPoints.Add(transform.OfPoint(vp));
+            }
+            return new Bezier(newCtrlPoints, this.FrameType);
         }
     }
 }

--- a/src/Elements/Geometry/Bezier.cs
+++ b/src/Elements/Geometry/Bezier.cs
@@ -262,7 +262,7 @@ namespace Elements.Geometry
         /// A transformed copy of this Bezier.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
-        public override ICurve Transformed(Transform transform)
+        public Bezier TransformedBezier(Transform transform)
         {
             var newCtrlPoints = new List<Vector3>();
             foreach (var vp in ControlPoints)
@@ -270,6 +270,15 @@ namespace Elements.Geometry
                 newCtrlPoints.Add(transform.OfPoint(vp));
             }
             return new Bezier(newCtrlPoints, this.FrameType);
+        }
+
+        /// <summary>
+        /// A transformed copy of this Curve.
+        /// </summary>
+        /// <param name="transform">The transform to apply.</param>
+        public override Curve Transformed(Transform transform)
+        {
+            return TransformedBezier(transform);
         }
     }
 }

--- a/src/Elements/Geometry/Bezier.cs
+++ b/src/Elements/Geometry/Bezier.cs
@@ -259,7 +259,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// A transformed copy of this Bezier.
+        /// Construct a transformed copy of this Bezier.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
         public Bezier TransformedBezier(Transform transform)
@@ -273,7 +273,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// A transformed copy of this Curve.
+        /// Construct a transformed copy of this Curve.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
         public override Curve Transformed(Transform transform)

--- a/src/Elements/Geometry/Curve.cs
+++ b/src/Elements/Geometry/Curve.cs
@@ -10,7 +10,7 @@ namespace Elements.Geometry
     [JsonInheritanceAttribute("Elements.Geometry.Polygon", typeof(Polygon))]
     [JsonInheritanceAttribute("Elements.Geometry.Bezier", typeof(Bezier))]
     [JsonInheritanceAttribute("Elements.Geometry.Circle", typeof(Circle))]
-    public abstract partial class Curve : ICurve
+    public abstract partial class Curve : ICurve, ITransformable<Curve>
     {
         /// <summary>
         /// The minimum chord length allowed for subdivision of the curve.
@@ -61,12 +61,6 @@ namespace Elements.Geometry
         /// <returns>A transform.</returns>
         public abstract Transform TransformAt(double u);
 
-        /// <summary>
-        /// A transformed copy of this curve.
-        /// </summary>
-        /// <param name="transform"></param>
-        /// <returns></returns>
-        public abstract ICurve Transformed(Transform transform); 
 
         /// <summary>
         /// Create a polyline through a set of points along the curve.
@@ -93,5 +87,11 @@ namespace Elements.Geometry
         /// A list of vertices used to render the curve.
         /// </summary>
         internal abstract IList<Vector3> RenderVertices();
+
+        /// <summary>
+        /// A transformed copy of this Curve.
+        /// </summary>
+        /// <param name="transform">The transform to apply.</param>
+        public abstract Curve Transformed(Transform transform);
     }
 }

--- a/src/Elements/Geometry/Curve.cs
+++ b/src/Elements/Geometry/Curve.cs
@@ -62,6 +62,13 @@ namespace Elements.Geometry
         public abstract Transform TransformAt(double u);
 
         /// <summary>
+        /// A transformed copy of this curve.
+        /// </summary>
+        /// <param name="transform"></param>
+        /// <returns></returns>
+        public abstract ICurve Transformed(Transform transform); 
+
+        /// <summary>
         /// Create a polyline through a set of points along the curve.
         /// </summary>
         /// <param name="divisions">The number of divisions of the curve.</param>

--- a/src/Elements/Geometry/Curve.cs
+++ b/src/Elements/Geometry/Curve.cs
@@ -89,7 +89,7 @@ namespace Elements.Geometry
         internal abstract IList<Vector3> RenderVertices();
 
         /// <summary>
-        /// A transformed copy of this Curve.
+        /// Construct a transformed copy of this Curve.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
         public abstract Curve Transformed(Transform transform);

--- a/src/Elements/Geometry/Interfaces/ICurve.cs
+++ b/src/Elements/Geometry/Interfaces/ICurve.cs
@@ -18,6 +18,12 @@ namespace Elements.Geometry.Interfaces
         Vector3 PointAt(double u);
 
         /// <summary>
+        /// Get a copy of this curve transformed by the supplied Transform.
+        /// </summary>
+        /// <param name="transform"></param>
+        ICurve Transformed(Transform transform);
+
+        /// <summary>
         /// Get the frame from the curve at parameter u.
         /// </summary>
         /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>

--- a/src/Elements/Geometry/Interfaces/ICurve.cs
+++ b/src/Elements/Geometry/Interfaces/ICurve.cs
@@ -18,12 +18,6 @@ namespace Elements.Geometry.Interfaces
         Vector3 PointAt(double u);
 
         /// <summary>
-        /// Get a copy of this curve transformed by the supplied Transform.
-        /// </summary>
-        /// <param name="transform"></param>
-        ICurve Transformed(Transform transform);
-
-        /// <summary>
         /// Get the frame from the curve at parameter u.
         /// </summary>
         /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>

--- a/src/Elements/Geometry/Interfaces/ITransformable.cs
+++ b/src/Elements/Geometry/Interfaces/ITransformable.cs
@@ -1,0 +1,17 @@
+﻿using System;
+namespace Elements.Geometry.Interfaces
+{
+    /// <summary>
+    /// An object that can return a transformed copy of itself 
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface ITransformable<T>
+    {
+        /// <summary>
+        /// Create a transformed copy of this ITransformable
+        /// </summary>
+        /// <param name="transform"></param>
+        /// <returns></returns>
+        T Transformed(Transform transform);
+    }
+}

--- a/src/Elements/Geometry/Interfaces/ITransformable.cs
+++ b/src/Elements/Geometry/Interfaces/ITransformable.cs
@@ -4,14 +4,14 @@ namespace Elements.Geometry.Interfaces
     /// <summary>
     /// An object that can return a transformed copy of itself 
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">The type of object to be transformed</typeparam>
     public interface ITransformable<T>
     {
         /// <summary>
         /// Create a transformed copy of this ITransformable
         /// </summary>
         /// <param name="transform"></param>
-        /// <returns></returns>
+        /// <returns>A transformed copy of the object</returns>
         T Transformed(Transform transform);
     }
 }

--- a/src/Elements/Geometry/Line.cs
+++ b/src/Elements/Geometry/Line.cs
@@ -78,10 +78,19 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// A transformed copy of this Curve.
+        /// </summary>
+        /// <param name="transform">The transform to apply.</param>
+        public override Curve Transformed(Transform transform)
+        {
+            return TransformedLine(transform);
+        }
+
+        /// <summary>
         /// A transformed copy of this Line.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
-        public override ICurve Transformed(Transform transform)
+        public Line TransformedLine(Transform transform)
         {
             return new Line(transform.OfPoint(this.Start), transform.OfPoint(this.End));
         }

--- a/src/Elements/Geometry/Line.cs
+++ b/src/Elements/Geometry/Line.cs
@@ -1,3 +1,4 @@
+using Elements.Geometry.Interfaces;
 using System;
 using System.Collections.Generic;
 
@@ -74,6 +75,15 @@ namespace Elements.Geometry
             }
             var offset = this.Length() * u;
             return this.Start + offset * this.Direction();
+        }
+
+        /// <summary>
+        /// A transformed copy of this Line.
+        /// </summary>
+        /// <param name="transform">The transform to apply.</param>
+        public override ICurve Transformed(Transform transform)
+        {
+            return new Line(transform.OfPoint(this.Start), transform.OfPoint(this.End));
         }
 
         /// <summary>

--- a/src/Elements/Geometry/Line.cs
+++ b/src/Elements/Geometry/Line.cs
@@ -78,7 +78,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// A transformed copy of this Curve.
+        /// Construct a transformed copy of this Curve.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
         public override Curve Transformed(Transform transform)
@@ -87,7 +87,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// A transformed copy of this Line.
+        /// Construct a transformed copy of this Line.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
         public Line TransformedLine(Transform transform)

--- a/src/Elements/Geometry/Polygon.cs
+++ b/src/Elements/Geometry/Polygon.cs
@@ -43,7 +43,7 @@ namespace Elements.Geometry
         /// A transformed copy of this Polygon.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
-        public override ICurve Transformed(Transform transform)
+        public Polygon TransformedPolygon(Transform transform)
         {
             var transformed = new Vector3[this.Vertices.Count];
             for (var i = 0; i < transformed.Length; i++)
@@ -52,6 +52,15 @@ namespace Elements.Geometry
             }
             var p = new Polygon(transformed);
             return p;
+        }
+
+        /// <summary>
+        /// A transformed copy of this Curve.
+        /// </summary>
+        /// <param name="transform">The transform to apply.</param>
+        public override Curve Transformed(Transform transform)
+        {
+            return TransformedPolygon(transform);
         }
 
         /// <summary>

--- a/src/Elements/Geometry/Polygon.cs
+++ b/src/Elements/Geometry/Polygon.cs
@@ -40,7 +40,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// A transformed copy of this Polygon.
+        /// Construct a transformed copy of this Polygon.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
         public Polygon TransformedPolygon(Transform transform)
@@ -55,7 +55,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// A transformed copy of this Curve.
+        /// Construct a transformed copy of this Curve.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
         public override Curve Transformed(Transform transform)

--- a/src/Elements/Geometry/Polygon.cs
+++ b/src/Elements/Geometry/Polygon.cs
@@ -1,4 +1,5 @@
 using ClipperLib;
+using Elements.Geometry.Interfaces;
 using LibTessDotNet.Double;
 using System;
 using System.Collections.Generic;
@@ -36,6 +37,21 @@ namespace Elements.Geometry
                 normal.Z += (p0.X - p1.X) * (p0.Y + p1.Y);
             }
             return normal.Unitized();
+        }
+
+        /// <summary>
+        /// A transformed copy of this Polygon.
+        /// </summary>
+        /// <param name="transform">The transform to apply.</param>
+        public override ICurve Transformed(Transform transform)
+        {
+            var transformed = new Vector3[this.Vertices.Count];
+            for (var i = 0; i < transformed.Length; i++)
+            {
+                transformed[i] = transform.OfPoint(this.Vertices[i]);
+            }
+            var p = new Polygon(transformed);
+            return p;
         }
 
         /// <summary>

--- a/src/Elements/Geometry/Polyline.cs
+++ b/src/Elements/Geometry/Polyline.cs
@@ -157,6 +157,21 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// A transformed copy of this Polyline.
+        /// </summary>
+        /// <param name="transform">The transform to apply.</param>
+        public override ICurve Transformed(Transform transform)
+        {
+            var transformed = new Vector3[this.Vertices.Count];
+            for (var i = 0; i < transformed.Length; i++)
+            {
+                transformed[i] = transform.OfPoint(this.Vertices[i]);
+            }
+            var p = new Polyline(transformed);
+            return p;
+        }
+
+        /// <summary>
         /// Get the transforms used to transform a Profile extruded along this Polyline.
         /// </summary>
         /// <param name="startSetback"></param>
@@ -259,7 +274,7 @@ namespace Elements.Geometry
 
             foreach (var l in segments)
             {
-                segmentsTrans.Add(t.OfLine(l));
+                segmentsTrans.Add((Line)l.Transformed(t));
             };
 
             for (var i = 0; i < segmentsTrans.Count; i++)

--- a/src/Elements/Geometry/Polyline.cs
+++ b/src/Elements/Geometry/Polyline.cs
@@ -283,7 +283,7 @@ namespace Elements.Geometry
 
             foreach (var l in segments)
             {
-                segmentsTrans.Add((Line)l.Transformed(t));
+                segmentsTrans.Add(l.TransformedLine(t));
             };
 
             for (var i = 0; i < segmentsTrans.Count; i++)

--- a/src/Elements/Geometry/Polyline.cs
+++ b/src/Elements/Geometry/Polyline.cs
@@ -157,7 +157,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// A transformed copy of this Polyline.
+        /// Construct a transformed copy of this Polyline.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
         public Polyline TransformedPolyline(Transform transform)
@@ -172,7 +172,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// A transformed copy of this Curve.
+        /// Construct a transformed copy of this Curve.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
         public override Curve Transformed(Transform transform)

--- a/src/Elements/Geometry/Polyline.cs
+++ b/src/Elements/Geometry/Polyline.cs
@@ -160,7 +160,7 @@ namespace Elements.Geometry
         /// A transformed copy of this Polyline.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
-        public override ICurve Transformed(Transform transform)
+        public Polyline TransformedPolyline(Transform transform)
         {
             var transformed = new Vector3[this.Vertices.Count];
             for (var i = 0; i < transformed.Length; i++)
@@ -169,6 +169,15 @@ namespace Elements.Geometry
             }
             var p = new Polyline(transformed);
             return p;
+        }
+
+        /// <summary>
+        /// A transformed copy of this Curve.
+        /// </summary>
+        /// <param name="transform">The transform to apply.</param>
+        public override Curve Transformed(Transform transform)
+        {
+            return TransformedPolyline(transform);
         }
 
         /// <summary>

--- a/src/Elements/Geometry/Ray.cs
+++ b/src/Elements/Geometry/Ray.cs
@@ -171,7 +171,7 @@ namespace Elements.Geometry
                 {
                     curveList = curveList.Union(voids.SelectMany(v => v.Segments())); 
                 }
-                curveList = curveList.Select(l => (Line)l.Transformed(transformFromPolygon));
+                curveList = curveList.Select(l => l.TransformedLine(transformFromPolygon));
 
                 if (Polygon.Contains(curveList, transformedIntersection, out _))
                 {

--- a/src/Elements/Geometry/Ray.cs
+++ b/src/Elements/Geometry/Ray.cs
@@ -171,7 +171,7 @@ namespace Elements.Geometry
                 {
                     curveList = curveList.Union(voids.SelectMany(v => v.Segments())); 
                 }
-                curveList = curveList.Select(l => transformFromPolygon.OfLine(l));
+                curveList = curveList.Select(l => (Line)l.Transformed(transformFromPolygon));
 
                 if (Polygon.Contains(curveList, transformedIntersection, out _))
                 {

--- a/src/Elements/Geometry/Transform.cs
+++ b/src/Elements/Geometry/Transform.cs
@@ -185,7 +185,7 @@ namespace Elements.Geometry
         [Obsolete("Use Curve.Transformed(Transform) instead.")]
         public Curve OfCurve(Curve curve)
         {
-            return curve.Transformed(this) as Curve;
+            return curve.Transformed(this);
         }
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace Elements.Geometry
         [Obsolete("Use Polygon.Transformed(Transform) instead.")]
         public Polygon OfPolygon(Polygon polygon)
         {
-            return polygon.Transformed(this) as Polygon;
+            return polygon.TransformedPolygon(this);
         }
 
         /// <summary>
@@ -209,7 +209,7 @@ namespace Elements.Geometry
             var result = new Polygon[polygons.Count];
             for (var i = 0; i < polygons.Count; i++)
             {
-                result[i] = polygons[i].Transformed(this) as Polygon;
+                result[i] = polygons[i].TransformedPolygon(this);
             }
             return result;
         }
@@ -222,7 +222,7 @@ namespace Elements.Geometry
         [Obsolete("Use Line.Transformed(Transform) instead.")]
         public Line OfLine(Line line)
         {
-            return line.Transformed(this) as Line;
+            return line.TransformedLine(this);
         }
 
         /// <summary>
@@ -251,10 +251,10 @@ namespace Elements.Geometry
                 voids = new Polygon[profile.Voids.Count];
                 for (var i = 0; i < voids.Length; i++)
                 {
-                    voids[i] = profile.Voids[i].Transformed(this) as Polygon;
+                    voids[i] = profile.Voids[i].TransformedPolygon(this);
                 }
             }
-            var p = new Profile(profile.Perimeter.Transformed(this) as Polygon, voids, Guid.NewGuid(), null);
+            var p = new Profile(profile.Perimeter.TransformedPolygon(this), voids, Guid.NewGuid(), null);
             return p;
         }
 
@@ -266,7 +266,7 @@ namespace Elements.Geometry
         [Obsolete("Use Bezier.Transformed(Transform) instead.")]
         public Bezier OfBezier(Bezier bezier)
         {
-            return bezier.Transformed(this) as Bezier;
+            return bezier.TransformedBezier(this);
         }
 
         /// <summary>

--- a/src/Elements/Geometry/Transform.cs
+++ b/src/Elements/Geometry/Transform.cs
@@ -179,19 +179,24 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// A transformed copy of the supplied curve.
+        /// </summary>
+        /// <param name="curve">The curve to transform.</param>
+        [Obsolete("Use Curve.Transformed(Transform) instead.")]
+        public Curve OfCurve(Curve curve)
+        {
+            return curve.Transformed(this) as Curve;
+        }
+
+        /// <summary>
         /// Transform the specified polygon.
         /// </summary>
         /// <param name="polygon">The polygon to transform.</param>
         /// <returns>A new polygon transformed by this transform.</returns>
+        [Obsolete("Use Polygon.Transformed(Transform) instead.")]
         public Polygon OfPolygon(Polygon polygon)
         {
-            var transformed = new Vector3[polygon.Vertices.Count];
-            for (var i = 0; i < transformed.Length; i++)
-            {
-                transformed[i] = OfPoint(polygon.Vertices[i]);
-            }
-            var p = new Polygon(transformed);
-            return p;
+            return polygon.Transformed(this) as Polygon;
         }
 
         /// <summary>
@@ -204,7 +209,7 @@ namespace Elements.Geometry
             var result = new Polygon[polygons.Count];
             for (var i = 0; i < polygons.Count; i++)
             {
-                result[i] = OfPolygon(polygons[i]);
+                result[i] = polygons[i].Transformed(this) as Polygon;
             }
             return result;
         }
@@ -214,9 +219,10 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="line">The line to transform.</param>
         /// <returns>A new line transformed by this transform.</returns>
+        [Obsolete("Use Line.Transformed(Transform) instead.")]
         public Line OfLine(Line line)
         {
-            return new Line(OfPoint(line.Start), OfPoint(line.End));
+            return line.Transformed(this) as Line;
         }
 
         /// <summary>
@@ -245,10 +251,10 @@ namespace Elements.Geometry
                 voids = new Polygon[profile.Voids.Count];
                 for (var i = 0; i < voids.Length; i++)
                 {
-                    voids[i] = OfPolygon(profile.Voids[i]);
+                    voids[i] = profile.Voids[i].Transformed(this) as Polygon;
                 }
             }
-            var p = new Profile(OfPolygon(profile.Perimeter), voids, Guid.NewGuid(), null);
+            var p = new Profile(profile.Perimeter.Transformed(this) as Polygon, voids, Guid.NewGuid(), null);
             return p;
         }
 
@@ -257,14 +263,10 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="bezier">The bezier to transform.</param>
         /// <returns>A new bezier transformed by this transform.</returns>
+        [Obsolete("Use Bezier.Transformed(Transform) instead.")]
         public Bezier OfBezier(Bezier bezier)
         {
-            var newCtrlPoints = new List<Vector3>();
-            foreach (var vp in bezier.ControlPoints)
-            {
-                newCtrlPoints.Add(OfPoint(vp));
-            }
-            return new Bezier(newCtrlPoints);
+            return bezier.Transformed(this) as Bezier;
         }
 
         /// <summary>


### PR DESCRIPTION
BACKGROUND:
- Needed to be able to transform any curve, and wanted to avoid a switch statement cycling through the `Transform.OfXXXX` methods.

DESCRIPTION:
- Adds an `ICurve Transformed(Transform)` to `ICurve`
- Implements it as `public abstract` in `Curve`
- Moves the `Transform.OfXXXX`  code from `Transform` to each curve type's `Transformed()`  method, and leaves the old `OfXXXX` methods in place but just call the Transformed methods inside
- Adds additional transform methods for `Arc` and `Polyline`
- Marks the old `OfXXXX` methods as Obsolete

TESTING:
- Tested in GH context, passes all tests
  
FUTURE WORK:
- It's a little annoying that you have to cast the result back to the curve type. I couldn't figure any good way to do this. I think in RhinoCommon their `Duplicate` method has a similar problem, so they implement a `public Foo DuplicateFoo` for each type as well. Open to doing this right now (e.g. Arc.TransformedArc(transform))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/323)
<!-- Reviewable:end -->
