### PR TITLE
handle missing type titles

### DIFF
--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -124,7 +124,7 @@ namespace Elements.Generate
         public string Generate(JsonSchema schema, string typeNameHint, IEnumerable<string> reservedTypeNames)
         {
             // Console.WriteLine(typeNameHint + ":" + schema.InheritedSchema ?? "none");
-            if (schema.IsEnumeration)
+            if (schema.IsEnumeration || String.IsNullOrEmpty(schema.Title))
             {
                 return typeNameHint;
             }


### PR DESCRIPTION
BACKGROUND:
- Element Types that had any a nested portion of their schema lacking a "Title" property would fail codegen.  

DESCRIPTION:
- use the type hint name if the schema title is null or empty

TESTING:
- previously, this schema would fail codegen: 

```json
{
    "$id": "https://hypar.io/Schemas/MeshList.json",
    "$schema": "http://json-schema.org/draft-07/schema#",
    "description": "Data from a file input.",
    "x-namespace": "Hypar.Functions.Execution",
    "title": "MeshList",
    "type": "object",
    "properties": {
        "meshes": {
            "type": "array",
            "$ref": "https://hypar.io/Schemas/Mesh.json"
        }
    },
    "additionalProperties": false
}
```
 
 - now it works

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/378)
<!-- Reviewable:end -->
