### PR TITLE
Add a getter for CoreTypeNames.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
 ## 0.8.1
+
+### Added
+- `TypeGenerator.CoreTypeNames`
+
 ## Removed
+- `TypeGenerator.GetCoreTypeNames()`
 - `UserElementAttribute`
 
 ## 0.8.0

--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -93,6 +93,11 @@ namespace Elements.Generate
             "Point",
         };
 
+        /// <summary>
+        /// All core type names.
+        /// </summary>
+        public static string[] CoreTypeNames => _coreTypeNames;
+
         private const string NAMESPACE_PROPERTY = "x-namespace";
         private const string STRUCT_PROPERTY = "x-struct";
         private static string _templatesPath;


### PR DESCRIPTION
BACKGROUND:
During testing of 0.8.1-alpha9 with the Hypar CLI, @wynged found that the `TypeGenerator.GetCoreTypeNames()` API was in fact required.

DESCRIPTION:
This PR introduces the `TypeGenerator.CoreTypeNames` property which wraps `_coreTypeNames`. A property is preferred over the method that we had previously because a method is no longer required to get the core type names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/477)
<!-- Reviewable:end -->
