### PR TITLE
fix void orientation for profiles and profile orientation for extrudes

### DIFF
--- a/Elements/src/Geometry/Kernel.cs
+++ b/Elements/src/Geometry/Kernel.cs
@@ -39,6 +39,10 @@ namespace Elements.Geometry
         /// <returns>A solid.</returns>
         public Solid CreateExtrude(Profile profile, double depth, Vector3 direction)
         {
+            if (profile.Perimeter.Normal().Dot(direction) < 0)
+            {
+                profile = profile.Reversed();
+            }
             return Solid.SweepFace(profile.Perimeter, profile.Voids, direction, depth, false);
         }
 

--- a/Elements/src/Geometry/Profile.cs
+++ b/Elements/src/Geometry/Profile.cs
@@ -70,6 +70,7 @@ namespace Elements.Geometry
             var voids = indices.Except(outerMostIndices).Select(i => polygons[i]);
             this.Perimeter = perimeter;
             this.Voids = voids.ToList();
+            OrientVoids();
         }
 
         /// <summary>
@@ -85,7 +86,7 @@ namespace Elements.Geometry
         /// <summary>
         /// Get a new profile which is the reverse of this profile.
         /// </summary>
-        public Profile Reverse()
+        public Profile Reversed()
         {
             Polygon[] voids = null;
             if (this.Voids != null)
@@ -191,6 +192,28 @@ namespace Elements.Geometry
                 this.Perimeter = polys[0];
                 this.Voids = polys.Skip(1).ToArray();
             }
+        }
+
+        /// <summary>
+        /// Ensure that voids run in an opposite winding direction to the perimeter of the profile.
+        /// Be sure to call this if you modify the Profile's Voids array directly.
+        /// </summary>
+        public void OrientVoids()
+        {
+            var correctedVoids = new List<Polygon>();
+            var perimeterIsClockwise = Perimeter.IsClockWise();
+            foreach (var voidCrv in Voids)
+            {
+                if (voidCrv.IsClockWise() == perimeterIsClockwise)
+                {
+                    correctedVoids.Add(voidCrv.Reversed());
+                }
+                else
+                {
+                    correctedVoids.Add(voidCrv);
+                }
+            }
+            this.Voids = correctedVoids;
         }
 
         private double ClippedArea()

--- a/Elements/src/Geometry/Profile.cs
+++ b/Elements/src/Geometry/Profile.cs
@@ -201,10 +201,10 @@ namespace Elements.Geometry
         public void OrientVoids()
         {
             var correctedVoids = new List<Polygon>();
-            var perimeterIsClockwise = Perimeter.IsClockWise();
+            var perimeterNormal = Perimeter.Normal();
             foreach (var voidCrv in Voids)
             {
-                if (voidCrv.IsClockWise() == perimeterIsClockwise)
+                if (voidCrv.Normal().Dot(perimeterNormal) > 0)
                 {
                     correctedVoids.Add(voidCrv.Reversed());
                 }

--- a/Elements/src/Validators/Validators.cs
+++ b/Elements/src/Validators/Validators.cs
@@ -76,6 +76,7 @@ namespace Elements.Validators
             {
                 profile.Voids = new List<Polygon>();
             }
+            profile.OrientVoids();
         }
 
         public void PreConstruct(object[] args)
@@ -83,7 +84,7 @@ namespace Elements.Validators
             var perimeter = (Polygon)args[0];
             if (perimeter != null && !perimeter.Vertices.AreCoplanar())
             {
-                throw new Exception("To construct a profile, all points must line in the same plane.");
+                throw new Exception("To construct a profile, all points must lie in the same plane.");
             }
         }
     }

--- a/Elements/test/ProfileTests.cs
+++ b/Elements/test/ProfileTests.cs
@@ -48,5 +48,47 @@ namespace Elements.Tests
 
             Assert.Equal(8, seed.Voids.Count());
         }
+
+        [Fact]
+        public void VoidsOrientedCorrectly()
+        {
+            this.Name = "VoidsOrientedCorrectly";
+            var outerRing = new Polygon(new[]
+            {
+                new Vector3(0,0,0),
+                new Vector3(10,0,0),
+                new Vector3(10,10,0),
+                new Vector3(0,10,0),
+            });
+            var innerRing1 = new Polygon(new[]
+            {
+                new Vector3(2,2,0),
+                new Vector3(4,2,0),
+                new Vector3(4,4,0),
+                new Vector3(2,4,0),
+            });
+            var innerRing2 = new Polygon(new[]
+            {
+                new Vector3(8,8,0),
+                new Vector3(8,6,0),
+                new Vector3(6,6,0),
+                new Vector3(6,8,0)
+            });
+
+            var profile1 = new Profile(new Polygon[] { innerRing2, outerRing, innerRing1 });
+            var profile2 = new Profile(outerRing.Reversed(), new[] { innerRing1, innerRing2 }, Guid.NewGuid(), null);
+            foreach (var profile in new[] { profile1, profile2 })
+            {
+                foreach (var curve in profile.Voids)
+                {
+                    Assert.NotEqual(curve.IsClockWise(), profile.Perimeter.IsClockWise());
+                }
+            }
+
+            var mass1 = new Mass(profile1, 1);
+            var mass2 = new Mass(profile2, 1, null, new Transform(0, 0, 10));
+            Model.AddElement(mass1);
+            Model.AddElement(mass2);
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- There was a bug that permitted profile voids to be oriented incorrectly relative to the outer perimeter, such that holes would not show up in an extrude. (Fixes https://github.com/hypar-io/Elements/issues/372) 
-  fixes https://github.com/hypar-io/Elements/issues/373

DESCRIPTION:
- Fixes void orientation relative to the perimeter with an OrientVoids() method that gets called in the constructor.
- Rename Profile.Reverse() => Profile.Reversed() for consistency
- Check profile normal before doing an extrude, and flip if they are anti-parallel to prevent inside-out extrusions
- adds a new test to verify that void orientation is corrected in the Profile constructor.

TESTING:
- Create a profile with voids oriented the same way as the perimeter — check that the voids get re-oriented to be consistent
- Create an extrusion in the +Z with a clockwise profile — it should correct itself

COMMENTS:
- Since a user can modify the voids array / the perimeter directly, it's still possible to wind up with an invalid profile/void relationship, but this should cover most cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/374)
<!-- Reviewable:end -->
