### PR TITLE
catch type load errors while building type cache. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.8.2
 ### Fixed
 - Fixed #483 `Deserialization of profiles created in UpdateRepresentation`
+- Fixed #484 `Failure to deserialize Model if any assembly can't be loaded.`
 
 
 ## 0.8.1

--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -187,8 +187,9 @@ namespace Elements
             // When user elements have been loaded into the app domain, they haven't always been
             // loaded into the InheritanceConverter's Cache.  This does have some overhead,
             // but is useful here, at the Model level, to ensure user types are available.
-            JsonInheritanceConverter.RefreshAppDomainTypeCache();
             errors = errors ?? new List<string>();
+            JsonInheritanceConverter.RefreshAppDomainTypeCache(out var typeLoadErrors);
+            errors.AddRange(typeLoadErrors);
             var model = Newtonsoft.Json.JsonConvert.DeserializeObject<Model>(json, new JsonSerializerSettings()
             {
                 Error = (sender, args) =>

--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -71,15 +71,11 @@ namespace Elements.Serialization.JSON
         /// <returns>A dictionary containing all found types keyed by their full name.</returns>
         private static Dictionary<string, Type> BuildAppDomainTypeCache(out List<string> failedAssemblyErrors)
         {
-            var sw = System.Diagnostics.Stopwatch.StartNew();
             var typeCache = new Dictionary<string, Type>();
 
-            var numAssemblies = 0;
-            var numTypesChecked = 0;
             failedAssemblyErrors = new List<string>();
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                numAssemblies++;
                 var types = Array.Empty<Type>();
                 try
                 {
@@ -92,10 +88,9 @@ namespace Elements.Serialization.JSON
                 }
                 foreach (var t in types)
                 {
-                    numTypesChecked++;
                     try
                     {
-                        if (!typeCache.ContainsKey(t.FullName) && IsValidTypeForElements(t))
+                        if (IsValidTypeForElements(t) && !typeCache.ContainsKey(t.FullName))
                         {
                             typeCache.Add(t.FullName, t);
                         }
@@ -108,8 +103,6 @@ namespace Elements.Serialization.JSON
                 }
             }
 
-            sw.Stop();
-            var elapsed = sw.Elapsed.TotalSeconds;
             return typeCache;
         }
 

--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -30,7 +30,7 @@ namespace Elements.Serialization.JSON
             {
                 if (_typeCache == null)
                 {
-                    _typeCache = BuildAppDomainTypeCache();
+                    _typeCache = BuildAppDomainTypeCache(out _);
                 }
                 return _typeCache;
             }
@@ -65,44 +65,57 @@ namespace Elements.Serialization.JSON
         /// The type cache needs to contains all types that will have a discriminator.
         /// This includes base types, like elements, and all derived types like Wall.
         /// We use reflection to find all public types available in the app domain
-        /// that have a Newtonsoft.Json.JsonConverterAttribute whose converter type is the 
+        /// that have a Newtonsoft.Json.JsonConverterAttribute whose converter type is the
         /// Elements.Serialization.JSON.JsonInheritanceConverter.
         /// </summary>
         /// <returns>A dictionary containing all found types keyed by their full name.</returns>
-        private static Dictionary<string, Type> BuildAppDomainTypeCache()
+        private static Dictionary<string, Type> BuildAppDomainTypeCache(out List<string> failedAssemblyErrors)
         {
             var typeCache = new Dictionary<string, Type>();
 
-            var exportedTypes = AppDomain.CurrentDomain.GetAssemblies().SelectMany(asm => asm.GetTypes().Where(t => t.IsPublic && t.IsClass));
-            var typesUsingInheritanceConverter = exportedTypes.Where(et =>
+            failedAssemblyErrors = new List<string>();
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                var attrib = et.GetCustomAttribute<JsonConverterAttribute>();
-                if (attrib != null && attrib.ConverterType == typeof(JsonInheritanceConverter))
+                try
                 {
-                    return true;
+                    foreach (var t in assembly.GetTypes())
+                    {
+                        if (!typeCache.ContainsKey(t.FullName) && IsValidTypeForElements(t))
+                        {
+                            typeCache.Add(t.FullName, t);
+                        }
+                    }
                 }
-                return false;
-            });
-
-            var derivedTypes = typesUsingInheritanceConverter.SelectMany(baseType => exportedTypes.Where(exportedType => baseType.IsAssignableFrom(exportedType)));
-            foreach (var t in derivedTypes)
-            {
-                if (!typeCache.ContainsKey(t.FullName))
+                catch (Exception e) when (e is TypeLoadException || e is ReflectionTypeLoadException)
                 {
-                    typeCache.Add(t.FullName, t);
+                    failedAssemblyErrors.Add($"Failed to load assembly: {assembly.FullName}");
                 }
             }
 
             return typeCache;
         }
 
+        private static bool IsValidTypeForElements(Type t)
+        {
+            if (t.IsPublic && t.IsClass)
+            {
+                var attrib = t.GetCustomAttribute<JsonConverterAttribute>();
+                if (attrib != null && attrib.ConverterType == typeof(JsonInheritanceConverter))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Call this method after assemblies have been loaded into the app
         /// domain to ensure that the converter's cache is up to date.
         /// </summary>
-        internal static void RefreshAppDomainTypeCache()
+        internal static void RefreshAppDomainTypeCache(out List<string> errors)
         {
-            _typeCache = BuildAppDomainTypeCache();
+            _typeCache = BuildAppDomainTypeCache(out errors);
         }
 
         public static bool ElementwiseSerialization { get; set; } = false;
@@ -166,7 +179,7 @@ namespace Elements.Serialization.JSON
 
         public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
         {
-            // The serialized value is an identifier, so the expectation is 
+            // The serialized value is an identifier, so the expectation is
             // that the element with that id has already been deserialized.
             if (typeof(Element).IsAssignableFrom(objectType) && reader.Path.Split('.').Length == 1 && reader.Value != null)
             {
@@ -202,7 +215,7 @@ namespace Elements.Serialization.JSON
             else
             {
                 // Without a discriminator the call to GetObjectSubtype will
-                // fall through to returning either a [UserElement] type or 
+                // fall through to returning either a [UserElement] type or
                 // the object type.
                 subtype = GetObjectSubtype(objectType, null, jObject);
             }

--- a/Elements/test/ModelTests.cs
+++ b/Elements/test/ModelTests.cs
@@ -71,21 +71,20 @@ namespace Elements.Tests
         {
             // We've changed an Elements.Beam to Elements.Foo
             var modelStr = "{'Transform':{'Matrix':{'Components':[1.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0]}},'Elements':{'c6d1dc68-f800-47c1-9190-745b525ad569':{'discriminator':'Elements.Baz'}, '37f161d6-a892-4588-ad65-457b04b97236':{'discriminator':'Elements.Geometry.Profiles.WideFlangeProfile','d':1.1176,'tw':0.025908,'bf':0.4064,'tf':0.044958,'Perimeter':{'discriminator':'Elements.Geometry.Polygon','Vertices':[{'X':-0.2032,'Y':0.5588,'Z':0.0},{'X':-0.2032,'Y':0.51384199999999991,'Z':0.0},{'X':-0.012954,'Y':0.51384199999999991,'Z':0.0},{'X':-0.012954,'Y':-0.51384199999999991,'Z':0.0},{'X':-0.2032,'Y':-0.51384199999999991,'Z':0.0},{'X':-0.2032,'Y':-0.5588,'Z':0.0},{'X':0.2032,'Y':-0.5588,'Z':0.0},{'X':0.2032,'Y':-0.51384199999999991,'Z':0.0},{'X':0.012954,'Y':-0.51384199999999991,'Z':0.0},{'X':0.012954,'Y':0.51384199999999991,'Z':0.0},{'X':0.2032,'Y':0.51384199999999991,'Z':0.0},{'X':0.2032,'Y':0.5588,'Z':0.0}]},'Voids':null,'Id':'37f161d6-a892-4588-ad65-457b04b97236','Name':'W44x335'},'6b77d69a-204e-40f9-bc1f-ed84683e64c6':{'discriminator':'Elements.Material','Color':{'Red':0.60000002384185791,'Green':0.5,'Blue':0.5,'Alpha':1.0},'SpecularFactor':0.0,'GlossinessFactor':0.0,'Id':'6b77d69a-204e-40f9-bc1f-ed84683e64c6','Name':'steel'},'fd35bd2c-0108-47df-8e6d-42cc43e4eed0':{'discriminator':'Elements.Foo','Curve':{'discriminator':'Elements.Geometry.Arc','Center':{'X':0.0,'Y':0.0,'Z':0.0},'Radius':2.0,'StartAngle':0.0,'EndAngle':90.0},'StartSetback':0.25,'EndSetback':0.25,'Profile':'37f161d6-a892-4588-ad65-457b04b97236','Transform':{'Matrix':{'Components':[1.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0]}},'Material':'6b77d69a-204e-40f9-bc1f-ed84683e64c6','Representation':{'SolidOperations':[{'discriminator':'Elements.Geometry.Solids.Sweep','Profile':'37f161d6-a892-4588-ad65-457b04b97236','Curve':{'discriminator':'Elements.Geometry.Arc','Center':{'X':0.0,'Y':0.0,'Z':0.0},'Radius':2.0,'StartAngle':0.0,'EndAngle':90.0},'StartSetback':0.25,'EndSetback':0.25,'Rotation':0.0,'IsVoid':false}]},'Id':'fd35bd2c-0108-47df-8e6d-42cc43e4eed0','Name':null}}}";
-            var errors = new List<string>();
-            var model = Model.FromJson(modelStr, errors);
+            var model = Model.FromJson(modelStr, out var errors);
             foreach (var e in errors)
             {
                 this._output.WriteLine(e);
             }
 
-            // We expect three geometric elements, 
+            // We expect three geometric elements,
             // but the baz will not deserialize.
             Assert.Equal(3, model.Elements.Count);
             Assert.Equal(2, errors.Count);
         }
 
         /// <summary>
-        /// Test whether two models, containing user defined types, can be 
+        /// Test whether two models, containing user defined types, can be
         /// deserialized and merged into one model.
         /// </summary>
         [Fact(Skip = "ModelMerging")]
@@ -218,8 +217,7 @@ namespace Elements.Tests
 
             // Remove the Location property
             c.Property("Location").Remove();
-            var errors = new List<string>();
-            var newModel = Model.FromJson(obj.ToString(), errors);
+            var newModel = Model.FromJson(obj.ToString(), out var errors);
             var newColumn = newModel.AllElementsOfType<Column>().First();
             Assert.Equal(Vector3.Origin, newColumn.Location);
         }
@@ -238,8 +236,7 @@ namespace Elements.Tests
 
             // Nullify a property.
             c.Property("Location").Value = null;
-            var errors = new List<string>();
-            var newModel = Model.FromJson(obj.ToString(), errors);
+            var newModel = Model.FromJson(obj.ToString(), out var errors);
             foreach (var e in errors)
             {
                 this._output.WriteLine(e);
@@ -259,7 +256,7 @@ namespace Elements.Tests
             model.AddElements(beam, column);
             var json = model.ToJson(true);
 
-            // We want to test that unknown element types will still deserialize 
+            // We want to test that unknown element types will still deserialize
             // to geometric elements.
             json = json.Replace("Elements.Beam", "Foo");
             json = json.Replace("Elements.Column", "Bar");

--- a/Elements/test/UserElementTests.cs
+++ b/Elements/test/UserElementTests.cs
@@ -75,8 +75,7 @@ namespace Elements.Tests
             this.Model.AddElement(ue);
 
             var json = this.Model.ToJson();
-            var errors = new List<string>();
-            var newModel = Model.FromJson(json, errors);
+            var newModel = Model.FromJson(json, out var errors);
             Assert.Empty(errors);
             var newUe = newModel.AllElementsOfType<TestUserElement>().First();
 


### PR DESCRIPTION
BACKGROUND:
- Model de-serialization was broken in the Revit context due to assembly loading issues.

DESCRIPTION:
- catch type load errors, and simply skip them while building the type cache.
- Allow these errors to be added to the `Model.FromJson` error list
- Refactor to iterate over types only once while building cache.
- fixed #484 

TESTING:
- Use in Revit Context, and/or observe that all tests continue to work.
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

CHANGELOG:
- [ x] `CHANGELOG.md` is updated as necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/485)
<!-- Reviewable:end -->
