### PR TITLE
add InputSchema to known types

### DIFF
--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -173,6 +173,7 @@ namespace Elements.Generate
                 "https://hypar.io/Schemas/Material.json",
                 "https://hypar.io/Schemas/Model.json",
                 "https://hypar.io/Schemas/Geometry/Matrix.json",
+                "https://hypar.io/Schemas/InputData.json",
                 "https://geojson.org/schema/Point.json",
             };
 


### PR DESCRIPTION
BACKGROUND:
- In order to support data inputs on input_schema, we need to 
1. publish the InputData class as a schema https://github.com/hypar-io/Hypar/pull/253,
and 2. add it to the list of known types that codegen shouldn't generate (this PR)

TESTING:
Have built the CLI with this change, and tried building a function that refers to the InputData schema and tested that it successfully builds the inputs class with a proper reference to the built-in type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/375)
<!-- Reviewable:end -->
