### PR TITLE
refact and add new generatetypes from json

### DIFF
--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -109,6 +109,44 @@ namespace Elements.Generate
             set => _templatesPath = value;
         }
 
+        /// <summary>
+        /// Genereate a user  defined type in a .g.cs file directly from the json.
+        /// </summary>
+        /// <param name="schemaJson"></param>
+        /// <param name="outputBaseDir"></param>
+        /// <param name="isUserElement"></param>
+        /// <returns></returns>
+        public static async Task<GenerationResult> GenerateUserElementTypeFromJsonAsync(string schemaJson, string outputBaseDir, bool isUserElement = false)
+        {
+            DotLiquid.Template.DefaultIsThreadSafe = true;
+            DotLiquid.Template.RegisterFilter(typeof(HyparFilters));
+
+            var schema = await JsonSchema.FromJsonAsync(schemaJson);
+
+            return ValidateAndWriteTypeToDisk(schema, outputBaseDir, isUserElement);
+
+        }
+
+        private static GenerationResult ValidateAndWriteTypeToDisk(JsonSchema schema, string outputBaseDir, bool isUserElement)
+        {
+            string ns;
+            if (!GetNamespace(schema, out ns))
+            {
+                return new GenerationResult
+                {
+                    Success = false,
+                    DiagnosticResults = new[] { "The provided schema does not contain the required 'x-namespace' property." }
+                };
+            }
+
+            var typeName = schema.Title;
+            if (_coreTypeNames == null)
+            {
+                _coreTypeNames = GetCoreTypeNames();
+            }
+            var excludedTypeNames = _coreTypeNames.Where(n => n != typeName).ToArray();
+            return WriteTypeFromSchemaToDisk(schema, outputBaseDir, typeName, ns, isUserElement, excludedTypeNames);
+        }
 
         /// <summary>
         /// Generate a user-defined type in a .g.cs file from a schema.
@@ -127,23 +165,7 @@ namespace Elements.Generate
 
             var schema = await GetSchemaAsync(uri);
 
-            string ns;
-            if (!GetNamespace(schema, out ns))
-            {
-                return new GenerationResult
-                {
-                    Success = false,
-                    DiagnosticResults = new[] { "The provided schema does not contain the required 'x-namespace' property." }
-                };
-            }
-
-            var typeName = schema.Title;
-            if (_coreTypeNames == null)
-            {
-                _coreTypeNames = GetCoreTypeNames();
-            }
-            var excludedTypeNames = _coreTypeNames.Where(n => n != typeName).ToArray();
-            return WriteTypeFromSchemaToDisk(schema, outputBaseDir, typeName, ns, isUserElement, excludedTypeNames);
+            return ValidateAndWriteTypeToDisk(schema, outputBaseDir, isUserElement);
         }
 
         /// <summary>


### PR DESCRIPTION
BACKGROUND:
- We have made a way for authenticated users to retrieve a list of schemas from the schema endpoint, all schemas of a given tag.  We now need a method to generate types directly from the JSON that is sent back.

DESCRIPTION:
- refact the last half of `GenerateUserElementTypeFromUriAsync` and use it in the new public method

TESTING:
- use new CLI test from the PR in the hypar repo https://github.com/hypar-io/Hypar/pull/272 
  

