### PR TITLE
different packing strategy

### DIFF
--- a/Elements/src/Elements.csproj
+++ b/Elements/src/Elements.csproj
@@ -28,13 +28,15 @@
     <Content Include="Textures\**\*.*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="../lib/Csg.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="Csg">
       <HintPath>../lib/Csg.dll</HintPath>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <Pack>true</Pack>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
BACKGROUND:
- still can't get csg in nuget package

DESCRIPTION:
- add the csg.dll explicitly as content like the texture.

TESTING:
- using a nupkg extension for vscode I can see that the nupkg has the csg.dll file now.
![image](https://user-images.githubusercontent.com/5872187/98033559-b405e900-1de3-11eb-986f-6613576c76ef.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/435)
<!-- Reviewable:end -->
