### PR TITLE
set global flag to make templates threadsafe

### DIFF
--- a/src/Elements/Generate/TypeGenerator.cs
+++ b/src/Elements/Generate/TypeGenerator.cs
@@ -54,7 +54,7 @@ namespace Elements.Generate
         // TODO(Ian): This type name generator is only required because njsonschema
         // calls dependencies 'Json2', 'Json3', etc. We use their title to label
         // them and then they get excluded by that title. This is fragile because
-        // if a user gives their schema a title that is different than its id, 
+        // if a user gives their schema a title that is different than its id,
         // this will break. We need to figure out why njson schema has this bizarre
         // behavior. This behavior does not exist when the schemas are loaded
         // from disk, only when they are referenced by urls.
@@ -110,7 +110,7 @@ namespace Elements.Generate
         private static string _templatesPath;
 
         /// <summary>
-        /// The directory in which to find code templates. Some execution contexts require this to be overriden as the 
+        /// The directory in which to find code templates. Some execution contexts require this to be overriden as the
         /// Executing Assembly is not necessarily in the same place as the templates (e.g. Headless Grasshopper Execution)
         /// </summary>
         public static string TemplatesPath
@@ -133,7 +133,7 @@ namespace Elements.Generate
         /// <param name="outputBaseDir">The base output directory.</param>
         /// <param name="isUserElement">Is the type a user-defined element?</param>
         /// <returns>
-        /// A GenerationResult object containing info about the success or failure of generation, 
+        /// A GenerationResult object containing info about the success or failure of generation,
         /// the file path of the generated code, and any errors that may have occurred during generation.
         /// </returns>
         public static async Task<GenerationResult> GenerateUserElementTypeFromUriAsync(string uri, string outputBaseDir, bool isUserElement = false)
@@ -225,7 +225,7 @@ namespace Elements.Generate
 
 
         /// <summary>
-        /// Generate the core element types as .cs files to the specified output directory. 
+        /// Generate the core element types as .cs files to the specified output directory.
         /// </summary>
         /// <param name="outputBaseDir">The root directory into which generated files will be written.</param>
         public static async Task<GenerationResult[]> GenerateElementTypesAsync(string outputBaseDir)
@@ -241,7 +241,7 @@ namespace Elements.Generate
                     Directory.CreateDirectory(outDir);
                 }
 
-               tasks.Add(GenerateUserElementTypeFromUriAsync(uri, outDir));
+                tasks.Add(GenerateUserElementTypeFromUriAsync(uri, outDir));
             }
             var allResults = await Task.WhenAll(tasks);
             return allResults;
@@ -307,6 +307,7 @@ namespace Elements.Generate
             // base class SolidOperation, or the Import class.
             var solidOpTypes = new[] { "Extrude", "Sweep", "Lamina" };
 
+            DotLiquid.Template.DefaultIsThreadSafe = true;
             var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings()
             {
                 Namespace = ns,


### PR DESCRIPTION
BACKGROUND:
- code generation started to fail after a change to make it run async.  the failure was misplaced commas that were not consistent or correct in constructor args.  @ikeough  correctly identified that the template variable controlling comma placement were being shared across code generation threads.

DESCRIPTION:
- Turn on a flag for template thread safety in dotliquid.  this fix is documented here: https://github.com/dotliquid/dotliquid/pull/220 

TESTING:
- I ran hypar cli locally and this seems to get past the identified issue.  
  
FUTURE WORK:
- CLI needs to reference this change for it to be fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/334)
<!-- Reviewable:end -->
