### PR TITLE
Deserialize to GeometricElement even when a type isn't recognized.

### DIFF
--- a/Elements/src/GeometricElement.cs
+++ b/Elements/src/GeometricElement.cs
@@ -3,7 +3,7 @@ using Elements.Geometry;
 
 namespace Elements
 {
-    public abstract partial class GeometricElement
+    public partial class GeometricElement
     {
         /// <summary>
         /// This method provides an opportunity for geometric elements
@@ -24,7 +24,7 @@ namespace Elements
         /// <param name="name">The name of this element instance.</param>
         public ElementInstance CreateInstance(Transform transform, string name)
         {
-            if(!this.IsElementDefinition)
+            if (!this.IsElementDefinition)
             {
                 throw new Exception($"An instance cannot be created of the type {this.GetType().Name} because it is not marked as an element definition. Set the IsElementDefinition flag to true.");
             }

--- a/Elements/test/ModelTests.cs
+++ b/Elements/test/ModelTests.cs
@@ -245,6 +245,31 @@ namespace Elements.Tests
             Assert.Empty(newModel.AllElementsOfType<Column>());
         }
 
+        [Fact]
+        public void DeserializesToGeometricElementsWhenTypeIsUnknownAndRepresentationExists()
+        {
+            var profile = new Profile(Polygon.Rectangle(1, 1));
+            var red = new Material("Red", Colors.Red);
+            var green = new Material("Green", Colors.Green);
+            var column = new Column(new Vector3(5, 0), 5, profile, red);
+            var beam = new Beam(new Line(Vector3.Origin, new Vector3(5, 5, 5)), profile, green);
+            var model = new Model();
+            model.AddElements(beam, column);
+            var json = model.ToJson(true);
+            this._output.WriteLine(json);
+
+            // We want to test that unknown element types will still deserialize 
+            // to geometric elements.
+            json = json.Replace("Elements.Beam", "Foo");
+            json = json.Replace("Elements.Column", "Bar");
+
+            var newModel = Model.FromJson(json);
+            Assert.Equal(2, newModel.AllElementsOfType<Material>().Count());
+            Assert.Equal(2, newModel.AllElementsOfType<GeometricElement>().Count());
+            var modelPath = $"models/geometric_elements.glb";
+            newModel.ToGlTF(modelPath, true);
+        }
+
         private Model QuadPanelModel()
         {
             var model = new Model();


### PR DESCRIPTION
BACKGROUND:
For Python functions, we want to be able to generate geometry from a JSON. Currently, deserializing into types that inherit from `GeometricElement` requires having a concrete type available in the context into which you can deserialize. This is not necessary as all `GeometricElement` have a `Representation` property that contains the geometry required to visualize.

DESCRIPTION:
This PR adds another fall-through case on the JSON converter that attempts to build a `GeometricElement` if the type can't be deserialized using the typical routes. As an example, I exported the Simple Tower project to JSON and deserialized it using the updated converter, then saved to a .glb. The result can be seen below. This model contains a number of types (`Envelope`, `Level`, and `FacadePanel`) that were not available during deserialization, but you can see that the resulting .glb includes representations of all of these.

![image](https://user-images.githubusercontent.com/1139788/90195680-f4bf0a80-dd7e-11ea-924d-25fa00932fca.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/369)
<!-- Reviewable:end -->
