### PR TITLE
Line and vector

### DIFF
--- a/src/Elements/Geometry/Line.cs
+++ b/src/Elements/Geometry/Line.cs
@@ -166,7 +166,7 @@ namespace Elements.Geometry
             else if (infinite)
             {
                 var rayIntersectsBackwards = new Ray(End, Direction().Negate()).Intersects(p, out Vector3 location2, out double t2);
-                if(rayIntersectsBackwards)
+                if (rayIntersectsBackwards)
                 {
                     result = location2;
                     return true;
@@ -195,10 +195,11 @@ namespace Elements.Geometry
         /// Does this line intersect the provided line in 3D?
         /// </summary>
         /// <param name="l"></param>
-        /// <param name="infinite">Treat the lines as infinite?</param>
         /// <param name="result"></param>
+        /// <param name="infinite">Treat the lines as infinite?</param>
+        /// <param name="includeEnds">If the end of one line lies exactly on the other, count it as an intersection?</param>
         /// <returns>True if the lines intersect, false if they are fully collinear or do not intersect.</returns>
-        public bool Intersects(Line l, out Vector3 result, bool infinite = false)
+        public bool Intersects(Line l, out Vector3 result, bool infinite = false, bool includeEnds = false)
         {
             // check if two lines are parallel
             if (Direction().IsParallelTo(l.Direction()))

--- a/src/Elements/Geometry/Line.cs
+++ b/src/Elements/Geometry/Line.cs
@@ -237,11 +237,13 @@ namespace Elements.Geometry
             // construct a plane 
             var normal = l.Direction().Cross(plane.Normal);
             Plane intersectionPlane = new Plane(l.Start, normal);
-            if (Intersects(intersectionPlane, out Vector3 planeIntersectionResult, infinite))
+            if (Intersects(intersectionPlane, out Vector3 planeIntersectionResult, true)) // does the line intersect the plane? 
             {
-                result = planeIntersectionResult;
-
-                return true;
+                if (infinite || (l.PointOnLine(planeIntersectionResult, includeEnds) && PointOnLine(planeIntersectionResult, includeEnds)))
+                {
+                    result = planeIntersectionResult;
+                    return true;
+                }
 
             }
             result = default(Vector3);

--- a/src/Elements/Geometry/Line.cs
+++ b/src/Elements/Geometry/Line.cs
@@ -280,6 +280,20 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Test if a point lies within this line segment
+        /// </summary>
+        /// <param name="point">The point to test.</param>
+        /// <param name="includeEnds">Consider a point at the endpoint as on the line.</param>
+        public bool PointOnLine(Vector3 point, bool includeEnds = false)
+        {
+            if (includeEnds && (point.DistanceTo(Start) < Vector3.EPSILON || point.DistanceTo(End) < Vector3.EPSILON))
+            {
+                return true;
+            }
+            return (Start - point).Unitized().Dot((End - point).Unitized()) < (Vector3.EPSILON - 1);
+        }
+
+        /// <summary>
         /// Divide the line into as many segments of the provided length as possible.
         /// </summary>
         /// <param name="l">The length.</param>

--- a/src/Elements/Geometry/Vector3.cs
+++ b/src/Elements/Geometry/Vector3.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Elements.Geometry
 {
@@ -530,9 +531,24 @@ namespace Elements.Geometry
                 return true;
             }
             var testVector = (points[1] - points[0]).Unitized();
+            // in general this loop should not execute. This is just a check in case the first two points are
+            // coincident.
+            while (testVector.IsZero())
+            {
+                points.RemoveAt(0);
+                if (points.Count < 3)
+                {
+                    return true;
+                }
+                testVector = (points[1] - points[0]).Unitized();
+            }
             for (int i = 2; i < points.Count; i++)
             {
                 var nextVector = (points[i] - points[i - 1]).Unitized();
+                if (nextVector.IsZero())
+                {
+                    continue;
+                }
                 if (Math.Abs(nextVector.Dot(testVector)) < (1 - Vector3.EPSILON))
                 {
                     return false;

--- a/src/Elements/Geometry/Vector3.cs
+++ b/src/Elements/Geometry/Vector3.cs
@@ -533,7 +533,7 @@ namespace Elements.Geometry
             var testVector = (points[1] - points[0]).Unitized();
             // in general this loop should not execute. This is just a check in case the first two points are
             // coincident.
-            while (testVector.IsZero())
+            while (testVector.IsZero()) //loop until you find an initial vector that isn't zero-length
             {
                 points.RemoveAt(0);
                 if (points.Count < 3)
@@ -545,7 +545,7 @@ namespace Elements.Geometry
             for (int i = 2; i < points.Count; i++)
             {
                 var nextVector = (points[i] - points[i - 1]).Unitized();
-                if (nextVector.IsZero())
+                if (nextVector.IsZero()) // coincident points may be safely skipped
                 {
                     continue;
                 }

--- a/src/Elements/Geometry/Vector3.cs
+++ b/src/Elements/Geometry/Vector3.cs
@@ -463,6 +463,8 @@ namespace Elements.Geometry
             var dir = line.Direction();
             var v = this - line.Start;
             var d = v.Dot(dir);
+            d = Math.Min(line.Length(), d);
+            d = Math.Max(d, 0);
             return line.Start + dir * d;
         }
 


### PR DESCRIPTION
BACKGROUND:
- Building functionality for a client function, and encountered several limitations / bugs with Elements

DESCRIPTION:
- adds a flag on `Line.Intersects(Line)` to indicate whether intersections exactly at the ends should be considered. In some cases, this may be undesirable (e.g. find self-intersections in a polygon), while in others it is useful (e.g. split a line with other lines). 
- also adds this flag to `PointOnLine`, for the same reason.
- fix behavior of "infinite" mode on `Line.Intersects(Line)`
- fixes a bug where the `AreCollinear` method would return false for a set of collinear vertices if it contained duplicates
- `Vector3.ClosestPointOn(Line)` would return points that were not on the line, this is fixed. For infinite use cases we should add a similar method when we implement the planned Infinite Line class. 


TESTING:
- all tests passing
- have tested in use for unispace project

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/330)
<!-- Reviewable:end -->
