### PR TITLE
Use PackageCopyToOutput.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,5 +12,8 @@
     <RepositoryUrl>https://github.com/hypar-io/CLI</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>$(Version)</Version>
+    <PackageOutputPath>../../nupkg</PackageOutputPath>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 </Project>

--- a/Elements.CodeGeneration/src/Elements.CodeGeneration.csproj
+++ b/Elements.CodeGeneration/src/Elements.CodeGeneration.csproj
@@ -11,9 +11,7 @@
         <Summary>Code generation utilities for Hypar.Elements.</Summary>
         <PackageProjectUrl>https://github.com/hypar-io/elements</PackageProjectUrl>
         <RepositoryUrl>https://github.com/hypar-io/elements</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
         <Version>$(Version)</Version>
-        <PackageOutputPath>../../nupkg</PackageOutputPath>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Elements.CodeGeneration/src/Elements.CodeGeneration.csproj
+++ b/Elements.CodeGeneration/src/Elements.CodeGeneration.csproj
@@ -28,12 +28,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <!-- Nuget solution using build targets came from here https://stackoverflow.com/questions/51924129/copy-files-from-nuget-package-to-output-directory-with-msbuild-in-csproj-and-do  -->
-        <Content Include="Elements.CodeGeneration.targets" PackagePath="build/Hypar.Elements.CodeGeneration.targets" />
         <Content Include="Templates\**\*.*">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-            <Pack>true</Pack>
-            <PackagePath>contentFiles\Templates</PackagePath>
+            <PackageCopyToOutput>true</PackageCopyToOutput>
         </Content>
     </ItemGroup>
 </Project>

--- a/Elements.Serialization.IFC/src/Elements.Serialization.IFC.csproj
+++ b/Elements.Serialization.IFC/src/Elements.Serialization.IFC.csproj
@@ -13,7 +13,6 @@
     <RepositoryUrl>https://github.com/hypar-io/elements</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <Version>$(Version)</Version>
-    <PackageOutputPath>../../nupkg</PackageOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Elements/src/Elements.csproj
+++ b/Elements/src/Elements.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <Content Include="Textures\**\*.*">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <PackageCopyToOutput>true</PackageCopyToOutput>
     </Content>
     <Content Include="../lib/Csg.dll">

--- a/Elements/src/Elements.csproj
+++ b/Elements/src/Elements.csproj
@@ -26,24 +26,17 @@
 
   <ItemGroup>
     <Content Include="Textures\**\*.*">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
     </Content>
     <Content Include="../lib/Csg.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <Pack>true</Pack>
-      <PackagePath>lib\$(TargetFramework)</PackagePath>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
     </Content>
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="Csg">
       <HintPath>../lib/Csg.dll</HintPath>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Reference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="UV.jpg" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/Elements/src/Elements.csproj
+++ b/Elements/src/Elements.csproj
@@ -11,9 +11,7 @@
     <Summary>The Elements library provides object types for generating the built environment.</Summary>
     <PackageProjectUrl>https://github.com/hypar-io/elements</PackageProjectUrl>
     <RepositoryUrl>https://github.com/hypar-io/elements</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <Version>$(Version)</Version>
-    <PackageOutputPath>../../nupkg</PackageOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Hypar LLC
+Copyright (c) 2020 Hypar Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
BACKGROUND:
While diagnosing an error with missing content in the CLI, we found that some content files were not being copied to the output directory when building projects with these packages as dependencies. It seems that a 

DESCRIPTION:
This PR adds the `PackageCopyToOutput` field in the csproj files, which encodes the content as requiring `copyToOutput=true`

With this change, the package manifest is as follows (note the addition of `copyToOutput: 'true'` in the `contentFiles` section):
```
Metadata:
  id: Hypar.Elements
  version: 1.0.0
  title: Hypar Elements
  authors: 'Hypar, Inc.'
  requireLicenseAcceptance: 'false'
  projectUrl: 'https://github.com/hypar-io/elements'
  description: A building elements library for AEC.
  copyright: 'Hypar, Inc. 2020'
  tags: 'AEC, Architecture, Structure, Engineering'
  repository:
    type: git
    url: 'https://github.com/hypar-io/elements'
  contentFiles:
    files:
      - $:
          include: any/netstandard2.0/Textures/UV.jpg
          buildAction: Content
          copyToOutput: 'true'
      - $:
          include: any/netstandard2.0/Csg.dll
          buildAction: Content
          copyToOutput: 'true'
Dependencies:
  .NETStandard2.0:
    Newtonsoft.Json: '>= 11.0.2'
    SixLabors.ImageSharp: '>= 1.0.0'
    System.ComponentModel.Annotations: '>= 4.6.0'
    Unofficial.LibTessDotNet: '>= 2.0.0'
    glTF2Loader: '>= 1.1.3'

Contents:
  - File:    _rels/.rels
  - File:    [Content_Types].xml
  - File:    content/Csg.dll
  - File:    content/Textures/UV.jpg
  - File:    contentFiles/any/netstandard2.0/Csg.dll
  - File:    contentFiles/any/netstandard2.0/Textures/UV.jpg
  - File:    Hypar.Elements.nuspec
  - File:    lib/netstandard2.0/Hypar.Elements.dll
  - File:    lib/netstandard2.0/Hypar.Elements.xml
  - File:    package/services/metadata/core-properties/29b7c1e2c4f94f83b4d32e58db6b8910.psmdcp
```

This package also moves two fields out of each .csproj and into the .props file, and adds a license field to the .props file to silence the errors around missing licenses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/446)
<!-- Reviewable:end -->
