### PR TITLE
Polygon Boolean Improvements

### DIFF
--- a/src/Elements/Geometry/Polygon.cs
+++ b/src/Elements/Geometry/Polygon.cs
@@ -191,8 +191,9 @@ namespace Elements.Geometry
         /// </returns>
         public bool Covers(Vector3 vector)
         {
+            var clipperScale = 1 / Vector3.EPSILON;
             var thisPath = this.ToClipperPath();
-            var intPoint = new IntPoint(vector.X * CLIPPER_SCALE, vector.Y * CLIPPER_SCALE);
+            var intPoint = new IntPoint(vector.X * clipperScale, vector.Y * clipperScale);
             if (Clipper.PointInPolygon(intPoint, thisPath) == 0)
             {
                 return false;
@@ -238,8 +239,9 @@ namespace Elements.Geometry
         /// </returns>
         public bool Disjoint(Vector3 vector)
         {
+            var clipperScale = 1.0 / Vector3.EPSILON;
             var thisPath = this.ToClipperPath();
-            var intPoint = new IntPoint(vector.X * CLIPPER_SCALE, vector.Y * CLIPPER_SCALE);
+            var intPoint = new IntPoint(vector.X * clipperScale, vector.Y * clipperScale);
             if (Clipper.PointInPolygon(intPoint, thisPath) != 0)
             {
                 return false;
@@ -304,13 +306,15 @@ namespace Elements.Geometry
         /// Tests if the supplied Vector3 is coincident with an edge of this Polygon when compared on a shared plane.
         /// </summary>
         /// <param name="vector">The Vector3 to compare to this Polygon.</param>
+        /// <param name="tolerance">An optional tolerance.</param>
         /// <returns>
         /// Returns true if the supplied Vector3 coincides with an edge of this Polygon when compared on a shared plane. Returns false if the supplied Vector3 is not coincident with an edge of this Polygon, or if the supplied Vector3 is null.
         /// </returns>
-        public bool Touches(Vector3 vector)
+        public bool Touches(Vector3 vector, double tolerance = Vector3.EPSILON)
         {
-            var thisPath = this.ToClipperPath();
-            var intPoint = new IntPoint(vector.X * CLIPPER_SCALE, vector.Y * CLIPPER_SCALE);
+            var clipperScale = 1.0 / tolerance;
+            var thisPath = this.ToClipperPath(tolerance);
+            var intPoint = new IntPoint(vector.X * clipperScale, vector.Y * clipperScale);
             if (Clipper.PointInPolygon(intPoint, thisPath) != -1)
             {
                 return false;
@@ -322,17 +326,18 @@ namespace Elements.Geometry
         /// Tests if at least one point of an edge of the supplied Polygon is shared with an edge of this Polygon without the Polygons interesecting when compared on a shared plane.
         /// </summary>
         /// <param name="polygon">The Polygon to compare to this Polygon.</param>
+        /// <param name="tolerance">An optional tolerance.</param>
         /// <returns>
         /// Returns true if the supplied Polygon shares at least one edge point with this Polygon without the Polygons intersecting when compared on a shared plane. Returns false if the Polygons intersect, are disjoint, or if the supplied Polygon is null.
         /// </returns>
-        public bool Touches(Polygon polygon)
+        public bool Touches(Polygon polygon, double tolerance = Vector3.EPSILON)
         {
             if (polygon == null || this.Intersects(polygon))
             {
                 return false;
             }
-            var thisPath = this.ToClipperPath();
-            var polyPath = polygon.ToClipperPath();
+            var thisPath = this.ToClipperPath(tolerance);
+            var polyPath = polygon.ToClipperPath(tolerance);
             foreach (IntPoint vertex in thisPath)
             {
                 if (Clipper.PointInPolygon(vertex, polyPath) == -1)
@@ -348,10 +353,11 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="firstSet">First set of polygons</param>
         /// <param name="secondSet">Second set of polygons</param>
+        /// <param name="tolerance">An optional tolerance.</param>
         /// <returns>Returns a list of Polygons representing the subtraction of the second set of polygons from the first set.</returns>
-        public static IList<Polygon> Difference(IList<Polygon> firstSet, IList<Polygon> secondSet)
+        public static IList<Polygon> Difference(IList<Polygon> firstSet, IList<Polygon> secondSet, double tolerance = Vector3.EPSILON)
         {
-            return BooleanTwoSets(firstSet, secondSet, BooleanMode.Difference);
+            return BooleanTwoSets(firstSet, secondSet, BooleanMode.Difference, tolerance);
         }
 
         /// <summary>
@@ -359,10 +365,11 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="firstSet">First set of polygons</param>
         /// <param name="secondSet">Second set of polygons</param>
+        /// <param name="tolerance">An optional tolerance.</param>
         /// <returns>Returns a list of Polygons representing the union of both sets of polygons.</returns>
-        public static IList<Polygon> Union(IList<Polygon> firstSet, IList<Polygon> secondSet)
+        public static IList<Polygon> Union(IList<Polygon> firstSet, IList<Polygon> secondSet, double tolerance = Vector3.EPSILON)
         {
-            return BooleanTwoSets(firstSet, secondSet, BooleanMode.Union);
+            return BooleanTwoSets(firstSet, secondSet, BooleanMode.Union, tolerance);
         }
 
         /// <summary>
@@ -370,13 +377,14 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="firstSet">First set of polygons</param>
         /// <param name="secondSet">Second set of polygons</param>
+        /// <param name="tolerance">An optional tolerance.</param>
         /// <returns>
         /// Returns a list of Polygons representing the symmetric difference of these two sets of polygons.
         /// Returns a representation of all polygons if they do not intersect.
         /// </returns>
-        public static IList<Polygon> XOR(IList<Polygon> firstSet, IList<Polygon> secondSet)
+        public static IList<Polygon> XOR(IList<Polygon> firstSet, IList<Polygon> secondSet, double tolerance = Vector3.EPSILON)
         {
-            return BooleanTwoSets(firstSet, secondSet, BooleanMode.XOr);
+            return BooleanTwoSets(firstSet, secondSet, BooleanMode.XOr, tolerance);
         }
 
         /// <summary>
@@ -384,13 +392,14 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="firstSet">First set of polygons</param>
         /// <param name="secondSet">Second set of polygons</param>
+        /// <param name="tolerance">An optional tolerance.</param>
         /// <returns>
         /// Returns a list of Polygons representing the intersection of the first set of Polygons with the second set.
         /// Returns null if the Polygons do not intersect.
         /// </returns>
-        public static IList<Polygon> Intersection(IList<Polygon> firstSet, IList<Polygon> secondSet)
+        public static IList<Polygon> Intersection(IList<Polygon> firstSet, IList<Polygon> secondSet, double tolerance = Vector3.EPSILON)
         {
-            return BooleanTwoSets(firstSet, secondSet, BooleanMode.Intersection);
+            return BooleanTwoSets(firstSet, secondSet, BooleanMode.Intersection, tolerance);
         }
 
 
@@ -401,10 +410,10 @@ namespace Elements.Geometry
         /// <param name="clippingPolygons">Polygons with which to clip</param>
         /// <param name="mode">The operation to apply: Union, Difference, Intersection, or XOr</param>
         /// <returns></returns>
-        private static IList<Polygon> BooleanTwoSets(IList<Polygon> subjectPolygons, IList<Polygon> clippingPolygons, BooleanMode mode)
+        private static IList<Polygon> BooleanTwoSets(IList<Polygon> subjectPolygons, IList<Polygon> clippingPolygons, BooleanMode mode, double tolerance = Vector3.EPSILON)
         {
-            var subjectPaths = subjectPolygons.Select(s => s.ToClipperPath()).ToList();
-            var clipPaths = clippingPolygons.Select(s => s.ToClipperPath()).ToList();
+            var subjectPaths = subjectPolygons.Select(s => s.ToClipperPath(tolerance)).ToList();
+            var clipPaths = clippingPolygons.Select(s => s.ToClipperPath(tolerance)).ToList();
             Clipper clipper = new Clipper();
             clipper.AddPaths(subjectPaths, PolyType.ptSubject, true);
             clipper.AddPaths(clipPaths, PolyType.ptClip, true);
@@ -433,7 +442,7 @@ namespace Elements.Geometry
             var polygons = new List<Polygon>();
             foreach (List<IntPoint> path in solution)
             {
-                polygons.Add(PolygonExtensions.ToPolygon(path));
+                polygons.Add(PolygonExtensions.ToPolygon(path, tolerance));
             }
             return polygons;
         }
@@ -442,20 +451,21 @@ namespace Elements.Geometry
         /// Constructs the geometric difference between this Polygon and the supplied Polygon.
         /// </summary>
         /// <param name="polygon">The intersecting Polygon.</param>
+        /// <param name="tolerance">An optional tolerance value.</param>
         /// <returns>
         /// Returns a list of Polygons representing the subtraction of the supplied Polygon from this Polygon.
         /// Returns null if the area of this Polygon is entirely subtracted.
         /// Returns a list containing a representation of the perimeter of this Polygon if the two Polygons do not intersect.
         /// </returns>
-        public IList<Polygon> Difference(Polygon polygon)
+        public IList<Polygon> Difference(Polygon polygon, double tolerance = Vector3.EPSILON)
         {
-            var thisPath = this.ToClipperPath();
-            var polyPath = polygon.ToClipperPath();
+            var thisPath = this.ToClipperPath(tolerance);
+            var polyPath = polygon.ToClipperPath(tolerance);
             Clipper clipper = new Clipper();
             clipper.AddPath(thisPath, PolyType.ptSubject, true);
             clipper.AddPath(polyPath, PolyType.ptClip, true);
             var solution = new List<List<IntPoint>>();
-            clipper.Execute(ClipType.ctDifference, solution);
+            clipper.Execute(ClipType.ctDifference, solution, PolyFillType.pftNonZero);
             if (solution.Count == 0)
             {
                 return null;
@@ -463,7 +473,7 @@ namespace Elements.Geometry
             var polygons = new List<Polygon>();
             foreach (List<IntPoint> path in solution)
             {
-                polygons.Add(PolygonExtensions.ToPolygon(path));
+                polygons.Add(PolygonExtensions.ToPolygon(path, tolerance));
             }
             return polygons;
         }
@@ -472,18 +482,19 @@ namespace Elements.Geometry
         /// Constructs the geometric difference between this Polygon and the supplied Polygons.
         /// </summary>
         /// <param name="difPolys">The list of intersecting Polygons.</param>
+        /// <param name="tolerance">An optional tolerance value.</param>
         /// <returns>
         /// Returns a list of Polygons representing the subtraction of the supplied Polygons from this Polygon.
         /// Returns null if the area of this Polygon is entirely subtracted.
         /// Returns a list containing a representation of the perimeter of this Polygon if the two Polygons do not intersect.
         /// </returns>
-        public IList<Polygon> Difference(IList<Polygon> difPolys)
+        public IList<Polygon> Difference(IList<Polygon> difPolys, double tolerance = Vector3.EPSILON)
         {
-            var thisPath = this.ToClipperPath();
+            var thisPath = this.ToClipperPath(tolerance);
             var polyPaths = new List<List<IntPoint>>();
             foreach (Polygon polygon in difPolys)
             {
-                polyPaths.Add(polygon.ToClipperPath());
+                polyPaths.Add(polygon.ToClipperPath(tolerance));
             }
             Clipper clipper = new Clipper();
             clipper.AddPath(thisPath, PolyType.ptSubject, true);
@@ -497,7 +508,14 @@ namespace Elements.Geometry
             var polygons = new List<Polygon>();
             foreach (List<IntPoint> path in solution)
             {
-                polygons.Add(PolygonExtensions.ToPolygon(path.Distinct().ToList()));
+                try
+                {
+                    polygons.Add(PolygonExtensions.ToPolygon(path.Distinct().ToList(), tolerance));
+                }
+                catch
+                {
+                    // swallow invalid polygons
+                }
             }
             return polygons;
         }
@@ -506,14 +524,15 @@ namespace Elements.Geometry
         /// Constructs the Polygon intersections between this Polygon and the supplied Polygon.
         /// </summary>
         /// <param name="polygon">The intersecting Polygon.</param>
+        /// <param name="tolerance">An optional tolerance.</param>
         /// <returns>
         /// Returns a list of Polygons representing the intersection of this Polygon with the supplied Polygon.
         /// Returns null if the two Polygons do not intersect.
         /// </returns>
-        public IList<Polygon> Intersection(Polygon polygon)
+        public IList<Polygon> Intersection(Polygon polygon, double tolerance = Vector3.EPSILON)
         {
-            var thisPath = this.ToClipperPath();
-            var polyPath = polygon.ToClipperPath();
+            var thisPath = this.ToClipperPath(tolerance);
+            var polyPath = polygon.ToClipperPath(tolerance);
             Clipper clipper = new Clipper();
             clipper.AddPath(thisPath, PolyType.ptSubject, true);
             clipper.AddPath(polyPath, PolyType.ptClip, true);
@@ -526,7 +545,7 @@ namespace Elements.Geometry
             var polygons = new List<Polygon>();
             foreach (List<IntPoint> path in solution)
             {
-                polygons.Add(PolygonExtensions.ToPolygon(path));
+                polygons.Add(PolygonExtensions.ToPolygon(path, tolerance));
             }
             return polygons;
         }
@@ -535,14 +554,15 @@ namespace Elements.Geometry
         /// Constructs the geometric union between this Polygon and the supplied Polygon.
         /// </summary>
         /// <param name="polygon">The Polygon to be combined with this Polygon.</param>
+        /// <param name="tolerance">An optional tolerance.</param>
         /// <returns>
         /// Returns a single Polygon from a successful union.
         /// Returns null if a union cannot be performed on the two Polygons.
         /// </returns>
-        public Polygon Union(Polygon polygon)
+        public Polygon Union(Polygon polygon, double tolerance = Vector3.EPSILON)
         {
-            var thisPath = this.ToClipperPath();
-            var polyPath = polygon.ToClipperPath();
+            var thisPath = this.ToClipperPath(tolerance);
+            var polyPath = polygon.ToClipperPath(tolerance);
             Clipper clipper = new Clipper();
             clipper.AddPath(thisPath, PolyType.ptSubject, true);
             clipper.AddPath(polyPath, PolyType.ptClip, true);
@@ -552,24 +572,25 @@ namespace Elements.Geometry
             {
                 return null;
             }
-            return solution.First().ToPolygon();
+            return solution.First().ToPolygon(tolerance);
         }
 
         /// <summary>
         /// Constructs the geometric union between this Polygon and the supplied list of Polygons.
         /// </summary>
         /// <param name="polygons">The list of Polygons to be combined with this Polygon.</param>
+        /// <param name="tolerance">An optional tolerance.</param>
         /// <returns>
         /// Returns a single Polygon from a successful union.
         /// Returns null if a union cannot be performed on the complete list of Polygons.
         /// </returns>
-        public Polygon Union(IList<Polygon> polygons)
+        public Polygon Union(IList<Polygon> polygons, double tolerance = Vector3.EPSILON)
         {
-            var thisPath = this.ToClipperPath();
+            var thisPath = this.ToClipperPath(tolerance);
             var polyPaths = new List<List<IntPoint>>();
             foreach (Polygon polygon in polygons)
             {
-                polyPaths.Add(polygon.ToClipperPath());
+                polyPaths.Add(polygon.ToClipperPath(tolerance));
             }
             Clipper clipper = new Clipper();
             clipper.AddPath(thisPath, PolyType.ptSubject, true);
@@ -580,21 +601,22 @@ namespace Elements.Geometry
             {
                 return null;
             }
-            return solution.First().Distinct().ToList().ToPolygon();
+            return solution.First().Distinct().ToList().ToPolygon(tolerance);
         }
 
         /// <summary>
         /// Returns Polygons representing the symmetric difference between this Polygon and the supplied Polygon.
         /// </summary>
         /// <param name="polygon">The intersecting polygon.</param>
+        /// <param name="tolerance">An optional tolerance.</param>
         /// <returns>
         /// Returns a list of Polygons representing the symmetric difference of this Polygon and the supplied Polygon.
         /// Returns a representation of this Polygon and the supplied Polygon if the Polygons do not intersect.
         /// </returns>
-        public IList<Polygon> XOR(Polygon polygon)
+        public IList<Polygon> XOR(Polygon polygon, double tolerance = Vector3.EPSILON)
         {
-            var thisPath = this.ToClipperPath();
-            var polyPath = polygon.ToClipperPath();
+            var thisPath = this.ToClipperPath(tolerance);
+            var polyPath = polygon.ToClipperPath(tolerance);
             Clipper clipper = new Clipper();
             clipper.AddPath(thisPath, PolyType.ptSubject, true);
             clipper.AddPath(polyPath, PolyType.ptClip, true);
@@ -603,7 +625,7 @@ namespace Elements.Geometry
             var polygons = new List<Polygon>();
             foreach (List<IntPoint> path in solution)
             {
-                polygons.Add(PolygonExtensions.ToPolygon(path));
+                polygons.Add(PolygonExtensions.ToPolygon(path, tolerance));
             }
             return polygons;
         }
@@ -613,11 +635,12 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="offset">The amount to offset.</param>
         /// <param name="endType">The type of closure used for the offset polygon.</param>
+        /// <param name="tolerance">An optional tolerance.</param>
         /// <returns>A new Polygon offset by offset.</returns>
         ///
-        public override Polygon[] Offset(double offset, EndType endType = EndType.ClosedPolygon)
+        public override Polygon[] Offset(double offset, EndType endType = EndType.ClosedPolygon, double tolerance = Vector3.EPSILON)
         {
-            return base.Offset(offset, endType);
+            return base.Offset(offset, endType, tolerance);
         }
 
 
@@ -921,19 +944,19 @@ namespace Elements.Geometry
     /// </summary>
     internal static class PolygonExtensions
     {
-        private const double scale = Polyline.CLIPPER_SCALE;
-
         /// <summary>
         /// Construct a clipper path from a Polygon.
         /// </summary>
         /// <param name="p"></param>
+        /// <param name="tolerance">Optional tolerance value. If converting back to a polygon after the operation, be sure to use the same tolerance value.</param>
         /// <returns></returns>
-        internal static List<IntPoint> ToClipperPath(this Polygon p)
+        internal static List<IntPoint> ToClipperPath(this Polygon p, double tolerance = Vector3.EPSILON)
         {
+            var scale = Math.Round(1.0 / tolerance);
             var path = new List<IntPoint>();
             foreach (var v in p.Vertices)
             {
-                path.Add(new IntPoint(v.X * scale, v.Y * scale));
+                path.Add(new IntPoint(Math.Round(v.X * scale), Math.Round(v.Y * scale)));
             }
             return path;
         }
@@ -942,9 +965,11 @@ namespace Elements.Geometry
         /// Construct a Polygon from a clipper path 
         /// </summary>
         /// <param name="p"></param>
+        /// <param name="tolerance">Optional tolerance value. Be sure to use the same tolerance value as you used when converting to Clipper path.</param>
         /// <returns></returns>
-        internal static Polygon ToPolygon(this List<IntPoint> p)
+        internal static Polygon ToPolygon(this List<IntPoint> p, double tolerance = Vector3.EPSILON)
         {
+            var scale = Math.Round(1.0 / tolerance);
             var converted = new Vector3[p.Count];
             for (var i = 0; i < converted.Length; i++)
             {

--- a/src/Elements/Geometry/Vector3.cs
+++ b/src/Elements/Geometry/Vector3.cs
@@ -346,6 +346,18 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Determine whether this vector's components are equal to the provided components, within tolerance.
+        /// </summary>
+        /// <param name="x">The x component to compare.</param>
+        /// <param name="y">The y component to compare.</param>
+        /// <param name="z">The z component to compare.</param>
+        /// <returns>True if the difference of this vector and the supplied vector's components are all within Tolerance, otherwise false.</returns>
+        public bool IsAlmostEqualTo(double x, double y, double z = 0)
+        {
+            return IsAlmostEqualTo(new Vector3(x, y, z));
+        }
+
+        /// <summary>
         /// The distance from this point to b.
         /// </summary>
         /// <param name="v">The target vector.</param>

--- a/src/Elements/Spatial/Grid2d.cs
+++ b/src/Elements/Spatial/Grid2d.cs
@@ -519,8 +519,7 @@ namespace Elements.Spatial
 
             var trimmedRect = Polygon.Intersection(new[] { baseRect }, boundariesInGridSpace);
             if (trimmedRect == null || trimmedRect.Count > 1 || trimmedRect.Count < 1) return false;
-            return !trimmedRect[0].IsAlmostEqualTo(baseRect, 1 / Polyline.CLIPPER_SCALE);
-            //TODO: decide if clipper_scale should be adjusted to reflect global tolerance settings so that 1 / polyline.clipper_scale = vector3.epsilon.
+            return !trimmedRect[0].IsAlmostEqualTo(baseRect, Vector3.EPSILON);
         }
 
         #endregion

--- a/test/Elements.Tests/PolygonTests.cs
+++ b/test/Elements.Tests/PolygonTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Newtonsoft.Json;
 using Elements.Tests;
+using Elements.Serialization.glTF;
 
 namespace Elements.Geometry.Tests
 {
@@ -369,12 +370,12 @@ namespace Elements.Geometry.Tests
             );
             var vertices = p1.Difference(p2).First().Vertices;
 
-            Assert.Contains(vertices, p => p.X == 0.0 && p.Y == 0.0);
-            Assert.Contains(vertices, p => p.X == 4.0 && p.Y == 0.0);
-            Assert.Contains(vertices, p => p.X == 4.0 && p.Y == 1.0);
-            Assert.Contains(vertices, p => p.X == 3.0 && p.Y == 1.0);
-            Assert.Contains(vertices, p => p.X == 3.0 && p.Y == 4.0);
-            Assert.Contains(vertices, p => p.X == 0.0 && p.Y == 4.0);
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(0.0, 0.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(4.0, 0.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(4.0, 1.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(3.0, 1.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(3.0, 4.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(0.0, 4.0));
         }
 
         [Fact]
@@ -413,10 +414,10 @@ namespace Elements.Geometry.Tests
             var ps = new List<Polygon> { p2, p3 };
             var vertices = p1.Intersection(p2).First().Vertices;
 
-            Assert.Contains(vertices, p => p.X == 3.0 && p.Y == 1.0);
-            Assert.Contains(vertices, p => p.X == 4.0 && p.Y == 1.0);
-            Assert.Contains(vertices, p => p.X == 4.0 && p.Y == 4.0);
-            Assert.Contains(vertices, p => p.X == 3.0 && p.Y == 4.0);
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(3.0, 1.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(4.0, 1.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(4.0, 4.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(3.0, 4.0));
         }
 
         [Fact]
@@ -456,29 +457,29 @@ namespace Elements.Geometry.Tests
 
             var vertices = p1.Union(p2).Vertices;
 
-            Assert.Contains(vertices, p => p.X == 0.0 && p.Y == 0.0);
-            Assert.Contains(vertices, p => p.X == 4.0 && p.Y == 0.0);
-            Assert.Contains(vertices, p => p.X == 4.0 && p.Y == 1.0);
-            Assert.Contains(vertices, p => p.X == 7.0 && p.Y == 1.0);
-            Assert.Contains(vertices, p => p.X == 7.0 && p.Y == 5.0);
-            Assert.Contains(vertices, p => p.X == 3.0 && p.Y == 5.0);
-            Assert.Contains(vertices, p => p.X == 3.0 && p.Y == 4.0);
-            Assert.Contains(vertices, p => p.X == 0.0 && p.Y == 4.0);
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(0.0, 0.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(4.0, 0.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(4.0, 1.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(7.0, 1.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(7.0, 5.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(3.0, 5.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(3.0, 4.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(0.0, 4.0));
 
             vertices = p1.Union(ps).Vertices;
 
-            Assert.Contains(vertices, p => p.X == 0.0 && p.Y == 0.0);
-            Assert.Contains(vertices, p => p.X == 4.0 && p.Y == 0.0);
-            Assert.Contains(vertices, p => p.X == 4.0 && p.Y == 1.0);
-            Assert.Contains(vertices, p => p.X == 7.0 && p.Y == 1.0);
-            Assert.Contains(vertices, p => p.X == 7.0 && p.Y == 2.0);
-            Assert.Contains(vertices, p => p.X == 8.0 && p.Y == 2.0);
-            Assert.Contains(vertices, p => p.X == 8.0 && p.Y == 3.0);
-            Assert.Contains(vertices, p => p.X == 7.0 && p.Y == 3.0);
-            Assert.Contains(vertices, p => p.X == 7.0 && p.Y == 5.0);
-            Assert.Contains(vertices, p => p.X == 3.0 && p.Y == 5.0);
-            Assert.Contains(vertices, p => p.X == 3.0 && p.Y == 4.0);
-            Assert.Contains(vertices, p => p.X == 0.0 && p.Y == 4.0);
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(0.0, 0.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(4.0, 0.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(4.0, 1.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(7.0, 1.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(7.0, 2.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(8.0, 2.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(8.0, 3.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(7.0, 3.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(7.0, 5.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(3.0, 5.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(3.0, 4.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(0.0, 4.0));
 
         }
 
@@ -507,14 +508,14 @@ namespace Elements.Geometry.Tests
             );
             var vertices = p1.XOR(p2).First().Vertices;
 
-            Assert.Contains(vertices, p => p.X == 4.0 && p.Y == 1.0);
-            Assert.Contains(vertices, p => p.X == 7.0 && p.Y == 1.0);
-            Assert.Contains(vertices, p => p.X == 7.0 && p.Y == 5.0);
-            Assert.Contains(vertices, p => p.X == 3.0 && p.Y == 5.0);
-            Assert.Contains(vertices, p => p.X == 3.0 && p.Y == 4.0);
-            Assert.Contains(vertices, p => p.X == 0.0 && p.Y == 4.0);
-            Assert.Contains(vertices, p => p.X == 0.0 && p.Y == 0.0);
-            Assert.Contains(vertices, p => p.X == 4.0 && p.Y == 0.0);
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(4.0, 1.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(7.0, 1.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(7.0, 5.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(3.0, 5.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(3.0, 4.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(0.0, 4.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(0.0, 0.0));
+            Assert.Contains(vertices, p => p.IsAlmostEqualTo(4.0, 0.0));
         }
 
         [Fact]
@@ -706,6 +707,39 @@ namespace Elements.Geometry.Tests
             Assert.Equal(shape3.Segments().Count() * 2, contour3.Count());
         }
 
+        [Fact]
+        public void PolygonDifferenceWithManyCoincidentEdges()
+        {
+            // an angle of 47 remains known to fail. This may be a fundamental limitation of clipper w/r/t
+            // polygon differences with coincident edges at an angle.
+            // var rotations = new[] { 0, 47, 90 };
+            var rotations = new[] { 0, 90 };
+            var areas = new List<double>();
+            foreach (var rotation in rotations)
+            {
+
+                var tR = new Transform(Vector3.Origin, rotation);
+                var polygon = Polygon.Rectangle(Vector3.Origin, new Vector3(100.0, 50.0)).TransformedPolygon(tR);
+                var subtracts = new List<Polygon>();
+
+                var side1 = Polygon.Rectangle(Vector3.Origin, new Vector3(1.0, 20.0));
+                var side2 = Polygon.Rectangle(new Vector3(0.0, 30.0), new Vector3(1.0, 50.0));
+                for (var i = 1; i < 99; i++)
+                {
+                    var translate = new Transform(i, 0, 0);
+                    subtracts.Add(side1.TransformedPolygon(translate).TransformedPolygon(tR));
+                    subtracts.Add(side2.TransformedPolygon(translate).TransformedPolygon(tR));
+                }
+                var polygons = polygon.Difference(subtracts);
+
+                areas.Add(polygons.First().Area());
+            }
+            var targetArea = areas[0];
+            for (int i = 1; i < areas.Count; i++)
+            {
+                Assert.Equal(targetArea, areas[i], 4);
+            }
+        }
 
         [Fact]
         public void PolygonIsAlmostEqualAfterBoolean()
@@ -730,8 +764,7 @@ namespace Elements.Geometry.Tests
 
             var intersection = innerPolygon.Intersection(outerPolygon);
 
-            Assert.True(intersection[0].IsAlmostEqualTo(innerPolygon, 1 / Polyline.CLIPPER_SCALE));
-            //TODO: decide if clipper_scale should be adjusted to reflect global tolerance settings so that 1 / polyline.clipper_scale = vector3.epsilon.
+            Assert.True(intersection[0].IsAlmostEqualTo(innerPolygon, Vector3.EPSILON));
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- Anthony ran into some consistent issues with performing a boolean difference between two polygons that share an edge, as reported here: https://github.com/hypar-io/Elements/issues/358
- this PR fixes some but not all of the cases in his report. There may be fundamental limits to clipper's ability to handle this kind of condition. 

DESCRIPTION:
- replaces the global constant `CLIPPER_SCALE` with per-function tolerance values that default to the global tolerance `Vector3.EPSILON`
- changes the rounding behavior of ToClipperPath to round to the nearest integer instead of rounding down

TESTING:
- have added a test adapted from @anthonyhauck's (and a note about the cases where it continues to fail)
- have tested a number of operations at various tolerance levels
- have ensured no existing test breaks (some modification was necessary as many tests previously used strict equality) 
  
FUTURE WORK:
- We should investigate whether:
1. there is a reasonable modification to our wrapper around clipper to handle cases with coincident edges better generally
2. there is an alternative to clipper that performs better on these cases

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/359)
<!-- Reviewable:end -->
