### PR TITLE
Add a static "Union" method accepting only one list of polygons

### DIFF
--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -373,6 +373,17 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Constructs the geometric union of a set of polygons.
+        /// </summary>
+        /// <param name="polygons">The polygons to union</param>
+        /// <param name="tolerance">An optional tolerance.</param>
+        /// <returns>Returns a list of Polygons representing the union of all polygons.</returns>
+        public static IList<Polygon> Union(IList<Polygon> polygons, double tolerance = Vector3.EPSILON)
+        {
+            return Union(polygons, new List<Polygon> { }, tolerance);
+        }
+
+        /// <summary>
         /// Returns Polygons representing the symmetric difference between two sets of polygons.
         /// </summary>
         /// <param name="firstSet">First set of polygons</param>

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -367,6 +367,7 @@ namespace Elements.Geometry
         /// <param name="secondSet">Second set of polygons</param>
         /// <param name="tolerance">An optional tolerance.</param>
         /// <returns>Returns a list of Polygons representing the union of both sets of polygons.</returns>
+        [Obsolete("Please use the version of this method that takes a single list of polygons.")]
         public static IList<Polygon> Union(IList<Polygon> firstSet, IList<Polygon> secondSet, double tolerance = Vector3.EPSILON)
         {
             return BooleanTwoSets(firstSet, secondSet, BooleanMode.Union, tolerance);
@@ -380,7 +381,7 @@ namespace Elements.Geometry
         /// <returns>Returns a list of Polygons representing the union of all polygons.</returns>
         public static IList<Polygon> Union(IList<Polygon> polygons, double tolerance = Vector3.EPSILON)
         {
-            return Union(polygons, new List<Polygon> { }, tolerance);
+            return BooleanTwoSets(polygons, new List<Polygon>(), BooleanMode.Union, tolerance);
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -367,7 +367,7 @@ namespace Elements.Geometry
         /// <param name="secondSet">Second set of polygons</param>
         /// <param name="tolerance">An optional tolerance.</param>
         /// <returns>Returns a list of Polygons representing the union of both sets of polygons.</returns>
-        [Obsolete("Please use the version of this method that takes a single list of polygons.")]
+        [Obsolete("Please use UnionAll, which takes a single list of polygons.")]
         public static IList<Polygon> Union(IList<Polygon> firstSet, IList<Polygon> secondSet, double tolerance = Vector3.EPSILON)
         {
             return BooleanTwoSets(firstSet, secondSet, BooleanMode.Union, tolerance);
@@ -379,7 +379,7 @@ namespace Elements.Geometry
         /// <param name="polygons">The polygons to union</param>
         /// <param name="tolerance">An optional tolerance.</param>
         /// <returns>Returns a list of Polygons representing the union of all polygons.</returns>
-        public static IList<Polygon> Union(IList<Polygon> polygons, double tolerance = Vector3.EPSILON)
+        public static IList<Polygon> UnionAll(IList<Polygon> polygons, double tolerance = Vector3.EPSILON)
         {
             return BooleanTwoSets(polygons, new List<Polygon>(), BooleanMode.Union, tolerance);
         }


### PR DESCRIPTION
BACKGROUND:
- Sometimes you just have a bunch of polygons and you want to union them together — there's no distinct "set A" and "set B"

DESCRIPTION:
- Creates an additional method that simply calls the existing union method with the second list empty

TESTING:
- Have tested the "second list empty" method in my own functions, it works as expected

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/379)
<!-- Reviewable:end -->
