### PR TITLE
Changelog updates for 0.8.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,30 @@
 
 ### Added
 - `TypeGenerator.CoreTypeNames`
+- `MeshConverter`
+- Implicit conversion of `Curve` types to `ModelCurve`.
+- `byte[] Model.ToGlb(...)`
+- `Grid1d.ClosestPosition()`
+- `Grid1d.DivideByFixedLengthFromPoint()`
+- `Grid2d.GetCellNodes()`
 
-## Removed
+### Changed
+- Removed `JsonInheritanceAttribute` from `Element` base types.
+- `Sweep` contstructor now takes a rotation. Transformation of the profile based on rotation happens internal to the sweep's construction.
+- `Polyline` are no longer required to be planar.
+- Modifies Grid1d.DivideByFixedLengthFromPosition() to be more flexible — supporting a "position" outside the grids domain.
+- Modifies Grid2d.GetCellSeparators() to support returning trimmed separators
+
+### Removed
 - `TypeGenerator.GetCoreTypeNames()`
 - `UserElementAttribute`
+- `NumericProperty`
+
+### Fixed
+- `Ray.Intersects` now calls `UpdateRepresentations` internally for accurate intersections.
+- Fixed #470
+- Fixes a bug in `Line.Trim(Polygon p)` where lines that started on the polygon would not be treated as outside the polygon.
+- Fixes a bug in `Grid2d.IsTrimmed()` that would ignore cases where a cell was trimmed by an inner hole.
 
 ## 0.8.0
 ### Added


### PR DESCRIPTION
We have not been good about changelog updates. This includes all updates going back to the 0.8.0 release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/478)
<!-- Reviewable:end -->
