### PR TITLE
don't add empty model points

### DIFF
--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -716,24 +716,17 @@ namespace Elements.Serialization.glTF
                     lines.Add(currLines);
                 }
 
-                try
-                {
-                    GetRenderDataForElement(e,
-                                            gltf,
-                                            materials,
-                                            buffer,
-                                            bufferViews,
-                                            accessors,
-                                            meshes,
-                                            nodes,
-                                            meshElementMap,
-                                            currLines,
-                                            drawEdges);
-                }
-                catch
-                {
-                    throw;
-                }
+                GetRenderDataForElement(e,
+                                        gltf,
+                                        materials,
+                                        buffer,
+                                        bufferViews,
+                                        accessors,
+                                        meshes,
+                                        nodes,
+                                        meshElementMap,
+                                        currLines,
+                                        drawEdges);
             }
             if (buffer.Count == 0)
             {

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -687,8 +687,8 @@ namespace Elements.Serialization.glTF
             var accessors = new List<Accessor>();
 
             var materialsToAdd = model.AllElementsOfType<Material>().ToList();
-            if(drawEdges)
-            {   
+            if (drawEdges)
+            {
                 materialsToAdd.Add(BuiltInMaterials.Edges);
             }
             var materials = gltf.AddMaterials(materialsToAdd, buffer, bufferViews);
@@ -716,17 +716,24 @@ namespace Elements.Serialization.glTF
                     lines.Add(currLines);
                 }
 
-                GetRenderDataForElement(e,
-                                        gltf,
-                                        materials,
-                                        buffer,
-                                        bufferViews,
-                                        accessors,
-                                        meshes,
-                                        nodes,
-                                        meshElementMap,
-                                        currLines,
-                                        drawEdges);
+                try
+                {
+                    GetRenderDataForElement(e,
+                                            gltf,
+                                            materials,
+                                            buffer,
+                                            bufferViews,
+                                            accessors,
+                                            meshes,
+                                            nodes,
+                                            meshElementMap,
+                                            currLines,
+                                            drawEdges);
+                }
+                catch
+                {
+                    throw;
+                }
             }
             if (buffer.Count == 0)
             {
@@ -849,7 +856,10 @@ namespace Elements.Serialization.glTF
             if (e is ModelPoints)
             {
                 var mp = (ModelPoints)e;
-                AddPoints(GetNextId(), mp.Locations, gltf, materials[mp.Material.Name], buffer, bufferViews, accessors, meshes, nodes, mp.Transform);
+                if (mp.Locations.Count != 0)
+                {
+                    AddPoints(GetNextId(), mp.Locations, gltf, materials[mp.Material.Name], buffer, bufferViews, accessors, meshes, nodes, mp.Transform);
+                }
             }
 
             if (e is ITessellate)
@@ -918,7 +928,7 @@ namespace Elements.Serialization.glTF
                 meshElementMap[e.Id].Add(meshId);
 
                 var geom = (GeometricElement)e;
-                if(!geom.IsElementDefinition)
+                if (!geom.IsElementDefinition)
                 {
                     CreateNodeForMesh(gltf, meshId, nodes, geom.Transform);
                 }


### PR DESCRIPTION
BACKGROUND:
- JSON to model was failing on recent exports from Revit.  We know now that it is because of the ModelPoint objects that had no points in them.

DESCRIPTION:
- The gltf export should not fail even if there's an empty ModelPoints object.  We check if there are any points before adding them to the gltf.

TESTING:
- I have used a local reference to Elements in the JSON to Model function and it works with this change, successfully not exporting points.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/367)
<!-- Reviewable:end -->
