### PR TITLE
Update github action to use .net core 3.1

### DIFF
--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 2.1.502
+          dotnet-version: 3.1.x
       - run: dotnet build --configuration release
       - run: dotnet test --configuration release

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageOutputPath>$(SolutionDir)nupkg</PackageOutputPath>
-    <PackageProjectUrl>https://github.com/hypar-io/CLI</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/hypar-io/CLI</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/hypar-io/Elements</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/hypar-io/Elements</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>$(Version)</Version>
   </PropertyGroup>


### PR DESCRIPTION
BACKGROUND:
A recently merged contribution from @jbolda added a github action to build and test elements. He introduced the PR so long ago that we only supported .net core 2.1 at the time.

DESCRIPTION:
This PR updates the github action to use the latest version of .net core 3.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/418)
<!-- Reviewable:end -->
