### PR TITLE
trim line with polygon

### DIFF
--- a/src/Elements/Geometry/Line.cs
+++ b/src/Elements/Geometry/Line.cs
@@ -287,7 +287,6 @@ namespace Elements.Geometry
         /// <param name="point"></param>
         public bool PointOnLine(Vector3 point)
         {
-
             return (Start - point).Unitized().Dot((End - point).Unitized()) < (Vector3.EPSILON - 1);
         }
 
@@ -461,9 +460,7 @@ namespace Elements.Geometry
         public List<Line> Trim(Polygon polygon, out List<Line> outsideSegments)
         {
             // adapted from http://csharphelper.com/blog/2016/01/clip-a-line-segment-to-a-polygon-in-c/
-
-            // Make lists to hold points of
-            // intersection
+            // Make lists to hold points of intersection
             var intersections = new List<Vector3>();
 
             // Add the segment's starting point.
@@ -485,18 +482,15 @@ namespace Elements.Geometry
                 // See if the segment intersects the edge. 
                 if (segmentsIntersect)
                 {
-                    // See if we need to record this intersection.
-
                     // Record this intersection.
                     intersections.Add(intersection);
                 }
-                //see if the segment intersects at a vertex
+                // see if the segment intersects at a vertex
                 else if (this.PointOnLine(polygon.Vertices[i1]))
                 {
                     intersections.Add(polygon.Vertices[i1]);
                     hasVertexIntersections = true;
                 }
-
             }
 
             // Add the segment's ending point.
@@ -532,7 +526,6 @@ namespace Elements.Geometry
 
             outsideSegments = outSegments;
             return inSegments;
-
         }
 
         /// <summary>

--- a/src/Elements/Geometry/Line.cs
+++ b/src/Elements/Geometry/Line.cs
@@ -281,6 +281,10 @@ namespace Elements.Geometry
             return (this.End - this.Start).Unitized();
         }
 
+        /// <summary>
+        /// Test if a point lies within this line segment
+        /// </summary>
+        /// <param name="point"></param>
         public bool PointOnLine(Vector3 point)
         {
 
@@ -451,7 +455,7 @@ namespace Elements.Geometry
         /// <summary>
         /// Trim a line with a polygon. 
         /// </summary>
-        /// <param name="polygons"></param>
+        /// <param name="polygon">The polygon to trim with.</param>
         /// <param name="outsideSegments">A list of the segment(s) of the line outside of the supplied polygon.</param>
         /// <returns>A list of the segment(s) of the line within the supplied polygon.</returns>
         public List<Line> Trim(Polygon polygon, out List<Line> outsideSegments)

--- a/test/Elements.Tests/LineTests.cs
+++ b/test/Elements.Tests/LineTests.cs
@@ -183,7 +183,8 @@ namespace Elements.Geometry.Tests
             Line fullyOutside = new Line(new Vector3(8, 9, 0), new Vector3(7, 6, 0));
             Line startsInsideAndCrossesOnce = new Line(new Vector3(2, 2, 0), new Vector3(7, 4, 0));
             Line startsOutsideAndLandsOnEdge = new Line(new Vector3(-2, 4, 0), new Vector3(4, 5, 0));
-            Line crossesAtVertex = new Line(new Vector3(6,2,0), new Vector3(4,0));
+            Line crossesAtVertexStaysOutside = new Line(new Vector3(6, 2, 0), new Vector3(4, 0));
+            Line passesThroughAtVertex = new Line(new Vector3(6, 0, 0), new Vector3(4, 2, 0));
             var Polygon = new Polygon(new[]
             {
                 new Vector3(1,1,0),
@@ -207,9 +208,12 @@ namespace Elements.Geometry.Tests
             var i5 = startsOutsideAndLandsOnEdge.Trim(Polygon, out var o5);
             Assert.Equal(1, i5.Count);
             Assert.Equal(1, o5.Count);
-            var i6 = crossesAtVertex.Trim(Polygon, out var o6);
+            var i6 = crossesAtVertexStaysOutside.Trim(Polygon, out var o6);
             Assert.Equal(0, i6.Count);
-            Assert.Equal(1, o6.Count);
+            Assert.Equal(2, o6.Count);
+            var i7 = passesThroughAtVertex.Trim(Polygon, out var o7);
+            Assert.Equal(1, i7.Count);
+            Assert.Equal(1, o7.Count);
 
         }
     }

--- a/test/Elements.Tests/LineTests.cs
+++ b/test/Elements.Tests/LineTests.cs
@@ -173,5 +173,44 @@ namespace Elements.Geometry.Tests
 
             Assert.NotNull(l3);
         }
+
+
+        [Fact]
+        public void LineTrimWithPolygon()
+        {
+            Line startsOutsideAndCrossesTwice = new Line(new Vector3(0, 0, 0), new Vector3(5, 6, 0));
+            Line fullyInside = new Line(new Vector3(2, 2, 0), new Vector3(3, 3, 0));
+            Line fullyOutside = new Line(new Vector3(8, 9, 0), new Vector3(7, 6, 0));
+            Line startsInsideAndCrossesOnce = new Line(new Vector3(2, 2, 0), new Vector3(7, 4, 0));
+            Line startsOutsideAndLandsOnEdge = new Line(new Vector3(-2, 4, 0), new Vector3(4, 5, 0));
+            Line crossesAtVertex = new Line(new Vector3(6,2,0), new Vector3(4,0));
+            var Polygon = new Polygon(new[]
+            {
+                new Vector3(1,1,0),
+                new Vector3(5,1,0),
+                new Vector3(5,5,0),
+                new Vector3(1,5,0)
+            });
+
+            var i1 = startsOutsideAndCrossesTwice.Trim(Polygon, out var o1);
+            Assert.Equal(1, i1.Count);
+            Assert.Equal(2, o1.Count);
+            var i2 = fullyInside.Trim(Polygon, out var o2);
+            Assert.Equal(1, i2.Count);
+            Assert.Equal(0, o2.Count);
+            var i3 = fullyOutside.Trim(Polygon, out var o3);
+            Assert.Equal(0, i3.Count);
+            Assert.Equal(1, o3.Count);
+            var i4 = startsInsideAndCrossesOnce.Trim(Polygon, out var o4);
+            Assert.Equal(1, i4.Count);
+            Assert.Equal(1, o4.Count);
+            var i5 = startsOutsideAndLandsOnEdge.Trim(Polygon, out var o5);
+            Assert.Equal(1, i5.Count);
+            Assert.Equal(1, o5.Count);
+            var i6 = crossesAtVertex.Trim(Polygon, out var o6);
+            Assert.Equal(0, i6.Count);
+            Assert.Equal(1, o6.Count);
+
+        }
     }
 }

--- a/test/Elements.Tests/ProfileTests.cs
+++ b/test/Elements.Tests/ProfileTests.cs
@@ -18,6 +18,7 @@ namespace Elements.Tests
             profile.Voids.Add(Polygon.Rectangle(0.5, 0.5));
         }
 
+        [Fact]
         public void ProfileMultipleUnion()
         {
             this.Name = "MultipleProfileUnion";


### PR DESCRIPTION
BACKGROUND:
- Needed a trim method for lines

DESCRIPTION:
- Adds a `Line.Trim(Polygon)` method
- Fixes a bug with `Line.Intersects(Line)` where it would report a false positive for intersection. 
- Adds a `Line.PointOnLine(Vector3 point)` method

TESTING:
- Have added `LineTrimWithPolygon()` to LineTests, and verified that it does the right thing for lines starting inside a polygon, lines starting outside a polygon, lines fully inside or outside a polygon, lines that end along an edge of the polygon, and lines that cross the polygon at a vertex (both passing through at the vertex and grazing the vertex). 
  
FUTURE WORK:
- It would be nice to also have a Line.Trim(Profile) or Line.Trim(List<Polygon>) method that build on this one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/329)
<!-- Reviewable:end -->
