### PR TITLE
Gen separate files

### DIFF
--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -569,7 +569,7 @@ using Hypar.Functions.Execution.AWS;", "");
                     }
                     var userElementAttribute = $"[UserElement]\n\t";
                     file = file.Insert(start, userElementAttribute);
-                    start += userElementAttribute.Length;  // increment chars to get past the recent insertion
+                    start += userElementAttribute.Length + 1;  // increment chars to get past the recent insertion
                 }
             }
 

--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -519,9 +519,20 @@ using Hypar.Functions;
 using Hypar.Functions.Execution;
 using Hypar.Functions.Execution.AWS;", "");
                 // Insert the UserElement attribute directly before
-                // 'public partial class <typeName>'
-                var start = file.IndexOf($"public partial class {typeName}");
-                file = file.Insert(start, $"[UserElement]\n\t");
+                // 'public partial class ' any time it occurs in the file
+                // because we may be generating code for multiple user types in 
+                // the same file.
+                var start = 0;
+                while (true)
+                {
+                    start = file.IndexOf($"public partial class ", start);
+                    if (start == -1)
+                    {
+                        break;
+                    }
+                    file = file.Insert(start, $"[UserElement]\n\t");
+                    start += 16;  // increment chars to get past the recent insertion
+                }
             }
 
             if (typeName == "Model")

--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -13,6 +13,7 @@ using NJsonSchema;
 using NJsonSchema.CodeGeneration.CSharp;
 using Elements.Generate.StringUtils;
 using NJsonSchema.CodeGeneration;
+using NJsonSchema.CodeGeneration.CSharp.Models;
 
 namespace Elements.Generate.StringUtils
 {
@@ -261,13 +262,12 @@ namespace Elements.Generate
             }
 
             var typeName = schema.Title;
-            var filePath = Path.Combine(outputBaseDir, GetFileNameFromTypeName(typeName));
             if (_coreTypeNames == null)
             {
                 _coreTypeNames = GetCoreTypeNames();
             }
             var excludedTypeNames = _coreTypeNames.Where(n => n != typeName).ToArray();
-            return WriteTypeFromSchemaToDisk(schema, filePath, typeName, ns, isUserElement, excludedTypeNames);
+            return WriteTypeFromSchemaToDisk(schema, outputBaseDir, typeName, ns, isUserElement, excludedTypeNames);
         }
 
         /// <summary>
@@ -296,7 +296,7 @@ namespace Elements.Generate
         public static async Task<CompilationResult> GenerateInMemoryAssemblyFromUrisAndLoadAsync(string[] uris, bool frameworkBuild = false)
         {
             // https://docs.microsoft.com/en-us/archive/msdn-magazine/2017/may/net-core-cross-platform-code-generation-with-roslyn-and-net-core
-            var code = new List<string>();
+            var code = new Dictionary<string, string>();
             foreach (var uri in uris)
             {
                 // TODO: We can refactor this inner loop to share the code
@@ -307,12 +307,15 @@ namespace Elements.Generate
                 try
                 {
                     var schema = await GetSchemaAsync(uri);
-                    string csharp = GenerateCSharpCodeForSchema(schema);
-                    if (csharp == null)
+                    var csharpFileContents = GenerateCSharpCodeForSchema(schema);
+                    foreach (var csharp in csharpFileContents)
                     {
-                        continue;
+                        if (code.ContainsKey(csharp.Key))
+                        {
+                            continue;
+                        }
+                        code[csharp.Key] = csharp.Value;
                     }
-                    code.Add(csharp);
                 }
                 catch (Exception ex)
                 {
@@ -328,7 +331,7 @@ namespace Elements.Generate
                 }
             }
 
-            var compilation = GenerateCompilation(code, frameworkBuild: frameworkBuild);
+            var compilation = GenerateCompilation(code.Values.ToList(), frameworkBuild: frameworkBuild);
 
             if (TryEmitAndLoad(compilation, out Assembly assembly, out string[] diagnosticResults))
             {
@@ -361,18 +364,21 @@ namespace Elements.Generate
         {
             // https://docs.microsoft.com/en-us/archive/msdn-magazine/2017/may/net-core-cross-platform-code-generation-with-roslyn-and-net-core
 
-            var code = new List<string>();
+            var code = new Dictionary<string, string>();
             foreach (var uri in uris)
             {
                 try
                 {
                     var schema = await GetSchemaAsync(uri);
-                    string csharp = GenerateCSharpCodeForSchema(schema);
-                    if (csharp == null)
+                    var csharpFileContents = GenerateCSharpCodeForSchema(schema);
+                    foreach (var csharp in csharpFileContents)
                     {
-                        continue;
+                        if (code.ContainsKey(csharp.Key))
+                        {
+                            continue;
+                        }
+                        code[csharp.Key] = csharp.Value;
                     }
-                    code.Add(csharp);
                 }
                 catch (Exception ex)
                 {
@@ -388,7 +394,7 @@ namespace Elements.Generate
                 }
             }
 
-            var compilation = GenerateCompilation(code, frameworkBuild: frameworkBuild);
+            var compilation = GenerateCompilation(code.Values.ToList(), frameworkBuild: frameworkBuild);
 
             if (TryEmitAndSave(compilation, dllPath, out string[] diagnosticResults))
             {
@@ -463,7 +469,7 @@ namespace Elements.Generate
             }
             else
             {
-                var path = Path.GetFullPath(Path.Combine(System.Environment.CurrentDirectory, uri));
+                var path = Path.GetFullPath(Path.Combine(Assembly.GetExecutingAssembly().Location, uri));
                 if (!File.Exists(path))
                 {
                     throw new Exception($"The specified schema, {uri}, can not be found as a relative file or a url.");
@@ -484,7 +490,7 @@ namespace Elements.Generate
             return true;
         }
 
-        private static string WriteTypeFromSchema(JsonSchema schema, string typeName, string ns, bool isUserElement = false, string[] excludedTypes = null)
+        private static Dictionary<string, string> GetCodeForTypesFromSchema(JsonSchema schema, string typeName, string ns, bool isUserElement = false, string[] excludedTypes = null)
         {
             var templates = TemplatesPath;
 
@@ -495,7 +501,7 @@ namespace Elements.Generate
             // base class SolidOperation, or the Import class.
             var solidOpTypes = new[] { "Extrude", "Sweep", "Lamina" };
 
-            var generator = new CSharpGenerator(schema, new CSharpGeneratorSettings()
+            var settings = new CSharpGeneratorSettings()
             {
                 Namespace = ns,
                 ArrayType = "IList",
@@ -506,9 +512,38 @@ namespace Elements.Generate
                 ClassStyle = solidOpTypes.Contains(typeName) ? CSharpClassStyle.Inpc : CSharpClassStyle.Poco,
                 TypeNameGenerator = new ElementsTypeNameGenerator(),
                 PropertyNameGenerator = new ElementsPropertyNameGenerator(),
-            });
-            var file = generator.GenerateFile();
+            };
 
+            var generator = new CSharpGenerator(schema, settings);
+
+            var typeFiles = new Dictionary<string, string>();
+            var file = generator.GenerateFile();
+            var typeArtifacts = generator.GenerateTypes();
+
+            foreach (var fileArtifact in typeArtifacts)
+            {
+                if (String.IsNullOrWhiteSpace(fileArtifact.Code))
+                {
+                    continue;
+                }
+                // strategy for using templates taken from the NJsonSchema source 
+                // https://github.com/RicoSuter/NJsonSchema/blob/master/src/NJsonSchema.CodeGeneration.CSharp/CSharpGenerator.cs#L50
+                var model = new FileTemplateModel
+                {
+                    Namespace = settings.Namespace ?? string.Empty,
+                    TypesCode = fileArtifact.Code
+                };
+                var template = settings.TemplateFactory.CreateTemplate("CSharp", "File", model);
+                var code = template.Render();
+                var fileContents = FileTweaksAndCleanup(typeName, isUserElement, structTypes, code);
+                typeFiles[fileArtifact.TypeName] = fileContents;
+            }
+
+            return typeFiles;
+        }
+
+        private static string FileTweaksAndCleanup(string typeName, bool isUserElement, string[] structTypes, string file)
+        {
             if (isUserElement)
             {
                 // remove unncessary imports
@@ -554,15 +589,32 @@ using Hypar.Functions.Execution.AWS;", "");
             return file;
         }
 
-        private static GenerationResult WriteTypeFromSchemaToDisk(JsonSchema schema, string outPath, string typeName, string ns, bool isUserElement = false, string[] excludedTypes = null)
+        private static GenerationResult WriteTypeFromSchemaToDisk(JsonSchema schema, string outDirPath, string typeName, string ns, bool isUserElement = false, string[] excludedTypes = null)
         {
-            Console.WriteLine($"Generating type {@ns}.{typeName} in {outPath}...");
-            var type = WriteTypeFromSchema(schema, typeName, ns, isUserElement, excludedTypes);
-            File.WriteAllText(outPath, type);
+            var diagnosticMessages = new List<string>();
+            Console.WriteLine($"Generating type {@ns}.{typeName} in {outDirPath}...");
+            var typeCodeDict = GetCodeForTypesFromSchema(schema, typeName, ns, isUserElement, excludedTypes);
+            foreach (var kvp in typeCodeDict)
+            {
+                var path = Path.Combine(outDirPath, $"{kvp.Key}.g.cs");
+                if (File.Exists(path))
+                {
+                    continue;
+                }
+                try
+                {
+
+                    File.WriteAllText(path, kvp.Value);
+                }
+                catch (IOException ioe)
+                {
+                    diagnosticMessages.Add($"{typeName} failed to write, possibly because it was already being written to disk.");
+                }
+            }
             return new GenerationResult
             {
                 Success = true,
-                FilePath = outPath,
+                FilePath = outDirPath,
                 DiagnosticResults = new string[0]
             };
         }
@@ -607,17 +659,17 @@ using Hypar.Functions.Execution.AWS;", "");
         /// <returns>Returns true if the dll was generated successfully, otherwise false.</returns>
         public static bool GenerateAndSaveDllForSchema(JsonSchema schema, string dllPath, out string[] diagnosticResults, bool frameworkBuild = false)
         {
-            var csharp = GenerateCSharpCodeForSchema(schema);
-            if (csharp == null)
+            var csharpFileContents = GenerateCSharpCodeForSchema(schema);
+            if (csharpFileContents == null)
             {
                 diagnosticResults = new string[] { };
                 return false;
             }
-            var compilation = GenerateCompilation(new List<string> { csharp }, schema.Title, frameworkBuild);
+            var compilation = GenerateCompilation(csharpFileContents.Select(kvp => kvp.Value).ToList(), schema.Title, frameworkBuild);
             return TryEmitAndSave(compilation, dllPath, out diagnosticResults);
         }
 
-        private static string GenerateCSharpCodeForSchema(JsonSchema schema)
+        private static Dictionary<string, string> GenerateCSharpCodeForSchema(JsonSchema schema)
         {
             string ns;
             if (!GetNamespace(schema, out ns))
@@ -632,10 +684,10 @@ using Hypar.Functions.Execution.AWS;", "");
             }
 
             var loadedTypes = GetLoadedElementTypes(true).Select(t => t.Name);
-            if (loadedTypes.Contains(typeName)) return null;
+            if (loadedTypes.Contains(typeName)) return new Dictionary<string, string>();
             var localExcludes = _coreTypeNames.Where(n => n != typeName).ToArray();
 
-            return WriteTypeFromSchema(schema, typeName, ns, true, localExcludes);
+            return GetCodeForTypesFromSchema(schema, typeName, ns, true, localExcludes);
         }
 
         private static CSharpCompilation GenerateCompilation(List<string> code, string compilationName = "UserElements", bool frameworkBuild = false)

--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -517,7 +517,7 @@ namespace Elements.Generate
             var generator = new CSharpGenerator(schema, settings);
 
             var typeFiles = new Dictionary<string, string>();
-            // still need this call to GenerateFile() even though we don't use the files
+            // We still need this call to GenerateFile() even though we don't use the file's
             // text.  It is already a documented issue https://github.com/RicoSuter/NJsonSchema/issues/893
             var file = generator.GenerateFile();
             var typeArtifacts = generator.GenerateTypes();

--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -414,7 +414,6 @@ namespace Elements.Generate
             }
         }
 
-
         /// <summary>
         /// Generate the core element types as .cs files to the specified output directory.
         /// </summary>
@@ -517,6 +516,8 @@ namespace Elements.Generate
             var generator = new CSharpGenerator(schema, settings);
 
             var typeFiles = new Dictionary<string, string>();
+            // still need this call to GenerateFile() even though we don't use the files
+            // text.  It is already a documented issue https://github.com/RicoSuter/NJsonSchema/issues/893
             var file = generator.GenerateFile();
             var typeArtifacts = generator.GenerateTypes();
 

--- a/Elements.CodeGeneration/test/TypeGeneratorTests.cs
+++ b/Elements.CodeGeneration/test/TypeGeneratorTests.cs
@@ -90,6 +90,29 @@ namespace Elements.Tests
     },
     ""additionalProperties"": false
 }";
+        /// <summary>
+        /// The embeddedSchemaTest2 demonstrates a schema that references the same  
+        /// schema that will be referenced in embeddedSchemaTest above at the same time.
+        /// </summary>
+        const string embeddedSchemaTest2 = @"{
+    ""$id"": ""https://hypar.io/Schemas/Truss.json"",
+    ""$schema"": ""http://json-schema.org/draft-07/schema#"",
+    ""description"": ""A test of schema embedding."",
+    ""title"": ""EmbeddedSchemaTestSecond"",
+    ""x-namespace"": ""Elements"",
+    ""type"": [""object"", ""null""],
+    ""allOf"": [{""$ref"": ""https://hypar.io/Schemas/GeometricElement.json""}],
+    ""required"": [""Panels""],
+    ""properties"": {
+        ""Panels"": {
+            ""type"": ""array"",
+            ""items"": {
+                ""$ref"": ""https://raw.githubusercontent.com/hypar-io/Schemas/master/FacadePanel.json""
+            }
+        }
+    },
+    ""additionalProperties"": false
+}";
         private ITestOutputHelper output;
 
         public TypeGeneratorTests(ITestOutputHelper output)
@@ -146,20 +169,53 @@ namespace Elements.Tests
         public async Task CodeGenerationOfTypeWithEmbeddedType()
         {
             var tmpPath = Path.Combine(Path.GetTempPath(), "HyparModels");
+            string relEmbeddedSchemaTestPath = RelativeSavedSchemaPath(embeddedSchemaTest, tmpPath, "embeddedSchemaTest.json");
+            string relEmbeddedSchemaTestPath2 = RelativeSavedSchemaPath(embeddedSchemaTest2, tmpPath, "embeddedSchemaTest2.json");
+
+            // Generate the truss type which contains the beam type.
+            await TypeGenerator.GenerateUserElementTypesFromUrisAsync(new[] { relEmbeddedSchemaTestPath, relEmbeddedSchemaTestPath2, "https://raw.githubusercontent.com/hypar-io/Schemas/master/FacadePanel.json" }, tmpPath, true);
+            // Ensure that there is only one beam.g.cs in the output.
+            Assert.Equal(3, Directory.GetFiles(tmpPath, "*.g.cs").Length);
+
+        }
+
+        [Fact]
+        public async Task InMemoryCodeGenOfTypeWithEmbeddedType()
+        {
+            var tmpPath = Path.Combine(Path.GetTempPath(), "HyparModels");
+            string relEmbeddedSchemaTestPath = RelativeSavedSchemaPath(embeddedSchemaTest, tmpPath, "embeddedSchemaTest.json");
+            string relEmbeddedSchemaTestPath2 = RelativeSavedSchemaPath(embeddedSchemaTest2, tmpPath, "embeddedSchemaTest2.json");
+
+            // Load schemas in memeory.
+            var asm = await TypeGenerator.GenerateInMemoryAssemblyFromUrisAndLoadAsync(new[] { relEmbeddedSchemaTestPath, relEmbeddedSchemaTestPath2 });
+            Assert.True(asm.Success);
+            var facadeType = asm.Assembly.GetType("Elements.FacadePanel");
+            Assert.NotNull(facadeType);
+        }
+
+        [Fact]
+        public async Task SaveDllCodeGenOfTypeWithEmbeddedType()
+        {
+            var tmpPath = Path.Combine(Path.GetTempPath(), "HyparModels");
+            string relEmbeddedSchemaTestPath = RelativeSavedSchemaPath(embeddedSchemaTest, tmpPath, "embeddedSchemaTest.json");
+            string relEmbeddedSchemaTestPath2 = RelativeSavedSchemaPath(embeddedSchemaTest2, tmpPath, "embeddedSchemaTest2.json");
+
+            // Save dll for schemas.
+            var dllPath = Path.Combine(tmpPath, "userElements.dll");
+            var asm2 = await TypeGenerator.GenerateInMemoryAssemblyFromUrisAndSaveAsync(new[] { relEmbeddedSchemaTestPath, relEmbeddedSchemaTestPath2 }, dllPath);
+            Assert.True(asm2.Success);
+        }
+
+        private static string RelativeSavedSchemaPath(string schema, string tmpPath, string fileName)
+        {
             if (!Directory.Exists(tmpPath))
             {
                 Directory.CreateDirectory(tmpPath);
             }
-
             var embeddedSchemaTestPath = Path.Combine(tmpPath, "embeddedSchemaTest.json");
             var relEmbeddedSchemaTestPath = Path.GetRelativePath(Assembly.GetExecutingAssembly().Location, embeddedSchemaTestPath);
-            File.WriteAllText(embeddedSchemaTestPath, embeddedSchemaTest);
-
-            // Generate the truss type which contains the beam type
-            await TypeGenerator.GenerateUserElementTypesFromUrisAsync(new[] { relEmbeddedSchemaTestPath, "https://raw.githubusercontent.com/hypar-io/Schemas/master/FacadePanel.json" }, tmpPath, true);
-
-            // Ensure that there is only one beam.g.cs in the output.
-            Assert.Equal(2, Directory.GetFiles(tmpPath, "*.g.cs").Length);
+            File.WriteAllText(embeddedSchemaTestPath, schema);
+            return relEmbeddedSchemaTestPath;
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- Coge gen failed when there were two schemas that each referenced another, because that last, referenced, schema would be duplicated when it existed in both classes

DESCRIPTION:
- Improve testing of multi-schema code gen
- Use the TypeArtifact from NJson generator to get the code for each type
- Use the templating tools directly to get the code for each file

TESTING:
- pull the branch and run the tests
- I have also used this local CLI to publish aliaxis functions that will break otherwise.
  
FUTURE WORK:
- Still have not completed the refactor of AssemblySave / AssemblyLoad that should merge their inner loops.  I'd like to do a file-reorg as well.


COMMENTS:
- Although I have tests for generating in-memory code and saving dlls, no guaruntee that when Excel and GH go to use this new version of Elements they will work smoothly, although the tests should help us have a good start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/370)
<!-- Reviewable:end -->
