### PR TITLE
Nuget fix

### DIFF
--- a/Elements.CodeGeneration/src/CompilationResult.cs
+++ b/Elements.CodeGeneration/src/CompilationResult.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+
+namespace Elements.Generate
+{
+    /// <summary>
+    /// The result of a compilation.
+    /// </summary>
+    public struct CompilationResult
+    {
+        /// <summary>
+        /// True if the compilation succeeded.
+        /// </summary>
+        public bool Success { get; internal set; }
+        /// <summary>
+        /// The Assembly loaded from the compilation, if successful.
+        /// </summary>
+        public Assembly Assembly { get; internal set; }
+        /// <summary>
+        /// Any messages or errors that arose during compilation.
+        /// </summary>
+        public string[] DiagnosticResults { get; internal set; }
+    }
+}

--- a/Elements.CodeGeneration/src/Elements.CodeGeneration.csproj
+++ b/Elements.CodeGeneration/src/Elements.CodeGeneration.csproj
@@ -28,6 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- Nuget solution using build targets came from here https://stackoverflow.com/questions/51924129/copy-files-from-nuget-package-to-output-directory-with-msbuild-in-csproj-and-do  -->
         <Content Include="Elements.CodeGeneration.targets" PackagePath="build/Hypar.Elements.CodeGeneration.targets" />
         <Content Include="Templates\**\*.*">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Elements.CodeGeneration/src/Elements.CodeGeneration.csproj
+++ b/Elements.CodeGeneration/src/Elements.CodeGeneration.csproj
@@ -1,35 +1,38 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>Hypar.Elements.CodeGeneration</AssemblyName>
-    <PackageTitle>Hypar Elements Code Generation</PackageTitle>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Title>Hypar Elements Code Generation</Title>
-    <PackageId>Hypar.Elements.CodeGeneration</PackageId>
-    <PackageDescription>Code generation utilities for Hypar.Elements.</PackageDescription>
-    <Summary>Code generation utilities for Hypar.Elements.</Summary>
-    <PackageProjectUrl>https://github.com/hypar-io/elements</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/hypar-io/elements</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <Version>$(Version)</Version>
-    <PackageOutputPath>../../nupkg</PackageOutputPath>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <AssemblyName>Hypar.Elements.CodeGeneration</AssemblyName>
+        <PackageTitle>Hypar Elements Code Generation</PackageTitle>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <Title>Hypar Elements Code Generation</Title>
+        <PackageId>Hypar.Elements.CodeGeneration</PackageId>
+        <PackageDescription>Code generation utilities for Hypar.Elements.</PackageDescription>
+        <Summary>Code generation utilities for Hypar.Elements.</Summary>
+        <PackageProjectUrl>https://github.com/hypar-io/elements</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/hypar-io/elements</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <Version>$(Version)</Version>
+        <PackageOutputPath>../../nupkg</PackageOutputPath>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="NJsonSchema.CodeGeneration" Version="10.1.21" />
-    <PackageReference Include="NJsonSchema.CodeGeneration.CSharp" Version="10.1.21" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.3.1" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="NJsonSchema.CodeGeneration" Version="10.1.21" />
+        <PackageReference Include="NJsonSchema.CodeGeneration.CSharp" Version="10.1.21" />
+        <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis" Version="3.3.1" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Elements\src\Elements.csproj" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Content Include="Templates\**\*.*">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\Elements\src\Elements.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="Elements.CodeGeneration.targets" PackagePath="build/Hypar.Elements.CodeGeneration.targets" />
+        <Content Include="Templates\**\*.*">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>contentFiles\Templates</PackagePath>
+        </Content>
+    </ItemGroup>
 </Project>

--- a/Elements.CodeGeneration/src/Elements.CodeGeneration.targets
+++ b/Elements.CodeGeneration/src/Elements.CodeGeneration.targets
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <ItemGroup>
+        <TemplateFiles Include="$(MSBuildThisFileDirectory)\..\contentFiles\Templates\*.*" />
+    </ItemGroup>
+    <Target Name="CopyTemplateFiles" BeforeTargets="Build">
+        <Copy SourceFiles="@(TemplateFiles)" DestinationFolder="$(TargetDir)Templates\" />
+    </Target>
+</Project>

--- a/Elements.CodeGeneration/src/GenerationResult.cs
+++ b/Elements.CodeGeneration/src/GenerationResult.cs
@@ -1,0 +1,21 @@
+namespace Elements.Generate
+{
+    /// <summary>
+    /// The result of code generation.
+    /// </summary>
+    public struct GenerationResult
+    {
+        /// <summary>
+        /// True if the code was generated successfully.
+        /// </summary>
+        public bool Success { get; internal set; }
+        /// <summary>
+        /// The file path to the generated code.
+        /// </summary>
+        public string FilePath { get; internal set; }
+        /// <summary>
+        /// Any messages or errors that arose during code generation.
+        /// </summary>
+        public string[] DiagnosticResults { get; internal set; }
+    }
+}

--- a/Elements.CodeGeneration/src/HyparFilters.cs
+++ b/Elements.CodeGeneration/src/HyparFilters.cs
@@ -1,0 +1,46 @@
+
+using System.Collections.Generic;
+using System.Linq;
+using DotLiquid;
+using Elements.Generate.StringUtils;
+using NJsonSchema;
+
+namespace Elements.Generate
+{
+    // TODO Delete this HyparFilters class when this issue gets resolved. https://github.com/RicoSuter/NJsonSchema/issues/1199
+    // This HyparFilters class contains filters that are copied directly from the NJsonSchema repo
+    // because the filters are not public but we need to register them globally for async code gen.
+    // Copied from https://github.com/RicoSuter/NJsonSchema/blob/687efeabdc30ddacd235e85213f3594458ed48b4/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs#L183
+    public static class HyparFilters
+    {
+        public static string Lowercamelcase(Context context, string input, bool firstCharacterMustBeAlpha = true)
+        {
+            return ConversionUtilities.ConvertToLowerCamelCase(input, firstCharacterMustBeAlpha);
+        }
+
+        public static string Safeidentifierlower(Context context, string input, bool firstCharacterMustBeAlpha = true)
+        {
+            return input.ToSafeIdentifier(true);
+        }
+
+        public static string Safeidentifierupper(Context context, string input, bool firstCharacterMustBeAlpha = true)
+        {
+            return input.ToSafeIdentifier();
+        }
+
+        public static string Csharpdocs(string input, int tabCount)
+        {
+            return ConversionUtilities.ConvertCSharpDocs(input, tabCount);
+        }
+
+        public static IEnumerable<object> Empty(Context context, object input)
+        {
+            return Enumerable.Empty<object>();
+        }
+
+        public static string Tab(Context context, string input, int tabCount)
+        {
+            return ConversionUtilities.Tab(input, tabCount);
+        }
+    }
+}

--- a/Elements.CodeGeneration/src/StringUtilities.cs
+++ b/Elements.CodeGeneration/src/StringUtilities.cs
@@ -1,0 +1,62 @@
+
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Elements.Generate.StringUtils
+{
+    public static class StringUtilities
+    {
+        // TODO: This is a direct copy of the method in Hypar.Model.
+        // We should move type generation out of elements to a place where it can refer to Hypar.Model.
+        public static string ToSafeIdentifier(this string name, bool firstCharLowercase = false)
+        {
+            if (String.IsNullOrWhiteSpace(name) || String.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("Invalid name.");
+            }
+            //remove special characters except for space, dash, period, and underscore
+            name = Regex.Replace(name, @"[^A-Za-z0-9 _\.-]", "");
+            //remove any numbers or whitespace/separator characters from the front
+            while (Char.IsDigit(name.First()) || name.First() == ' ' || name.First() == '_' || name.First() == '-' || name.First() == '.')
+            {
+                if (name.Length < 2)
+                {
+                    throw new ArgumentException("Name is invalid: nothing is left after removing numeric characters. Names must contain at least one letter.");
+                }
+                name = name.Substring(1);
+            }
+            //split on whitespace or - or _
+            var splits = name.Split(new[] { ' ', '-', '_', '.' });
+            var cleanName = "";
+            var dontCapitalize = firstCharLowercase;
+            foreach (var split in splits)
+            {
+                if (split.Length == 0)
+                {
+                    continue;
+                }
+                if (dontCapitalize)
+                {
+                    cleanName += split.First().ToString().ToLower();
+                    dontCapitalize = false;
+                }
+                else
+                {
+                    cleanName += split.First().ToString().ToUpper();
+                }
+                if (split.Length > 1)
+                {
+                    cleanName += split.Substring(1);
+                }
+            }
+            if (string.IsNullOrEmpty(cleanName))
+            {
+                throw new ArgumentException("Names must have at least one letter character.");
+            }
+            return cleanName;
+        }
+
+    }
+
+}

--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -12,8 +12,6 @@ using NJsonSchema.CodeGeneration.CSharp;
 using Elements.Generate.StringUtils;
 using NJsonSchema.CodeGeneration;
 using NJsonSchema.CodeGeneration.CSharp.Models;
-using Elements.Geometry;
-
 
 namespace Elements.Generate
 {

--- a/Elements/src/Elements.csproj
+++ b/Elements/src/Elements.csproj
@@ -1,37 +1,37 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>Hypar.Elements</AssemblyName>
-    <PackageTitle>Hypar Elements</PackageTitle>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Title>Hypar Elements</Title>
-    <PackageId>Hypar.Elements</PackageId>
-    <PackageDescription>A building elements library for AEC.</PackageDescription>
-    <Summary>The Elements library provides object types for generating the built environment.</Summary>
-    <PackageProjectUrl>https://github.com/hypar-io/elements</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/hypar-io/elements</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <Version>$(Version)</Version>
-    <PackageOutputPath>../../nupkg</PackageOutputPath>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <AssemblyName>Hypar.Elements</AssemblyName>
+        <PackageTitle>Hypar Elements</PackageTitle>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <Title>Hypar Elements</Title>
+        <PackageId>Hypar.Elements</PackageId>
+        <PackageDescription>A building elements library for AEC.</PackageDescription>
+        <Summary>The Elements library provides object types for generating the built environment.</Summary>
+        <PackageProjectUrl>https://github.com/hypar-io/elements</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/hypar-io/elements</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <Version>$(Version)</Version>
+        <PackageOutputPath>../../nupkg</PackageOutputPath>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="glTF2Loader" Version="1.1.3-alpha" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
-    <PackageReference Include="Unofficial.LibTessDotNet" Version="2.0.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="glTF2Loader" Version="1.1.3-alpha" />
+        <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0" />
+        <PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
+        <PackageReference Include="Unofficial.LibTessDotNet" Version="2.0.0" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="Textures\**\*.*">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>   
-  </ItemGroup>
-  
-  <ItemGroup>
-    <None Update="UV.jpg" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
+    <ItemGroup>
+        <Content Include="Textures\**\*.*">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Update="UV.jpg" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
BACKGROUND:
- Export server in it's new location in the api repo needed to ref code gen via nuget package, not via local reference.  This didn't work because of missing templates.

DESCRIPTION:
- add a build target that is packaged with the nuget package.  Then when this package is referenced it calls this build target which copies the `Templates` directory into the bin folder of the consuming project.  See the file `Elements.CodeGeneration.targets` and the .csproj file for the meat of the nuget fix.
- Also refactor some classes into separate files.

TESTING:
- Tested with local nuget references in ExportServer, and also in a test proejct.
- Tested after deploying 0.8.0-alpha.7
  
FUTURE WORK:

COMMENTS:
- turns out this resolves a long standing unknown issue where code gen wouldn't work if done with Elements as a nuget package reference unless a custom templates folder was provided and set, as was the case in GrasshopperRunner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/388)
<!-- Reviewable:end -->
