### PR TITLE
use epsilon tolerance while creating transfor from points

### DIFF
--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -589,7 +589,7 @@ namespace Elements.Geometry
             {
                 b = (points[i] - points[1]).Unitized();
                 var dot = b.Dot(a);
-                if (dot > -1 && dot < 1)
+                if (dot > -1 + Vector3.EPSILON && dot < 1 - Vector3.EPSILON)
                 {
                     // Console.WriteLine("Found valid second vector.");
                     break;

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -66,6 +66,24 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void CreateTransform()
+        {
+            // This list of vectors will make an invalid transform unless we
+            // have the Vector3.Epsilon tolerance while doing the dot comparison
+            // in the ToTransform() method.
+            var points = new List<Vector3>{
+                new Vector3(84.65819230015089, 45.936106099249145, 0),
+                new Vector3(84.73003434911944, 45.864264050280596, 0),
+                new Vector3(85.04991559960003, 45.544382799800005, 0),
+                new Vector3(85.04991559960003, 45.544382799800005, 3.0480000000001444),
+            };
+            var t = points.ToTransform();
+            Assert.True(t.XAxis.Length() > 0);
+            Assert.True(t.YAxis.Length() > 0);
+            Assert.True(t.ZAxis.Length() > 0);
+        }
+
+        [Fact]
         public void DistanceToPlane()
         {
             var v = new Vector3(0.5, 0.5, 1.0);


### PR DESCRIPTION
BACKGROUND:
- Wall export from revit was failing with line end points being the same.  This was traced back to a bad transform that was flattening the z coordinate of all points.  Bad transform made because a bad vector was accepted while trying to choose a transform from a list of points.  The dot product check for >< 1 did not include a tolerance check.
![image](https://user-images.githubusercontent.com/5872187/89696039-239f3180-d8e4-11ea-9b1d-46b27b23ce17.png)


DESCRIPTION:
- add tolerance check to dot product comparison.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/366)
<!-- Reviewable:end -->
