### PR TITLE
Send gltf buffers to Revit DirectContext3D directly.

### DIFF
--- a/src/Revit/Hypar.Revit.sln
+++ b/src/Revit/Hypar.Revit.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hypar.Revit", "HyparRevit\Hypar.Revit.csproj", "{D503F6A2-9531-48C6-B775-ED2812F85EA5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D503F6A2-9531-48C6-B775-ED2812F85EA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D503F6A2-9531-48C6-B775-ED2812F85EA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D503F6A2-9531-48C6-B775-ED2812F85EA5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D503F6A2-9531-48C6-B775-ED2812F85EA5}.Debug|x64.Build.0 = Debug|Any CPU
+		{D503F6A2-9531-48C6-B775-ED2812F85EA5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D503F6A2-9531-48C6-B775-ED2812F85EA5}.Debug|x86.Build.0 = Debug|Any CPU
+		{D503F6A2-9531-48C6-B775-ED2812F85EA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D503F6A2-9531-48C6-B775-ED2812F85EA5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D503F6A2-9531-48C6-B775-ED2812F85EA5}.Release|x64.ActiveCfg = Release|Any CPU
+		{D503F6A2-9531-48C6-B775-ED2812F85EA5}.Release|x64.Build.0 = Release|Any CPU
+		{D503F6A2-9531-48C6-B775-ED2812F85EA5}.Release|x86.ActiveCfg = Release|Any CPU
+		{D503F6A2-9531-48C6-B775-ED2812F85EA5}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/Revit/HyparRevit/Hypar.Revit.csproj
+++ b/src/Revit/HyparRevit/Hypar.Revit.csproj
@@ -19,7 +19,7 @@
     <AddinFiles Include="$(TargetDir)publish\**\*"/>
   </ItemGroup>
 
-  <Target Name="CopyAddin" AfterTargets="AfterBuild">
+  <Target Name="CopyAddin" AfterTargets="Publish">
     <RemoveDir Directories="$(AppData)\Autodesk\Revit\Addins\2020\Hypar.Revit"/>
     <Message Importance="High" Text="Completed CopyAddin target."/>
     <Copy SourceFiles="Hypar.Revit.addin" DestinationFolder="$(AppData)\Autodesk\Revit\Addins\2020" />

--- a/src/Revit/HyparRevit/HyparHubApp.cs
+++ b/src/Revit/HyparRevit/HyparHubApp.cs
@@ -14,7 +14,6 @@ namespace Hypar.Revit
     {
         private static HubConnection _hyparConnection;
         private static Dictionary<string, WorkflowSettings> _settings;
-        private static bool _isFirstRun = true;
 
         public static HyparHubApp HyparApp { get; private set; }
         public static ILogger HyparLogger { get; private set; }
@@ -105,26 +104,6 @@ namespace Hypar.Revit
                     {
                         HyparLogger.Debug("The current Revit file, {RevitFileName} was not associated with the workflow settings. No sync will occur.", fileName);
                         return;
-                    }
-
-                    if (_isFirstRun)
-                    {
-                        try
-                        {
-                            var depPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".hypar", "workflows", workflow.Id, $"{workflow.Id}.dll");
-                            if (File.Exists(depPath))
-                            {
-                                HyparLogger.Information("Loading the dependencies assembly at {DepPath}.", depPath);
-                                var asmBytes = File.ReadAllBytes(depPath);
-                                var depAsm = AppDomain.CurrentDomain.Load(asmBytes);
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            HyparLogger.Debug(ex.Message);
-                            HyparLogger.Debug(ex.StackTrace);
-                        }
-                        _isFirstRun = false;
                     }
 
                     if (!CurrentWorkflows.ContainsKey(workflow.Id))


### PR DESCRIPTION
BACKGROUND:
In its initial release Hypar for Revit deserialized elements from models in the hub, then generated graphics from the geometry in those elements. This required building an assembly of the dependent types and loading it and created the restriction that we couldn't reload that assembly when a workflow was changed by adding or removing a function that used new types.

DESCRIPTION:
This PR removes element deserialization and reads geometry buffers directly from gltfs and into Revit buffers. This has the following benefits:
- It is faster. No assembly creation, loading, or deserialization of JSON models is required.
- It enables update of visualization when functions are added or removed from a workflow without stopping the hub and restarting Revit. The hub functionality to enable this will come in subsequent PR on the CLI.

TESTING:
- Load Hypar for Revit following the [instructions](https://hypar-io.github.io/Elements/Revit.html).
- Add a function to the workflow and verify that the new function's execution geometry appears in Revit.
  
FUTURE WORK:
- This PR creates one regression. It removes edge rendering in hidden line views. Previously we had solids from which we could pull the edges, but those don't exist in the gltf. A new strategy will need to be devised to draw the edges.
- View refresh is still broken. We are looking for a way to refresh the view automatically when the hub updates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/348)
<!-- Reviewable:end -->
