### PR TITLE
use approx for pointAt and epsilon for divide by

### DIFF
--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -372,18 +372,18 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Divide the line into n+1 equal segments.
+        /// Divide the line into n equal segments.
         /// </summary>
         /// <param name="n">The number of segments.</param>
-        public List<Line> DivideByCount(int n)
+        public List<Line> DivideIntoEqualSegments(int n)
         {
             if (n < 0)
             {
                 throw new ArgumentException($"The number of divisions must be greater than 0.");
             }
             var lines = new List<Line>();
-            var div = 1.0 / (n + 1);
-            for (var t = 0.0; t <= 1.0 - div + Vector3.EPSILON; t += div)
+            var div = 1.0 / (n );
+            for (var t = 0.0; t < 1.0 - div + Vector3.EPSILON; t += div)
             {
                 var a = PointAt(t);
                 var b = PointAt(t + div);

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -59,12 +59,12 @@ namespace Elements.Geometry
         /// <returns>A point on the curve at parameter u.</returns>
         public override Vector3 PointAt(double u)
         {
-            if (u == 0.0)
+            if (u.ApproximatelyEquals(0.0))
             {
                 return this.Start;
             }
 
-            if (u == 1.0)
+            if (u.ApproximatelyEquals(1.0))
             {
                 return this.End;
             }
@@ -383,7 +383,7 @@ namespace Elements.Geometry
             }
             var lines = new List<Line>();
             var div = 1.0 / (n + 1);
-            for (var t = 0.0; t <= 1.0 - div; t += div)
+            for (var t = 0.0; t <= 1.0 - div + Vector3.EPSILON; t += div)
             {
                 var a = PointAt(t);
                 var b = PointAt(t + div);

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -377,12 +377,12 @@ namespace Elements.Geometry
         /// <param name="n">The number of segments.</param>
         public List<Line> DivideIntoEqualSegments(int n)
         {
-            if (n < 0)
+            if (n <= 0)
             {
                 throw new ArgumentException($"The number of divisions must be greater than 0.");
             }
             var lines = new List<Line>();
-            var div = 1.0 / (n );
+            var div = 1.0 / n;
             for (var t = 0.0; t < 1.0 - div + Vector3.EPSILON; t += div)
             {
                 var a = PointAt(t);

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -101,10 +101,10 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
-        public void DivideByCount()
+        public void DivideIntoEqualSegments()
         {
             var l = new Line(Vector3.Origin, new Vector3(100, 0));
-            var segments = l.DivideByCount(40);
+            var segments = l.DivideIntoEqualSegments(41);
             var len = l.Length();
             Assert.Equal(41, segments.Count);
             foreach (var s in segments)

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -103,12 +103,13 @@ namespace Elements.Geometry.Tests
         [Fact]
         public void DivideByCount()
         {
-            var l = new Line(Vector3.Origin, new Vector3(5, 0));
-            var segments = l.DivideByCount(5);
+            var l = new Line(Vector3.Origin, new Vector3(100, 0));
+            var segments = l.DivideByCount(40);
             var len = l.Length();
+            Assert.Equal(41, segments.Count);
             foreach (var s in segments)
             {
-                Assert.Equal(s.Length(), len / 6, 5);
+                Assert.Equal(s.Length(), len / 41, 5);
             }
         }
 


### PR DESCRIPTION
BACKGROUND:
- Failed to get all segments for a line when asking for divide by

DESCRIPTION:
- Add a tolerance to the check of whether to stop segmenting, approxEquals for endpoint checks in PointAt, and a test

TESTING:
- run the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/442)
<!-- Reviewable:end -->
