### PR TITLE
Add Polygon.TransformSegment()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Fixed #483 `Deserialization of profiles created in UpdateRepresentation`
 - Fixed #484 `Failure to deserialize Model if any assembly can't be loaded.`
 
+### Added
+- `Polyline.TransformSegment(...)` - Allows transforms for individual polyline segments. May be optionally flagged as polygon and/or planar motion.
+
 ## 0.8.1
 
 ### Added

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -898,45 +898,26 @@ namespace Elements.Geometry
         {
             var v = this.Vertices;
 
-            if (v.Count != 3 && !TransformIsPlanar(t))
-            {
-                // All motion is valid for a triangle, so we can skip this check in that case.
-                throw new Exception("Segment transformation must be within the polygon's plane.");
-            }
-
-
             if (i < 0 || i > v.Count)
             {
                 // Segment index is out of range, do no work.
                 return;
             }
 
+            var candidates = new List<Vector3>(this.Vertices);
+
             var endIndex = (i + 1) % v.Count;
 
-            v[i] = t.OfPoint(v[i]);
-            v[endIndex] = t.OfPoint(v[endIndex]);
-        }
+            candidates[i] = t.OfPoint(v[i]);
+            candidates[endIndex] = t.OfPoint(v[endIndex]);
 
-        internal bool TransformIsPlanar(Transform t)
-        {
-            // Get polygon normal and center
-            var n = this.Plane().Normal.Unitized();
-            var a = this.Centroid();
+            if (v.Count != 3 && !candidates.AreCoplanar())
+            {
+                // All motion is valid for a triangle, so we can skip this check in that case.
+                throw new Exception("Segment transformation must be within the polygon's plane.");
+            }
 
-            // Get the transform normal and center
-            var v = t.ZAxis.Unitized();
-            var b = t.Origin;
-
-            // Confirm planes have the same orientation
-            var cross = a.Cross(v);
-            var isSameOrientation = cross.X == 0 && cross.Y == 0 && cross.Z == 0;
-
-            // Confirm translation is planar
-            var translation = b - a;
-            var dot = n.Dot(translation);
-            var isPlanarTranslation = dot.ApproximatelyEquals(0);
-
-            return isSameOrientation && isPlanarTranslation;
+            this.Vertices = candidates;
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -896,12 +896,14 @@ namespace Elements.Geometry
         /// <param name="i">The segment to transform. If it does not exist, then no work will be done.</param>
         public void TransformSegment(Transform t, int i)
         {
-            if (!TransformIsPlanar(t))
+            var v = this.Vertices;
+
+            if (v.Count != 3 && !TransformIsPlanar(t))
             {
+                // All motion is valid for a triangle, so we can skip this check in that case.
                 throw new Exception("Segment transformation must be within the polygon's plane.");
             }
 
-            var v = this.Vertices;
 
             if (i < 0 || i > v.Count)
             {

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -21,9 +21,9 @@ namespace Elements.Geometry
         /// <param name="p">The polygon to convert.</param>
         public static implicit operator Profile(Polygon p) => new Profile(p);
 
-        // Though this conversion may seem redundant to the Curve => ModelCurve converter, it is needed to 
-        // make this the default implicit conversion from a polygon to an element (rather than the 
-        // polygon => profile conversion above.)  
+        // Though this conversion may seem redundant to the Curve => ModelCurve converter, it is needed to
+        // make this the default implicit conversion from a polygon to an element (rather than the
+        // polygon => profile conversion above.)
         /// <summary>
         /// Implicitly convert a Polygon to a ModelCurve Element.
         /// </summary>
@@ -68,7 +68,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Tests if the supplied Vector3 is within this Polygon, using a 2D method. 
+        /// Tests if the supplied Vector3 is within this Polygon, using a 2D method.
         /// </summary>
         /// <param name="vector">The position to test.</param>
         /// <param name="containment">Whether the point is inside, outside, at an edge, or at a vertex.</param>
@@ -890,6 +890,54 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Transform a specified segment of this polygon in place.
+        /// </summary>
+        /// <param name="t">The transform. If it is not within the polygon plane, then an exception will be thrown.</param>
+        /// <param name="i">The segment to transform. If it does not exist, then no work will be done.</param>
+        public void TransformSegment(Transform t, int i)
+        {
+            if (!TransformIsPlanar(t))
+            {
+                throw new Exception("Segment transformation must be within the polygon's plane.");
+            }
+
+            var v = this.Vertices;
+
+            if (i < 0 || i > v.Count)
+            {
+                // Segment index is out of range, do no work.
+                return;
+            }
+
+            var endIndex = (i + 1) % v.Count;
+
+            v[i] = t.OfPoint(v[i]);
+            v[endIndex] = t.OfPoint(v[endIndex]);
+        }
+
+        internal bool TransformIsPlanar(Transform t)
+        {
+            // Get polygon normal and center
+            var n = this.Plane().Normal.Unitized();
+            var a = this.Centroid();
+
+            // Get the transform normal and center
+            var v = t.ZAxis.Unitized();
+            var b = t.Origin;
+
+            // Confirm planes have the same orientation
+            var cross = a.Cross(v);
+            var isSameOrientation = cross.X == 0 && cross.Y == 0 && cross.Z == 0;
+
+            // Confirm translation is planar
+            var translation = b - a;
+            var dot = n.Dot(translation);
+            var isPlanarTranslation = dot.ApproximatelyEquals(0);
+
+            return isSameOrientation && isPlanarTranslation;
+        }
+
+        /// <summary>
         /// Fillet all corners on this polygon.
         /// </summary>
         /// <param name="radius">The fillet radius.</param>
@@ -1023,7 +1071,7 @@ namespace Elements.Geometry
         /// </summary>
         Intersection,
         /// <summary>
-        /// Exclusive or — either A or B but not both. 
+        /// Exclusive or — either A or B but not both.
         /// </summary>
         XOr
     }
@@ -1036,12 +1084,12 @@ namespace Elements.Geometry
     {
         /// <summary>
         /// Use an Even/Odd fill pattern to decide whether internal polygons are solid or void.
-        /// This corresponds to Clipper's "EvenOdd" PolyFillType. 
+        /// This corresponds to Clipper's "EvenOdd" PolyFillType.
         /// </summary>
         PreserveInternalVoids = 0,
         /// <summary>
         /// Treat all contained or overlapping polygons as solid.
-        /// This corresponds to Clipper's "Positive" PolyFillType. 
+        /// This corresponds to Clipper's "Positive" PolyFillType.
         /// </summary>
         IgnoreInternalVoids = 1
     }
@@ -1069,7 +1117,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Construct a Polygon from a clipper path 
+        /// Construct a Polygon from a clipper path
         /// </summary>
         /// <param name="p"></param>
         /// <param name="tolerance">Optional tolerance value. Be sure to use the same tolerance value as you used when converting to Clipper path.</param>

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -896,28 +896,7 @@ namespace Elements.Geometry
         /// <param name="i">The segment to transform. If it does not exist, then no work will be done.</param>
         public void TransformSegment(Transform t, int i)
         {
-            var v = this.Vertices;
-
-            if (i < 0 || i > v.Count)
-            {
-                // Segment index is out of range, do no work.
-                return;
-            }
-
-            var candidates = new List<Vector3>(this.Vertices);
-
-            var endIndex = (i + 1) % v.Count;
-
-            candidates[i] = t.OfPoint(v[i]);
-            candidates[endIndex] = t.OfPoint(v[endIndex]);
-
-            if (v.Count != 3 && !candidates.AreCoplanar())
-            {
-                // All motion is valid for a triangle, so we can skip this check in that case.
-                throw new Exception("Segment transformation must be within the polygon's plane.");
-            }
-
-            this.Vertices = candidates;
+            this.TransformSegment(t, i, true, true);
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -179,6 +179,41 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Transform a specified segment of this polyline in place.
+        /// </summary>
+        /// <param name="t">The transform. If it is not within the polygon plane, then an exception will be thrown.</param>
+        /// <param name="i">The segment to transform. If it does not exist, then no work will be done.</param>
+        /// <param name="isClosed">If set to true, the segment between the start end end point will be considered a valid target.</param>
+        /// <param name="isPlanar">If set to true, an exception will be thrown if the resultant shape is no longer planar.</param>
+        public void TransformSegment(Transform t, int i, bool isClosed = false, bool isPlanar = false)
+        {
+            var v = this.Vertices;
+
+            if (i < 0 || i > v.Count)
+            {
+                // Segment index is out of range, do no work.
+                return;
+            }
+
+            var candidates = new List<Vector3>(this.Vertices);
+
+            var endIndex = (i + 1) % v.Count;
+
+            candidates[i] = t.OfPoint(v[i]);
+            candidates[endIndex] = t.OfPoint(v[endIndex]);
+
+            // All motion for a triangle results in a planar shape, skip this case.
+            var enforcePlanar = v.Count != 3 && isPlanar;
+
+            if (enforcePlanar && !candidates.AreCoplanar())
+            {
+                throw new Exception("Segment transformation must be within the polygon's plane.");
+            }
+
+            this.Vertices = candidates;
+        }
+
+        /// <summary>
         /// Get the normal of each vertex on the polyline.
         /// </summary>
         /// <returns>A collection of unit vectors, each corresponding to a single vertex.</returns>
@@ -530,7 +565,7 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="l">The line to convert.</param>
         public static Polyline ToPolyline(this Line l) => new Polyline(new[] { l.Start, l.End });
-   
+
     }
 
     /// <summary>
@@ -539,7 +574,7 @@ namespace Elements.Geometry
     public enum EndType
     {
         /// <summary>
-        /// Open ends are extended by the offset distance and squared off 
+        /// Open ends are extended by the offset distance and squared off
         /// </summary>
         Square,
         /// <summary>

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -914,7 +914,7 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
-        public void TransformSegment_UnitSquare_ThrowsOnNonPlanar()
+        public void TransformSegment_UnitSquare_AllowsValidNonPlanar()
         {
             var s = 0.5;
 
@@ -928,7 +928,7 @@ namespace Elements.Geometry.Tests
 
             var t = new Transform(1, 1, 1);
 
-            Assert.Throws<Exception>(() => square.TransformSegment(t, 0));
+            square.TransformSegment(t, 0);
         }
 
         [Fact]
@@ -958,6 +958,16 @@ namespace Elements.Geometry.Tests
             Assert.Equal(s + 2, segment.Start.Z);
             Assert.Equal(s + 2, segment.End.Y);
             Assert.Equal(s + 2, segment.End.Z);
+        }
+
+        [Fact]
+        public void TransformSegment_Circle_ThrowsOnNonPlanar()
+        {
+            var circle = new Circle(new Vector3(), 1).ToPolygon();
+
+            var t = new Transform(2, 2, 2);
+
+            Assert.Throws<Exception>(() => circle.TransformSegment(t, 0));
         }
     }
 }

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -819,14 +819,16 @@ namespace Elements.Geometry.Tests
 
             square.TransformSegment(t, 0);
 
+            var segment = square.Segments()[0];
+
             var start = square.Vertices[0];
             var end = square.Vertices[1];
 
             // Confirm vertices are correctly moved
-            Assert.Equal(s, start.X);
-            Assert.Equal(s + 1, start.Y);
-            Assert.Equal(-s, end.X);
-            Assert.Equal(s + 1, end.Y);
+            Assert.Equal(s, segment.Start.X);
+            Assert.Equal(s + 1, segment.Start.Y);
+            Assert.Equal(-s, segment.End.X);
+            Assert.Equal(s + 1, segment.End.Y);
 
             // Confirm area has been correctly modified
             Assert.True(square.Area().ApproximatelyEquals(2));
@@ -849,17 +851,45 @@ namespace Elements.Geometry.Tests
 
             square.TransformSegment(t, 0);
 
-            var start = square.Vertices[0];
-            var end = square.Vertices[1];
+            var segment = square.Segments()[0];
 
             // Confirm vertices are correctly moved
-            Assert.Equal(s, start.X);
-            Assert.Equal(s - 0.5, start.Y);
-            Assert.Equal(-s, end.X);
-            Assert.Equal(s - 0.5, end.Y);
+            Assert.Equal(s, segment.Start.X);
+            Assert.Equal(s - 0.5, segment.Start.Y);
+            Assert.Equal(-s, segment.End.X);
+            Assert.Equal(s - 0.5, segment.End.Y);
 
             // Confirm area has been correctly modified
             Assert.True(square.Area().ApproximatelyEquals(0.5));
+        }
+
+        [Fact]
+        public void TransformSegment_UnitSquare_LastSegment()
+        {
+            var s = 0.5;
+
+            var square = new Polygon(new List<Vector3>()
+            {
+                new Vector3(s, s, 0),
+                new Vector3(-s, s, 0),
+                new Vector3(-s, -s, 0),
+                new Vector3(s, -s, 0)
+            });
+
+            var t = new Transform(1, 0, 0);
+
+            square.TransformSegment(t, 3);
+
+            var segment = square.Segments()[3];
+
+            // Confirm vertices are correctly moved
+            Assert.Equal(s + 1, segment.Start.X);
+            Assert.Equal(-s, segment.Start.Y);
+            Assert.Equal(s + 1, segment.End.X);
+            Assert.Equal(s, segment.End.Y);
+
+            // Confirm area has been correctly modified
+            Assert.True(square.Area().ApproximatelyEquals(2));
         }
 
         [Fact]
@@ -918,14 +948,16 @@ namespace Elements.Geometry.Tests
 
             square.TransformSegment(t, 0);
 
+            var segment = square.Segments()[0];
+
             var start = square.Vertices[0];
             var end = square.Vertices[1];
 
             // Confirm vertices are correctly moved
-            Assert.Equal(s + 2, start.Y);
-            Assert.Equal(s + 2, start.Z);
-            Assert.Equal(s + 2, end.Y);
-            Assert.Equal(s + 2, end.Z);
+            Assert.Equal(s + 2, segment.Start.Y);
+            Assert.Equal(s + 2, segment.Start.Z);
+            Assert.Equal(s + 2, segment.End.Y);
+            Assert.Equal(s + 2, segment.End.Z);
         }
     }
 }

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -671,7 +671,7 @@ namespace Elements.Geometry.Tests
         public void DeserializesWithoutDiscriminator()
         {
             // We've received a Polygon and we know that we're receiving
-            // a Polygon. The Polygon should deserialize without a 
+            // a Polygon. The Polygon should deserialize without a
             // discriminator.
             string json = @"
             {
@@ -800,6 +800,132 @@ namespace Elements.Geometry.Tests
                 var pt = polyCircle.PointAt(u);
                 this.Model.AddElement(new ModelCurve(circle.Transformed(new Transform(pt)), BuiltInMaterials.XAxis));
             }
+        }
+
+        [Fact]
+        public void TransformSegment_UnitSquare_Outwards()
+        {
+            var s = 0.5;
+
+            var square = new Polygon(new List<Vector3>()
+            {
+                new Vector3(s, s, 0),
+                new Vector3(-s, s, 0),
+                new Vector3(-s, -s, 0),
+                new Vector3(s, -s, 0)
+            });
+
+            var t = new Transform(0, 1, 0);
+
+            square.TransformSegment(t, 0);
+
+            var start = square.Vertices[0];
+            var end = square.Vertices[1];
+
+            // Confirm vertices are correctly moved
+            Assert.Equal(s, start.X);
+            Assert.Equal(s + 1, start.Y);
+            Assert.Equal(-s, end.X);
+            Assert.Equal(s + 1, end.Y);
+
+            // Confirm area has been correctly modified
+            Assert.True(square.Area().ApproximatelyEquals(2));
+        }
+
+        [Fact]
+        public void TransformSegment_UnitSquare_Inwards()
+        {
+            var s = 0.5;
+
+            var square = new Polygon(new List<Vector3>()
+            {
+                new Vector3(s, s, 0),
+                new Vector3(-s, s, 0),
+                new Vector3(-s, -s, 0),
+                new Vector3(s, -s, 0)
+            });
+
+            var t = new Transform(0, -0.5, 0);
+
+            square.TransformSegment(t, 0);
+
+            var start = square.Vertices[0];
+            var end = square.Vertices[1];
+
+            // Confirm vertices are correctly moved
+            Assert.Equal(s, start.X);
+            Assert.Equal(s - 0.5, start.Y);
+            Assert.Equal(-s, end.X);
+            Assert.Equal(s - 0.5, end.Y);
+
+            // Confirm area has been correctly modified
+            Assert.True(square.Area().ApproximatelyEquals(0.5));
+        }
+
+        [Fact]
+        public void TransformSegment_UnitSquare_OutOfRange()
+        {
+            var s = 0.5;
+
+            var square = new Polygon(new List<Vector3>()
+            {
+                new Vector3(s, s, 0),
+                new Vector3(-s, s, 0),
+                new Vector3(-s, -s, 0),
+                new Vector3(s, -s, 0)
+            });
+
+            var t = new Transform(1, 1, 0);
+
+            square.TransformSegment(t, 100);
+
+            // Confirm area has remained the same
+            Assert.True(square.Area().ApproximatelyEquals(1));
+        }
+
+        [Fact]
+        public void TransformSegment_UnitSquare_ThrowsOnNonPlanar()
+        {
+            var s = 0.5;
+
+            var square = new Polygon(new List<Vector3>()
+            {
+                new Vector3(s, s, 0),
+                new Vector3(-s, s, 0),
+                new Vector3(-s, -s, 0),
+                new Vector3(s, -s, 0)
+            });
+
+            var t = new Transform(1, 1, 1);
+
+            Assert.Throws<Exception>(() => square.TransformSegment(t, 0));
+        }
+
+        [Fact]
+        public void TransformSegment_RotatedSquare_AllowsPlanarMotion()
+        {
+            var s = 0.5;
+
+            var square = new Polygon(new List<Vector3>()
+            {
+                new Vector3(s, s, s),
+                new Vector3(-s, s, s),
+                new Vector3(-s, -s, -s),
+                new Vector3(s, -s, -s)
+            });
+
+            var t = new Transform(0, 2, 2);
+
+            square.TransformSegment(t, 0);
+
+            var start = square.Vertices[0];
+            var end = square.Vertices[1];
+
+            // Confirm vertices are correctly moved
+            Assert.Equal(s + 2, start.Y);
+            Assert.Equal(s + 2, start.Z);
+            Assert.Equal(s + 2, end.Y);
+            Assert.Equal(s + 2, end.Z);
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- I was developing this method for a specific function and realized it probably belongs in Elements proper.

DESCRIPTION:
- Adds the ability to translate just one 'segment' of a polygon (two consecutive vertices). 
- Throws an exception if the requested transformation is not within the polygon's current plane.
  - Triangles skip this check, since they are always planar.

TESTING:
Tests in the code:

- One-axis transformations of a square on the XY plane
- Two-axis transformations of a square in 3D space
- Confirm no work is done if specified segment does not exist
- Confirm function throws in request motion in non-planar
  
FUTURE WORK:
- There may be valid transformation cases that we support but I didn't realize! These should probably have tests.
- Some shapes may have valid non-planar transformations. (e.g. a flat square's edge can be moved vertically out-of-plane and still be a planar shape). I don't know how to generically check for this, though, and do not need to support this kind of motion. So, for now, I opted for the current more-constrained check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/487)
<!-- Reviewable:end -->
