### PR TITLE
fix for element codegen

### DIFF
--- a/src/Elements/Generate/TypeGenerator.cs
+++ b/src/Elements/Generate/TypeGenerator.cs
@@ -428,6 +428,11 @@ namespace Elements.Generate
 
             if (isUserElement)
             {
+                // remove unncessary imports
+                file = file.Replace(@"
+using Hypar.Functions;
+using Hypar.Functions.Execution;
+using Hypar.Functions.Execution.AWS;", "");
                 // Insert the UserElement attribute directly before
                 // 'public partial class <typeName>'
                 var start = file.IndexOf($"public partial class {typeName}");

--- a/src/Elements/Generate/TypeGenerator.cs
+++ b/src/Elements/Generate/TypeGenerator.cs
@@ -429,6 +429,8 @@ namespace Elements.Generate
             if (isUserElement)
             {
                 // remove unncessary imports
+                // TODO: make this a conditional for the code generation using ExtensionData, instead of using string replacement. 
+                // For whatever reason, this was not working with code in File.liquid — only Class.liquid.
                 file = file.Replace(@"
 using Hypar.Functions;
 using Hypar.Functions.Execution;


### PR DESCRIPTION
related to https://github.com/hypar-io/Hypar/pull/230
Custom elements were no longer codegenning correctly for several reasons. Above PR corrects the first, this corrects the other.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/350)
<!-- Reviewable:end -->
