### PR TITLE
global template settings incl filters

### DIFF
--- a/src/Elements/Generate/TypeGenerator.cs
+++ b/src/Elements/Generate/TypeGenerator.cs
@@ -126,6 +126,7 @@ namespace Elements.Generate
             }
             set => _templatesPath = value;
         }
+
         // TODO Delete this HyparFilters class when this issue gets resolved. https://github.com/RicoSuter/NJsonSchema/issues/1199
         // This HyparFilters class contains filters that are copied directly from the NJsonSchema repo
         // because the filters are not public but we need to register them globally for async code gen.


### PR DESCRIPTION
BACKGROUND:
- async code generation requires a couple more changes

DESCRIPTION:
- move the thread safe setting up in the execution tree, we only need to set it once.  
- create and use the HyparFilters which is only necessary while the LiquidFilters class is marked internal see this Issue: https://github.com/RicoSuter/NJsonSchema/issues/1199 

TESTING:
- code gen for JSONtoModel seems to work great now, with the correct naming as well.
  
FUTURE WORK:
- We'll want to remove the duplicate code when that issue gets resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/337)
<!-- Reviewable:end -->
