### PR TITLE
always copy the csg lib

### DIFF
--- a/Elements/src/Elements.csproj
+++ b/Elements/src/Elements.csproj
@@ -27,15 +27,16 @@
   <ItemGroup>
     <Content Include="Textures\**\*.*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>   
+    </Content>
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="Csg ">
       <HintPath>../lib/Csg.dll</HintPath>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Reference>
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Update="UV.jpg" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>


### PR DESCRIPTION
BACKGROUND:
- the csg library wasn't found while working on the ExportServer lambda in the api repo
```
There was an error writing an element of type Elements.Beam to IFC: Could not load file or assembly 'Csg, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.

```

DESCRIPTION:
- Add the setting `CopyToOutputDirectory=Always`

TESTING:
- next nuget package will work.  it's also running live on the sam stack `api=ew-export` which you could use from explore while exporting gltf.
  
FUTURE WORK:
- need to confirm this setting is all we need for nuget packages to always have this file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/428)
<!-- Reviewable:end -->
