### PR TITLE
Vertex Constructor should respect supplied normal

### DIFF
--- a/src/Elements/Geometry/Mesh.cs
+++ b/src/Elements/Geometry/Mesh.cs
@@ -192,7 +192,7 @@ namespace Elements.Geometry
         public Vertex(Vector3 position, Vector3? normal = null, Color color = default(Color))
         {
             this.Position = position;
-            this.Normal = Vector3.Origin;
+            this.Normal = normal ?? Vector3.Origin;
             this.Color = color;
         }
     }


### PR DESCRIPTION
BACKGROUND:
- couldn't figure out why my normals from GH meshes weren't showing
- turns out they were just being ignored

DESCRIPTION:
- uses the supplied normal in the Vertex constructor if present

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/327)
<!-- Reviewable:end -->
