### PR TITLE
fix for computeNormals exception

### DIFF
--- a/src/Elements/Geometry/Mesh.cs
+++ b/src/Elements/Geometry/Mesh.cs
@@ -289,6 +289,11 @@ Triangles:{_triangles.Count}";
         {
             foreach (var v in this.Vertices)
             {
+                if(v.Triangles.Count == 0)
+                {
+                    v.Normal = default(Vector3);
+                    continue;
+                }
                 var avg = new Vector3();
                 foreach (var t in v.Triangles)
                 {


### PR DESCRIPTION
BACKGROUND:
- It is possible to construct a mesh including a vertex with no triangles. In this case, the ComputeNormals() method will throw an exception due to dividing by zero. 

DESCRIPTION:
- Adds a check for a vertex triangle count = 0, returning a 0 normal in that case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/328)
<!-- Reviewable:end -->
