### PR TITLE
Fix bug with solid glb creation.

### DIFF
--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -644,7 +644,7 @@ namespace Elements.Serialization.glTF
 
             gltf.BufferViews = bufferViews.ToArray(bufferViews.Count);
             gltf.Accessors = accessors.ToArray(accessors.Count);
-            gltf.Nodes = nodes.ToArray(accessors.Count);
+            gltf.Nodes = nodes.ToArray(nodes.Count);
             if (meshes.Count > 0)
             {
                 gltf.Meshes = meshes.ToArray(meshes.Count);


### PR DESCRIPTION
The accessor count was inadvertently used where the node count should be, leading to glbs which had incorrect node array sizes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/413)
<!-- Reviewable:end -->
