### PR TITLE
Add Polygon.SharedSegments()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Fixed #483 `Deserialization of profiles created in UpdateRepresentation`
 - Fixed #484 `Failure to deserialize Model if any assembly can't be loaded.`
 
+### Added
+- `Polyline.SharedSegments()` - Enables search for segments shared between two polylines.
+
 ## 0.8.1
 
 ### Added

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -1003,56 +1003,6 @@ namespace Elements.Geometry
             verts.Add(this.Start);
             return verts;
         }
-
-        /// <summary>
-        /// Identify any shared segments between two polygons.
-        /// </summary>
-        /// <param name="a">The first polygon to compare.</param>
-        /// <param name="b">The second polygon to compare.</param>
-        /// <returns>Returns a list of tuples of indices for the segments that match in each polygon.</returns>
-        public static List<(int, int)> SharedSegments(Polygon a, Polygon b)
-        {
-            var result = new List<(int, int)>();
-
-            // Abbreviate lists to compare
-            var va = a.Vertices;
-            var vb = b.Vertices;
-
-            for (var i = 0; i < va.Count; i++)
-            {
-                var ia = va[i];
-                var ib = va[(i + 1) % va.Count];
-
-                for (var j = 0; j < vb.Count; j++)
-                {
-                    var ja = vb[j];
-
-                    if (ia.IsAlmostEqualTo(ja))
-                    {
-                        // Current vertices match, compare next vertices
-                        var jNext = (j + 1) % vb.Count;
-                        var jPrev = j == 0 ? vb.Count - 1 : j - 1;
-
-                        var jb = vb[jNext];
-                        var jc = vb[jPrev];
-
-                        if (ib.IsAlmostEqualTo(jb))
-                        {
-                            // Match is current segment a and current segment b
-                            result.Add((i, j));
-                        }
-
-                        if (ib.IsAlmostEqualTo(jc))
-                        {
-                            // Match is current segment a and previous segment b
-                            result.Add((i, jPrev));
-                        }
-                    }
-                }
-            }
-
-            return result;
-        }
     }
 
     /// <summary>

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -21,9 +21,9 @@ namespace Elements.Geometry
         /// <param name="p">The polygon to convert.</param>
         public static implicit operator Profile(Polygon p) => new Profile(p);
 
-        // Though this conversion may seem redundant to the Curve => ModelCurve converter, it is needed to 
-        // make this the default implicit conversion from a polygon to an element (rather than the 
-        // polygon => profile conversion above.)  
+        // Though this conversion may seem redundant to the Curve => ModelCurve converter, it is needed to
+        // make this the default implicit conversion from a polygon to an element (rather than the
+        // polygon => profile conversion above.)
         /// <summary>
         /// Implicitly convert a Polygon to a ModelCurve Element.
         /// </summary>
@@ -68,7 +68,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Tests if the supplied Vector3 is within this Polygon, using a 2D method. 
+        /// Tests if the supplied Vector3 is within this Polygon, using a 2D method.
         /// </summary>
         /// <param name="vector">The position to test.</param>
         /// <param name="containment">Whether the point is inside, outside, at an edge, or at a vertex.</param>
@@ -1003,6 +1003,56 @@ namespace Elements.Geometry
             verts.Add(this.Start);
             return verts;
         }
+
+        /// <summary>
+        /// Identify any shared segments between two polygons.
+        /// </summary>
+        /// <param name="a">The first polygon to compare.</param>
+        /// <param name="b">The second polygon to compare.</param>
+        /// <returns>Returns a list of tuples of indices for the segments that match in each polygon.</returns>
+        public static List<(int, int)> SharedSegments(Polygon a, Polygon b)
+        {
+            var result = new List<(int, int)>();
+
+            // Abbreviate lists to compare
+            var va = a.Vertices;
+            var vb = b.Vertices;
+
+            for (var i = 0; i < va.Count; i++)
+            {
+                var ia = va[i];
+                var ib = va[(i + 1) % va.Count];
+
+                for (var j = 0; j < vb.Count; j++)
+                {
+                    var ja = vb[j];
+
+                    if (ia.IsAlmostEqualTo(ja))
+                    {
+                        // Current vertices match, compare next vertices
+                        var jNext = (j + 1) % vb.Count;
+                        var jPrev = j == 0 ? vb.Count - 1 : j - 1;
+
+                        var jb = vb[jNext];
+                        var jc = vb[jPrev];
+
+                        if (ib.IsAlmostEqualTo(jb))
+                        {
+                            // Match is current segment a and current segment b
+                            result.Add((i, j));
+                        }
+
+                        if (ib.IsAlmostEqualTo(jc))
+                        {
+                            // Match is current segment a and previous segment b
+                            result.Add((i, jPrev));
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
     }
 
     /// <summary>
@@ -1023,7 +1073,7 @@ namespace Elements.Geometry
         /// </summary>
         Intersection,
         /// <summary>
-        /// Exclusive or — either A or B but not both. 
+        /// Exclusive or — either A or B but not both.
         /// </summary>
         XOr
     }
@@ -1036,12 +1086,12 @@ namespace Elements.Geometry
     {
         /// <summary>
         /// Use an Even/Odd fill pattern to decide whether internal polygons are solid or void.
-        /// This corresponds to Clipper's "EvenOdd" PolyFillType. 
+        /// This corresponds to Clipper's "EvenOdd" PolyFillType.
         /// </summary>
         PreserveInternalVoids = 0,
         /// <summary>
         /// Treat all contained or overlapping polygons as solid.
-        /// This corresponds to Clipper's "Positive" PolyFillType. 
+        /// This corresponds to Clipper's "Positive" PolyFillType.
         /// </summary>
         IgnoreInternalVoids = 1
     }
@@ -1069,7 +1119,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Construct a Polygon from a clipper path 
+        /// Construct a Polygon from a clipper path
         /// </summary>
         /// <param name="p"></param>
         /// <param name="tolerance">Optional tolerance value. Be sure to use the same tolerance value as you used when converting to Clipper path.</param>

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -808,7 +808,7 @@ namespace Elements.Geometry.Tests
             var a = new Circle(new Vector3(), 1).ToPolygon();
             var b = new Circle(new Vector3(), 2).ToPolygon();
 
-            var results = Polygon.SharedSegments(a, b);
+            var results = Polygon.SharedSegments(a, b, true);
 
             Assert.Equal(0, results.Count);
         }
@@ -819,7 +819,7 @@ namespace Elements.Geometry.Tests
             var a = new Circle(new Vector3(1, 0, 0), 2).ToPolygon();
             var b = new Circle(new Vector3(-1, 0, 0), 2).ToPolygon();
 
-            var results = Polygon.SharedSegments(a, b);
+            var results = Polygon.SharedSegments(a, b, true);
 
             Assert.Equal(0, results.Count);
         }
@@ -830,7 +830,7 @@ namespace Elements.Geometry.Tests
             var a = new Circle(new Vector3(), 1).ToPolygon();
             var b = new Circle(new Vector3(), 1).ToPolygon();
 
-            var results = Polygon.SharedSegments(a, b);
+            var results = Polygon.SharedSegments(a, b, true);
 
             Assert.Equal(10, results.Count);
         }
@@ -841,7 +841,7 @@ namespace Elements.Geometry.Tests
             var a = new Circle(new Vector3(), 1).ToPolygon();
             var b = new Circle(new Vector3(), 1).ToPolygon();
 
-            var matches = Polygon.SharedSegments(a, b);
+            var matches = Polygon.SharedSegments(a, b, true);
 
             var result = matches.Select(match =>
             {
@@ -876,7 +876,7 @@ namespace Elements.Geometry.Tests
             var a = new Circle(new Vector3(), 1).ToPolygon();
             var b = new Circle(new Vector3(), 1).ToPolygon().Reversed();
 
-            var matches = Polygon.SharedSegments(a, b);
+            var matches = Polygon.SharedSegments(a, b, true);
 
             var result = matches.Select(match =>
             {
@@ -923,7 +923,7 @@ namespace Elements.Geometry.Tests
                 new Vector3(0, 0, 0),
             });
 
-            var matches = Polygon.SharedSegments(a, b);
+            var matches = Polygon.SharedSegments(a, b, true);
 
             Assert.Equal(1, matches.Count);
         }
@@ -946,7 +946,7 @@ namespace Elements.Geometry.Tests
                 new Vector3(0, 0.5, 0),
             });
 
-            var matches = Polygon.SharedSegments(a, b);
+            var matches = Polygon.SharedSegments(a, b, true);
 
             Assert.Equal(0, matches.Count);
         }

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -810,7 +810,7 @@ namespace Elements.Geometry.Tests
 
             var results = Polygon.SharedSegments(a, b, true);
 
-            Assert.Equal(0, results.Count);
+            Assert.Empty(results);
         }
 
         [Fact]
@@ -821,7 +821,7 @@ namespace Elements.Geometry.Tests
 
             var results = Polygon.SharedSegments(a, b, true);
 
-            Assert.Equal(0, results.Count);
+            Assert.Empty(results);
         }
 
         [Fact]
@@ -925,7 +925,7 @@ namespace Elements.Geometry.Tests
 
             var matches = Polygon.SharedSegments(a, b, true);
 
-            Assert.Equal(1, matches.Count);
+            Assert.Single(matches);
         }
 
         [Fact]
@@ -948,8 +948,10 @@ namespace Elements.Geometry.Tests
 
             var matches = Polygon.SharedSegments(a, b, true);
 
-            Assert.Equal(0, matches.Count);
+            Assert.Empty(matches);
         }
+
+        [Fact]
         public void TransformSegment_UnitSquare_Outwards()
         {
             var s = 0.5;

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -871,6 +871,41 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
+        public void SharedSegments_DuplicateReversedCircles_AccurateResults()
+        {
+            var a = new Circle(new Vector3(), 1).ToPolygon();
+            var b = new Circle(new Vector3(), 1).ToPolygon().Reversed();
+
+            var matches = Polygon.SharedSegments(a, b);
+
+            var result = matches.Select(match =>
+            {
+                var (t, u) = match;
+
+                var segmentA = a.Segments()[t];
+                var segmentB = b.Segments()[u];
+
+                // Reverse segment b if necessary
+                if (!segmentA.Start.IsAlmostEqualTo(segmentB.Start))
+                {
+                    segmentB = segmentB.Reversed();
+                }
+
+                var sa = segmentA.Start;
+                var sb = segmentB.Start;
+                var ea = segmentA.End;
+                var eb = segmentB.End;
+
+                var startMatches = sa.IsAlmostEqualTo(sb);
+                var endMatches = ea.IsAlmostEqualTo(eb);
+
+                return startMatches && endMatches;
+            });
+
+            Assert.DoesNotContain(false, result);
+        }
+
+        [Fact]
         public void SharedSegments_MirroredSquares_OneResult()
         {
             var s = 1;
@@ -891,6 +926,29 @@ namespace Elements.Geometry.Tests
             var matches = Polygon.SharedSegments(a, b);
 
             Assert.Equal(1, matches.Count);
+        }
+
+        [Fact]
+        public void SharedSegments_TouchingShiftedSquares_NoResults()
+        {
+            var s = 1;
+
+            var a = new Polygon(new List<Vector3>(){
+                new Vector3(0, s, 0),
+                new Vector3(-s, s, 0),
+                new Vector3(-s, 0, 0),
+                new Vector3(0, 0, 0),
+            });
+            var b = new Polygon(new List<Vector3>(){
+                new Vector3(0, s + 0.5, 0),
+                new Vector3(s, s + 0.5, 0),
+                new Vector3(s, 0.5, 0),
+                new Vector3(0, 0.5, 0),
+            });
+
+            var matches = Polygon.SharedSegments(a, b);
+
+            Assert.Equal(0, matches.Count);
         }
     }
 }

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -72,7 +72,7 @@ namespace Elements.Geometry.Tests
 
             var matches = Polygon.SharedSegments(a, b);
 
-            Assert.Equal(0, matches.Count);
+            Assert.Empty(matches);
         }
     }
 }

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -1,9 +1,10 @@
+using System.Collections.Generic;
 using Elements.Tests;
 using Xunit;
 
 namespace Elements.Geometry.Tests
 {
-    public class PolylineTests: ModelTest
+    public class PolylineTests : ModelTest
     {
         public PolylineTests()
         {
@@ -45,10 +46,33 @@ namespace Elements.Geometry.Tests
             var offsetResult = offsetResults[0];
             Assert.Equal(4, offsetResult.Vertices.Count);
             // offsets to a rectangle that's offsetAmt longer than the segment in
-            // each direction, and 2x offsetAmt in width, so the long sides are 
+            // each direction, and 2x offsetAmt in width, so the long sides are
             // each length + 2x offsetAmt, and the short sides are each 2x offsetAmt.
             var targetLength = 2 * length + 8 * offsetAmt;
             Assert.Equal(targetLength, offsetResult.Length(), 2);
+        }
+
+        [Fact]
+        public void SharedSegments_OpenMirroredSquares_OneResult()
+        {
+            var s = 1;
+
+            var a = new Polygon(new List<Vector3>(){
+                new Vector3(0, s, 0),
+                new Vector3(-s, s, 0),
+                new Vector3(-s, 0, 0),
+                new Vector3(0, 0, 0),
+            });
+            var b = new Polygon(new List<Vector3>(){
+                new Vector3(0, s, 0),
+                new Vector3(s, s, 0),
+                new Vector3(s, 0, 0),
+                new Vector3(0, 0, 0),
+            });
+
+            var matches = Polygon.SharedSegments(a, b);
+
+            Assert.Equal(0, matches.Count);
         }
     }
 }

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -53,7 +53,7 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
-        public void SharedSegments_OpenMirroredSquares_OneResult()
+        public void SharedSegments_OpenMirroredSquares_NoResults()
         {
             var s = 1;
 


### PR DESCRIPTION
BACKGROUND:
- I need the ability to find shared segments between polygons for another function. I thought it would be useful to include in elements.

DESCRIPTION:
- Adds a static `Polygon.SharedSegments()` method.
- Given two polygons, it returns a set of tuples for any shared segments
  - A 'shared segment' means the start and end points are the same (although possibly reversed)
- The tuple is of the segment indices for their respective polygons. They can be different, hence tuple instead of just `int`.

TESTING:
Tests in code are:

- Concentric polygon circles return no results
- Intersecting polygon circles return no results
- Identical polygon circles return ten accurate results
- Identical polygon circles (one reversed) return ten accurate results
- A pair of squares with one shared edge return one result
- A pair of squares with touching (but not identical) edges returns no results

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/488)
<!-- Reviewable:end -->
