### PR TITLE
Fix build after separation from core.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,16 @@
+<Project>
+  <PropertyGroup>
+    <Authors>Hypar, Inc.</Authors>
+    <Company>Hypar, Inc.</Company>
+    <Copyright>Hypar, Inc. 2020</Copyright>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>AEC, Architecture, Structure, Engineering</PackageTags>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageOutputPath>$(SolutionDir)nupkg</PackageOutputPath>
+    <PackageProjectUrl>https://github.com/hypar-io/CLI</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/hypar-io/CLI</RepositoryUrl>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>$(Version)</Version>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
After removing Elements as a submodule from Hypar, the build script no longer placed a `/nupkg` folder with the built packages at the root of the Elements directory. This was due to the lack of the `Directory.Build.Props` file which, in addition to specifying where to put the built packages also specified the version number for the build. This PR adds a `Directory.Build.props` file identical to the one in Hypar so that the build script works correctly when run from Hypar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/371)
<!-- Reviewable:end -->
