### PR TITLE
add point schema

### DIFF
--- a/src/Elements/Generate/TypeGenerator.cs
+++ b/src/Elements/Generate/TypeGenerator.cs
@@ -104,6 +104,7 @@ namespace Elements.Generate
                 "https://hypar.io/Schemas/Material.json",
                 "https://hypar.io/Schemas/Model.json",
                 "https://hypar.io/Schemas/Geometry/Matrix.json",
+                "https://geojson.org/schema/Point.json",
             };
 
         private const string NAMESPACE_PROPERTY = "x-namespace";
@@ -353,7 +354,10 @@ namespace Elements.Generate
             return allResults;
         }
 
-        private static string[] GetCoreTypeNames()
+        /// <summary>
+        /// Get a list of the core Hypar types, which should be excluded from code generation. 
+        /// </summary>
+        public static string[] GetCoreTypeNames()
         {
             return _hyparSchemas.Select(u => GetTypeNameFromSchemaUri(u)).ToArray();
         }


### PR DESCRIPTION
BACKGROUND:
- In order to support `input_schema` codegen for Locations, the schema for GeoJSON.Point needed to be added to known schemas. In order to support `input_schema` codegen for other built-in special types, the method for listing the excluded (known) types needed to be made public.

DESCRIPTION:
- Adds ` https://geojson.org/schema/Point.json` to `_hyparSchemas`
- exposes `GetCoreTypeNames()` as public

TESTING:
- Have tested with a new version of the CLI that relies on these changes (PR forthcoming)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/351)
<!-- Reviewable:end -->
