### PR TITLE
copy on publish

### DIFF
--- a/Elements.CodeGeneration/src/Elements.CodeGeneration.targets
+++ b/Elements.CodeGeneration/src/Elements.CodeGeneration.targets
@@ -3,7 +3,10 @@
     <ItemGroup>
         <TemplateFiles Include="$(MSBuildThisFileDirectory)\..\contentFiles\Templates\*.*" />
     </ItemGroup>
-    <Target Name="CopyTemplateFiles" BeforeTargets="Build">
+    <Target Name="BuildCopyTemplateFiles" BeforeTargets="Build">
         <Copy SourceFiles="@(TemplateFiles)" DestinationFolder="$(TargetDir)Templates\" />
+    </Target>
+    <Target Name="PublishCopyTemplateFiles" BeforeTargets="Publish">
+        <Copy SourceFiles="@(TemplateFiles)" DestinationFolder="$(PublishDir)Templates\" />
     </Target>
 </Project>


### PR DESCRIPTION
BACKGROUND:
- sam deployment failed due to `publish` not copying the Templates folder the way `build` does.

DESCRIPTION:
- Include the copy target both before build and before publish

TESTING:
- Locally if you run dotnet publish with a project that references this nuget package the Templates folder will appear in the publish directory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/389)
<!-- Reviewable:end -->
