### PR TITLE
Fix issue with inverted vertical curve transforms.

### DIFF
--- a/Elements/src/Geometry/Transform.cs
+++ b/Elements/src/Geometry/Transform.cs
@@ -98,6 +98,14 @@ namespace Elements.Geometry
                 x = test.Cross(z).Unitized();
                 y = x.Cross(z.Negate()).Unitized();
             }
+            else
+            {
+                // Ensure that we have a right-handed coordinate system.
+                if (z.Dot(Vector3.ZAxis).ApproximatelyEquals(-1))
+                {
+                    y = Vector3.YAxis.Negate();
+                }
+            }
 
             this.Matrix = new Matrix(x, y, z, Vector3.Origin);
             ApplyRotationAndTranslation(rotation, z, origin);

--- a/Elements/test/TransformTests.cs
+++ b/Elements/test/TransformTests.cs
@@ -121,7 +121,7 @@ namespace Elements.Tests
 
             var curves = new List<Curve>();
 
-            var line = new Line(Vector3.Origin, new Vector3(5, 5, 5));
+            var line = new Line(Vector3.Origin, new Vector3(1, 2, 5));
             curves.Add(line);
 
             var t = new Transform();
@@ -161,6 +161,22 @@ namespace Elements.Tests
                     last = tu;
                 }
             }
+
+            var centerLine = new Line(new Vector3(15, 0, -1), new Vector3(15, 0, 10));
+            var upT = centerLine.TransformAt(0);
+            this.Model.AddElements(upT.ToModelCurves());
+
+            var beam = new Beam(centerLine, Polygon.Rectangle(0.1, 0.1));
+            this.Model.AddElement(beam);
+
+            var centerLineRev = centerLine.Reversed().Transformed(new Transform(new Vector3(2, 0, 0)));
+            var downT = centerLineRev.TransformAt(0);
+            this.Model.AddElements(downT.ToModelCurves());
+
+            var beamDown = new Beam(centerLineRev, Polygon.Rectangle(0.1, 0.1));
+            this.Model.AddElement(beamDown);
+
+            Assert.Equal(upT.YAxis, downT.YAxis.Negate());
         }
     }
 


### PR DESCRIPTION
BACKGROUND:
CSGs were failing to boolean properly with strange results. We found that vertical sweeps had their geometry inverted. This was due to an inverted Y axis of the transforms along a line causing transforms to not be "right handed".

DESCRIPTION:
This PR properly orients transforms along vertical curves and adds a test to ensure vertical curves in the up and down direction both work correctly.

![image](https://user-images.githubusercontent.com/1139788/98424882-1d863180-2048-11eb-9862-4eec8bf805cc.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/445)
<!-- Reviewable:end -->
