### PR TITLE
Fix Union All overlap treatment behavior

### DIFF
--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -421,6 +421,18 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
+        public void UnionAll()
+        {
+            var polygons = new List<Polygon> {
+                Polygon.Rectangle(10, 10),
+                Polygon.Rectangle(10, 10).TransformedPolygon(new Transform(5,5,0))
+            };
+
+            var result = Polygon.UnionAll(polygons).First();
+            Assert.Equal(175, result.Area());
+        }
+
+        [Fact]
         public void Union()
         {
             var p1 = new Polygon


### PR DESCRIPTION
BACKGROUND:
- Polygon.UnionAll did not work as expected when supplied with a list of overlapping polygons. Because we were using Clipper's EvenOdd PolyFillType by default, it treated the overlapping region between two polygons as a "hole" when it should have been added to the union. 
![image](https://user-images.githubusercontent.com/31935763/100118437-d8ce0900-2e43-11eb-8510-85bcd29b54cf.png)
 

DESCRIPTION:
- Adds a parameter to BooleanTwoSets to govern which PolyFillType to apply
- Sets UnionAll to use VoidTreatment.IgnoreInternalVoids
- Preserves existing behavior for other non-static cases, which will allow us to join two shapes-with-holes and get a correct result.

TESTING:
- Run the new `PolygonTests.UnionAll` test
  
FUTURE WORK:
- It's conceivable that we might need to expose this option all the way to the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/456)
<!-- Reviewable:end -->
