### PR TITLE
use PropertyName not just name

### DIFF
--- a/src/Elements/Templates/Class.Constructor.Record.liquid
+++ b/src/Elements/Templates/Class.Constructor.Record.liquid
@@ -9,21 +9,21 @@
 {% assign sortedParentProperties = parentProperties | sort: "Name" -%}
 
 [Newtonsoft.Json.JsonConstructor]
-{% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}({% for property in AllProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%} {{ property.Type }} @{{ property.Name | lowercamelcase }}{% endfor -%})
+{% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}({% for property in AllProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%} {{ property.Type }} @{{ property.PropertyName | lowercamelcase }}{% endfor -%})
 {% assign skipComma = true -%}
 {% if HasInheritance -%}
-    : base({% for property in parentProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%}{{ property.Name | lowercamelcase }}{% endfor -%})
+    : base({% for property in parentProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%}{{ property.PropertyName | lowercamelcase }}{% endfor -%})
 {% endif -%}
 {
     var validator = Validator.Instance.GetFirstValidatorForType<{{ClassName}}>();
     if(validator != null)
     {
         {% assign skipComma = true -%}
-validator.PreConstruct(new object[]{ {% for property in AllProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%}@{{ property.Name | lowercamelcase }}{% endfor -%} });
+validator.PreConstruct(new object[]{ {% for property in AllProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%}@{{ property.PropertyName | lowercamelcase }}{% endfor -%} });
     }
 
 {% for property in Properties -%}
-    this.{{property.PropertyName}} = @{{property.Name | lowercamelcase}};
+    this.{{property.PropertyName}} = @{{ property.PropertyName | lowercamelcase }};
 {% endfor -%}
 
     if(validator != null)


### PR DESCRIPTION
BACKGROUND:
- code generation for generation C# class files from schemas was providing bad results when the properties had a space.

DESCRIPTION:
- change the constructor template to use PropertyNames rather than using just the name property.  PropertyName appears to be a cleaned up value, sans spaces

TESTING:
- This change combined with the ThreadSafety flag in a different PR allowed me to update and publish the JSON to Model function which generates code from a large number of schemas.
  
FUTURE WORK:
- We'll need to flex the CLI after these changes, before next release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/335)
<!-- Reviewable:end -->
