### PR TITLE
check missing texture and null mess

### DIFF
--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -136,7 +136,7 @@ namespace Elements.Serialization.glTF
                     };
                 }
 
-                if (material.Texture != null)
+                if (material.Texture != null && File.Exists(material.Texture))
                 {
                     // Add the texture
                     var ti = new TextureInfo();
@@ -903,6 +903,10 @@ namespace Elements.Serialization.glTF
                 var geo = (ITessellate)e;
                 var mesh = new Elements.Geometry.Mesh();
                 geo.Tessellate(ref mesh);
+                if (mesh == null)
+                {
+                    return;
+                }
 
                 byte[] vertexBuffer;
                 byte[] normalBuffer;


### PR DESCRIPTION
BACKGROUND:
- gltf exporting caused failures in the export server.

DESCRIPTION:
- don't add material with missing texture paths.
- ignore meshes where the mesh is null.

TESTING:
- the temporary stack ew-sand has an export server that uses this version of Elements, you can use this workflow to see two functions that normally break being exported.
https://dev.hypar.io/workflows/4442ed8d-b409-409c-96e3-b756b0491258?api=ew-export

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/390)
<!-- Reviewable:end -->
