### PR TITLE
add UserElement annotation for any partial classes

### DIFF
--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -519,9 +519,20 @@ using Hypar.Functions;
 using Hypar.Functions.Execution;
 using Hypar.Functions.Execution.AWS;", "");
                 // Insert the UserElement attribute directly before
-                // 'public partial class <typeName>'
-                var start = file.IndexOf($"public partial class {typeName}");
-                file = file.Insert(start, $"[UserElement]\n\t");
+                // 'public partial class ' any time it occurs in the file
+                // because we may be generating code for multiple user types in 
+                // the same file.
+                var start = 0;
+                while (true)
+                {
+                    start = file.IndexOf($"public partial class ", start);
+                    if (start == -1)
+                    {
+                        break;
+                    }
+                    file = file.Insert(start, $"[UserElement]\n\t");
+                    start += 16;  // increment chars to get past the recent insertion
+                }
             }
 
             if (typeName == "Model")


### PR DESCRIPTION
BACKGROUND:
- When we generate code for a UserElement that references another UserElement, the code gen has a problem where the nested generated type doesn't have the UserElement annotation.  This resulted in those elements not deserializing correctly as the UserElement type wasn't found during deserialization.

DESCRIPTION:
- The part of the code that adds the `[UserElement]` annotation only added it for the class being created, but it should be added to every generated class in the file.  

TESTING:
- The function I was working with used this schema for RainLoad https://dev-api.hypar.io/schemas/c62f0800-7367-4287-a8f7-6066a0de9e7d 
- Any function that uses that schema and doesn't have these code changes will not de serialize incoming DrainableRoofSections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/368)
<!-- Reviewable:end -->
