### PR TITLE
Check for IDictionary instead of IDictionary<string,object>

### DIFF
--- a/src/Elements/Model.cs
+++ b/src/Elements/Model.cs
@@ -266,12 +266,12 @@ namespace Elements
                 }
 
                 // Get the properties dictionaries.
-                var dict = pValue as IDictionary<string, object>;
+                var dict = pValue as IDictionary;
                 if (dict != null)
                 {
-                    foreach (var kvp in dict)
+                    foreach (var value in dict.Values)
                     {
-                        elements.AddRange(RecursiveGatherSubElements(kvp.Value));
+                        elements.AddRange(RecursiveGatherSubElements(value));
                     }
                     continue;
                 }


### PR DESCRIPTION
BACKGROUND:
- Elements types that have `Dictionary<string,double>` (or similar) properties in their schemas will throw exceptions on Hypar during serialization.
- This is because the dictionary "Check" was casting the incoming dictionary to `IDictionary<string, object>`, which will return null for an IDictionary of another type. 
- Then this property would fall through to recurse further, and fail on line 252 `var pValue = p.GetValue(obj, null);`

DESCRIPTION:
- Replace the cast check with one to IDictionary instead of IDictionary<string, object>
- iterate over dict.Values

TESTING:
- tested with [a schema that was failing](https://raw.githubusercontent.com/hypar-io/unispace/optimizationFunction/cellGeneration/OptimizedSpaceAssignment/OptimizationResults.json?token=AHTU2EYYDVXFFC4FW6VIS6K66D6Q6), now it works correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/333)
<!-- Reviewable:end -->
