### PR TITLE
grid1d/grid2d bug fixes and improvements

### DIFF
--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -472,7 +472,7 @@ namespace Elements.Geometry
             polygon.Contains(this.Start, out var containment);
             var StartsOutsidePolygon = containment == Containment.Outside;
 
-            var hasVertexIntersections = false;
+            var hasVertexIntersections = containment == Containment.CoincidesAtVertex;
 
             // Examine the polygon's edges.
             for (int i1 = 0; i1 < polygon.Vertices.Count; i1++)
@@ -514,7 +514,7 @@ namespace Elements.Geometry
                     continue;
                 }
                 var segment = new Line(A, B);
-                if (hasVertexIntersections || containment == Containment.CoincidesAtEdge) // if it passed through a vertex, or started at an edge, we can't rely on alternating, so check each midpoint
+                if (hasVertexIntersections || containment == Containment.CoincidesAtEdge) // if it passed through a vertex, or started at an edge or vertex, we can't rely on alternating, so check each midpoint
                 {
                     currentlyIn = polygon.Contains((A + B) / 2);
                 }

--- a/Elements/src/Spatial/Grid2d.cs
+++ b/Elements/src/Spatial/Grid2d.cs
@@ -577,15 +577,10 @@ namespace Elements.Spatial
                 return false;
             }
 
-            if (boundariesInGridSpace.Count > 1)
-            {
-                return true;
-            }
-
             var baseRect = GetBaseRectangleTransformed();
-
             var trimmedRect = Polygon.Intersection(new[] { baseRect }, boundariesInGridSpace);
-            if (trimmedRect == null || trimmedRect.Count > 1 || trimmedRect.Count < 1) return false;
+            if (trimmedRect == null || trimmedRect.Count < 1) { return false; }
+            if (trimmedRect.Count > 1) { return true; }
             return !trimmedRect[0].IsAlmostEqualTo(baseRect, Vector3.EPSILON);
         }
 

--- a/Elements/src/Spatial/Grid2d.cs
+++ b/Elements/src/Spatial/Grid2d.cs
@@ -47,12 +47,12 @@ namespace Elements.Spatial
         /// <summary>
         /// A transform from grid space to world space
         /// </summary>
-        private Transform fromGrid = new Transform();
+        internal Transform fromGrid = new Transform();
 
         /// <summary>
         /// A transform from world space to grid space
         /// </summary>
-        private Transform toGrid = new Transform();
+        internal Transform toGrid = new Transform();
 
         private Domain1d UDomainInternal = new Domain1d(0, 0);
         private Domain1d VDomainInternal = new Domain1d(0, 0);
@@ -251,9 +251,8 @@ namespace Elements.Spatial
         /// <param name="point">The point at which to split.</param>
         public void SplitAtPoint(Vector3 point)
         {
-            var ptTransformed = toGrid.OfPoint(point);
-            U.SplitAtPoint(AxisTransformPoint(GridDirection.U, ptTransformed));
-            V.SplitAtPoint(AxisTransformPoint(GridDirection.V, ptTransformed));
+            U.SplitAtPoint(AxisTransformPoint(GridDirection.U, point));
+            V.SplitAtPoint(AxisTransformPoint(GridDirection.V, point));
         }
 
         /// <summary>
@@ -408,11 +407,34 @@ namespace Elements.Spatial
         }
 
         /// <summary>
+        /// Get the points at the corners of all grid cells.
+        /// /// </summary>
+        /// <returns></returns>
+        public List<Vector3> GetCellNodes()
+        {
+            var points = new List<Vector3>();
+            var origin = GetTransformedOrigin();
+            var vToOrigin = origin - V.StartPoint();
+            var uToOrigin = origin - U.StartPoint();
+            var uPoints = U.GetCellSeparators(true);
+            var vPoints = V.GetCellSeparators(true);
+
+            foreach (var vpt in vPoints)
+            {
+                var displacement = new Transform(vpt - uToOrigin);
+                // points.AddRange(uPoints.Select(u => fromGrid.OfPoint(displacement.OfPoint(u))));
+                points.AddRange(uPoints.Select(u => fromGrid.OfPoint(u + vpt)));
+            }
+            return points;
+        }
+
+        /// <summary>
         /// Get the top-level lines separating cells from one another.
         /// </summary>
         /// <param name="direction">The grid direction in which you want to get separators. </param>
+        /// <param name="trim">Whether or not to trim cell separators with the trimmed cell boundary</param>
         /// <returns>The lines between cells, running parallel to the grid direction selected. </returns>
-        public List<ICurve> GetCellSeparators(GridDirection direction)
+        public List<ICurve> GetCellSeparators(GridDirection direction, bool trim = false)
         {
             var curves = new List<ICurve>();
             var points = new List<Vector3>();
@@ -438,7 +460,47 @@ namespace Elements.Spatial
                 curves.Add(otherDirection.Transformed(displacement).Transformed(fromGrid));
             }
 
-            //TODO: add support for trimmed lines
+
+            if (trim && IsTrimmed())
+            {
+                List<ICurve> trimmedCurves = new List<ICurve>();
+                var trimmedCellGeometry = GetTrimmedCellGeometry().OfType<Polygon>();
+                // TODO: support keeping polylines joined when trimming. This would depend on an implementation of Polyline.Trim(Polygon p)
+                // Currently we simply return the "shattered" lines that result. Since most grids are constructed from linear
+                // axes, this is fine most of the time.
+                if (trimmedCellGeometry.Count() == 1)
+                {
+                    var boundary = trimmedCellGeometry.First();
+                    var lines = curves.OfType<Line>().Union(curves.OfType<Polyline>().SelectMany(c => c.Segments()));
+                    trimmedCurves.AddRange(lines.SelectMany(l => l.Trim(boundary, out var _)));
+                }
+                else
+                {
+                    // If we potentially have nested polygons, assume clockwise winding indicates a hole — trim with all the outer polygons first,
+                    // and then trim out anything inside the holes. 
+                    // TODO: get smarter about complex nesting scenarios taking advantage of clipper's PolyTree structure. 
+                    var outerPolygons = trimmedCellGeometry.Where(p => !p.IsClockWise());
+                    var innerPolygons = trimmedCellGeometry.Where(p => p.IsClockWise());
+                    foreach (var outerPoly in outerPolygons)
+                    {
+                        var lines = curves.OfType<Line>().Union(curves.OfType<Polyline>().SelectMany(c => c.Segments()));
+                        var intermediateResults = lines.SelectMany(l => l.Trim(outerPoly, out var _));
+                        var innerPolygonsWithinOuterPolygon = innerPolygons.Where(i => outerPoly.Contains(i.Vertices.First()));
+                        foreach (var ip in innerPolygonsWithinOuterPolygon)
+                        {
+                            var linesOutsideHole = intermediateResults.SelectMany(ir =>
+                            {
+                                ir.Trim(ip, out var outsideLines);
+                                return outsideLines;
+                            });
+                            intermediateResults = linesOutsideHole;
+                        }
+                        trimmedCurves.AddRange(intermediateResults);
+                    }
+                }
+
+                return trimmedCurves;
+            }
 
             return curves;
 
@@ -513,6 +575,11 @@ namespace Elements.Spatial
             if (boundariesInGridSpace == null || boundariesInGridSpace.Count == 0)
             {
                 return false;
+            }
+
+            if (boundariesInGridSpace.Count > 1)
+            {
+                return true;
             }
 
             var baseRect = GetBaseRectangleTransformed();
@@ -614,8 +681,8 @@ namespace Elements.Spatial
                 return new List<List<Grid2d>> { new List<Grid2d> { this } };
             }
             var cells = new List<List<Grid2d>>();
-            var uCells = U.IsSingleCell ? new List<Grid1d> { U } : U.Cells;
-            var vCells = V.IsSingleCell ? new List<Grid1d> { V } : V.Cells;
+            var uCells = U.IsSingleCell ? new List<Grid1d> { U } : U.GetCells();
+            var vCells = V.IsSingleCell ? new List<Grid1d> { V } : V.GetCells();
             foreach (var uCell in uCells)
             {
                 var column = new List<Grid2d>();

--- a/Elements/test/Grid1dTests.cs
+++ b/Elements/test/Grid1dTests.cs
@@ -103,9 +103,18 @@ namespace Elements.Tests
         public void DivideFromPosition()
         {
             var grid = new Grid1d(new Domain1d(-8, 8));
-            Assert.Throws<ArgumentException>(() => grid.DivideByFixedLengthFromPosition(1, 10));
+            grid.DivideByFixedLengthFromPosition(20, 10);
+            Assert.Null(grid.Cells); // this should have been left undivided
             grid.DivideByFixedLengthFromPosition(4, 0);
             Assert.Equal(4, grid.Cells.Count);
+        }
+
+        [Fact]
+        public void DivideFromPoint()
+        {
+            var grid = new Grid1d(new Line(new Vector3(-5, -5), new Vector3(5, 5)));
+            grid.DivideByFixedLengthFromPoint(3, new Vector3(-4, 4));
+            Assert.Equal(6, grid.Cells.Count);
         }
 
         [Fact]

--- a/Elements/test/Grid2dTests.cs
+++ b/Elements/test/Grid2dTests.cs
@@ -85,6 +85,35 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void CellSeparatorsTrimmed()
+        {
+            Name = "CellSeparatorsTrimmed";
+            var polygon = new Polygon(new[] {
+                Vector3.Origin,
+                new Vector3(4,2),
+                new Vector3(5,3),
+                new Vector3(7,7),
+                new Vector3(3,6)
+            });
+            var polygon2 = new Polygon(new[] {
+                new Vector3(1.1,1),
+                new Vector3(1.5,1),
+                new Vector3(1.5,2),
+                new Vector3(1.1,2)
+            });
+            var polygons = new[] { polygon, polygon2 };
+            var grid2d = new Grid2d(polygons);
+            grid2d.U.DivideByCount(10);
+            grid2d.V.DivideByFixedLength(1);
+            var csu = grid2d.GetCellSeparators(GridDirection.U, true);
+            var csv = grid2d.GetCellSeparators(GridDirection.V, true);
+            Assert.Equal(10, csu.Count);
+            Assert.Equal(10, csv.Count);
+            Model.AddElements(polygons.Select(p => new ModelCurve(p, BuiltInMaterials.XAxis)));
+            Model.AddElements(csu.Union(csv).Select(l => new ModelCurve(l as Line)));
+        }
+
+        [Fact]
         public void RotationOfTransform()
         {
             var rectangle = Polygon.Rectangle(10, 6);

--- a/Elements/test/Grid2dTests.cs
+++ b/Elements/test/Grid2dTests.cs
@@ -64,6 +64,7 @@ namespace Elements.Tests
         [Fact]
         public void TrimBehavior()
         {
+            Name = "TrimBehavior";
             var polygonjson = "[{\"discriminator\":\"Elements.Geometry.Polygon\",\"Vertices\":[{\"X\":-14.371519985751306,\"Y\":-4.8816304299427005,\"Z\":0.0},{\"X\":-17.661873645682569,\"Y\":9.2555712951713573,\"Z\":0.0},{\"X\":12.965610421927806,\"Y\":9.2555712951713573,\"Z\":0.0},{\"X\":12.965610421927806,\"Y\":3.5538269529982784,\"Z\":0.0},{\"X\":6.4046991240848143,\"Y\":3.5538269529982784,\"Z\":0.0},{\"X\":1.3278034769444158,\"Y\":-4.8816304299427005,\"Z\":0.0}]},{\"discriminator\":\"Elements.Geometry.Polygon\",\"Vertices\":[{\"X\":-9.4508365123690652,\"Y\":0.20473478280229102,\"Z\":0.0},{\"X\":-1.8745460850979974,\"Y\":0.20473478280229102,\"Z\":0.0},{\"X\":-1.8745460850979974,\"Y\":5.4378426037008651,\"Z\":0.0},{\"X\":-9.4508365123690652,\"Y\":5.4378426037008651,\"Z\":0.0}]}]\r\n";
             var polygons = JsonConvert.DeserializeObject<List<Polygon>>(polygonjson);
             var grid = new Grid2d(polygons);
@@ -73,15 +74,23 @@ namespace Elements.Tests
             }
             grid.CellsFlat.ForEach(c => c.U.DivideByApproximateLength(1.0, EvenDivisionMode.RoundDown));
 
-            var trimmedCells = grid.GetCells().Select(c => new Dictionary<string, object>
+            var trimmedCells = grid.GetCells().Select(c =>
+                (TrimmedGeometry: c.GetTrimmedCellGeometry(),
+                BaseRect: c.GetCellGeometry(),
+                IsTrimmed: c.IsTrimmed()));
+
+            foreach (var trimGeometry in trimmedCells)
+            {
+                var trimGeo = trimGeometry.TrimmedGeometry.OfType<Polygon>();
+                var material = trimGeometry.IsTrimmed ? BuiltInMaterials.XAxis : BuiltInMaterials.ZAxis;
+                foreach (var t in trimGeo)
                 {
-                    {"TrimmedGeometry", c.GetTrimmedCellGeometry()},
-                    {"BaseRect", c.GetCellGeometry() },
-                    {"IsTrimmed", c.IsTrimmed()}
+                    Model.AddElement(new ModelCurve(t));
+                    Model.AddElement(new Mass(t, 1, material, new Transform(0, 0, -1.001)));
                 }
-            );
+            }
             Assert.Equal(87, trimmedCells.Count());
-            Assert.Equal(18, trimmedCells.Count(c => (bool)c["IsTrimmed"]));
+            Assert.Equal(18, trimmedCells.Count(c => c.IsTrimmed));
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
- I've been doing a lot of work with grids, and run into a few bugs and limitations. 

DESCRIPTION:
- Adds `Grid1d.ClosestPosition()`,
- Adds `Grid1d.DivideByFixedLengthFromPoint()`
- Adds `Grid2d.GetCellNodes()`
- Modifies `Grid1d.DivideByFixedLengthFromPosition()` to be more flexible — supporting a "position" outside the grids domain.
- Modifies `Grid2d.GetCellSeparators()` to support returning trimmed separators
- Fixes a bug in `Line.Trim(Polygon p)` where lines that started on the polygon would not be treated as outside the polygon.
- Fixes a bug in `Grid2d.IsTrimmed()` that would ignore cases where a cell was trimmed by an inner hole

TESTING:
- There are several new tests, and modifications to existing tests, to ensure that this behavior works as desired. I have also tested these functionality changes in functions using the local library builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/458)
<!-- Reviewable:end -->
