### PR TITLE
Fix #461: Support 3d polylines

### DIFF
--- a/Elements/src/GeoJSON/Geometry.cs
+++ b/Elements/src/GeoJSON/Geometry.cs
@@ -232,7 +232,7 @@ namespace Elements.GeoJSON
         }
 
         /// <summary>
-        /// Convert the coordinate array to a collection of polylines.
+        /// Convert the coordinate array to a collection of polygons.
         /// The last position of the polygon is dropped.
         /// </summary>
         /// <returns></returns>

--- a/Elements/src/Geometry/Circle.cs
+++ b/Elements/src/Geometry/Circle.cs
@@ -26,7 +26,7 @@ namespace Elements.Geometry
         /// Create a polygon through a set of points along the arc.
         /// </summary>
         /// <param name="divisions">The number of divisions of the arc.</param>
-        /// <returns>A polyline.</returns>
+        /// <returns>A polygon.</returns>
         public Polygon ToPolygon(int divisions = 10)
         {
             var pts = new Vector3[divisions];

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -798,7 +798,19 @@ namespace Elements.Geometry
         /// <param name="endSetback"></param>
         public override Transform[] Frames(double startSetback, double endSetback)
         {
-            return FramesInternal(startSetback, endSetback, true);
+            // Create an array of transforms with the same
+            // number of items as the vertices.
+            var result = new Transform[this.Vertices.Count];
+
+            // Cache the normal so we don't have to recalculate
+            // using Newell for every frame.
+            var up = Normal();
+            for (var i = 0; i < result.Length; i++)
+            {
+                var a = this.Vertices[i];
+                result[i] = CreateMiterTransform(i, a, up);
+            }
+            return result;
         }
 
         /// <summary>
@@ -941,7 +953,7 @@ namespace Elements.Geometry
         /// The normal of this polygon, according to Newell's Method.
         /// </summary>
         /// <returns>The unitized sum of the cross products of each pair of edges.</returns>
-        public override Vector3 Normal()
+        public Vector3 Normal()
         {
             var normal = new Vector3();
             for (int i = 0; i < Vertices.Count; i++)
@@ -953,6 +965,24 @@ namespace Elements.Geometry
                 normal.Z += (p0.X - p1.X) * (p0.Y + p1.Y);
             }
             return normal.Unitized();
+        }
+        /// <summary>
+        /// Get the normal of each vertex on the polygon.
+        /// </summary>
+        /// <remarks>All normals will be the same since polygons are coplanar by definition.</remarks>
+        /// <returns>A collection of unit vectors, each corresponding to a single vertex.</returns>
+        protected override Vector3[] NormalsAtVertices()
+        {
+            // Create an array of transforms with the same number of items as the vertices.
+            var result = new Vector3[this.Vertices.Count];
+
+            // Since polygons must be coplanar, all vertex normals can match the polygon's normal.
+            var normal = this.Normal();
+            for (int i = 0; i < Vertices.Count; i++)
+            {
+                result[i] = normal;
+            }
+            return result;
         }
 
         /// <summary>

--- a/Elements/src/Validators/Validators.cs
+++ b/Elements/src/Validators/Validators.cs
@@ -353,11 +353,6 @@ namespace Elements.Validators
         {
             var vertices = (IList<Vector3>)args[0];
 
-            if (!vertices.AreCoplanar())
-            {
-                throw new ArgumentException("The polygon could not be created. The provided vertices are not coplanar.");
-            }
-
             var segments = Polyline.SegmentsInternal(vertices);
             Polyline.CheckSegmentLengthAndThrow(segments);
         }

--- a/Elements/test/SolidTests.cs
+++ b/Elements/test/SolidTests.cs
@@ -110,10 +110,25 @@ namespace Elements.Tests
         }
 
         [Fact]
-        public void SweptSolidPolyline()
+        public void SweptSolidCollinearPolyline()
         {
             var profile = WideFlangeProfileServer.Instance.GetProfileByType(WideFlangeProfileType.W10x100);
             var path = new Polyline(new[] { new Vector3(0, 0), new Vector3(0, 2), new Vector3(0, 3, 1), new Vector3(0, 5, 1) });
+            var solid = Solid.SweepFaceAlongCurve(profile.Perimeter, null, path);
+            foreach (var e in solid.Edges.Values)
+            {
+                Assert.NotNull(e.Left);
+                Assert.NotNull(e.Right);
+                Assert.NotSame(e.Left, e.Right);
+            }
+            solid.ToGlb("models/SweptSolidCollinearPolyline.glb");
+        }
+
+        [Fact]
+        public void SweptSolidPolyline()
+        {
+            var profile = WideFlangeProfileServer.Instance.GetProfileByType(WideFlangeProfileType.W10x100);
+            var path = new Polyline(new[] { new Vector3(-2, 2, 0), new Vector3(0, 2, 0), new Vector3(0, 3, 1), new Vector3(0, 5, 1), new Vector3(-2, 6, 0) });
             var solid = Solid.SweepFaceAlongCurve(profile.Perimeter, null, path);
             foreach (var e in solid.Edges.Values)
             {

--- a/Schemas/Geometry/Polyline.json
+++ b/Schemas/Geometry/Polyline.json
@@ -4,7 +4,7 @@
     "title": "Polyline",
     "x-namespace": "Elements.Geometry",
     "type": ["object","null"],
-    "description": "A planar continuous set of lines.",
+    "description": "A continuous set of lines.",
     "allOf": [{"$ref": "https://hypar.io/Schemas/Geometry/Curve.json"}],
     "required": ["Vertices"],
     "properties": {


### PR DESCRIPTION
BACKGROUND:
See #461.

DESCRIPTION:
This removes the validation that polylines must be coplanar, adjusts docs accordingly, and updates methods to support 3d polylines where appropriate.

TESTING:
- I updated tests and verified that results looked reasonable. Coplanar polyline sweeps are unchanged and non-coplanar sweeps look reasonable:
![image](https://user-images.githubusercontent.com/48925/101647891-431ba780-3a07-11eb-8d6c-2ad977f93887.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/463)
<!-- Reviewable:end -->
