### PR TITLE
run alpha release correctly after main release

### DIFF
--- a/.github/workflows/build-and-publish-alpha.yml
+++ b/.github/workflows/build-and-publish-alpha.yml
@@ -42,7 +42,14 @@ jobs:
         run: echo "NUGET_VERSION=${{steps.bump-beta.outputs.next-version}}" >> $GITHUB_ENV
       - name: Set NuGet version as first alpha if previous tag is a main release
         if: ${{!contains(steps.version.outputs.tag, 'beta') && !contains(steps.version.outputs.tag, 'alpha')}}
-        run: echo "NUGET_VERSION=${{steps.version.outputs.tag}}-alpha1" >> $GITHUB_ENV
+        id: bump-first-alpha
+        uses: christian-draeger/increment-semantic-version@1.0.2
+        with:
+          current-version: ${{steps.version.outputs.tag}}
+          version-fragment: "bug"
+      - name: Set NuGet version from first alpha
+        if: ${{!contains(steps.version.outputs.tag, 'beta') && !contains(steps.version.outputs.tag, 'alpha')}}
+        run: echo "NUGET_VERSION=${{steps.bump-first-alpha.outputs.next-version}}-alpha1" >> $GITHUB_ENV
       - run: dotnet build -c release -p:Version=${{ env.NUGET_VERSION }}
       - name: Publish NuGet package.
         run: |

--- a/.github/workflows/build-and-publish-alpha.yml
+++ b/.github/workflows/build-and-publish-alpha.yml
@@ -21,14 +21,14 @@ jobs:
         id: version
         uses: "WyriHaximus/github-action-get-previous-tag@master"
       - name: Bump if alpha.
-        if: ${{contains(steps.version.outputs.tag, 'alpha')}}
+        if: ${{contains(steps.version.outputs.tag, 'alpha') || !contains(steps.version.outputs.tag, 'beta')}}
         id: bump-alpha
         uses: christian-draeger/increment-semantic-version@1.0.2
         with:
           current-version: ${{steps.version.outputs.tag}}
           version-fragment: "alpha"
       - name: Set NuGet version from alpha.
-        if: ${{contains(steps.version.outputs.tag, 'alpha')}}
+        if: ${{contains(steps.bump-alpha.outputs.next-version, 'alpha')}}
         run: echo "NUGET_VERSION=${{steps.bump-alpha.outputs.next-version}}" >> $GITHUB_ENV
       - name: Bump if beta.
         if: ${{contains(steps.version.outputs.tag, 'beta')}}

--- a/.github/workflows/build-and-publish-alpha.yml
+++ b/.github/workflows/build-and-publish-alpha.yml
@@ -21,14 +21,14 @@ jobs:
         id: version
         uses: "WyriHaximus/github-action-get-previous-tag@master"
       - name: Bump if alpha.
-        if: ${{contains(steps.version.outputs.tag, 'alpha') || !contains(steps.version.outputs.tag, 'beta')}}
+        if: ${{contains(steps.version.outputs.tag, 'alpha')}}
         id: bump-alpha
         uses: christian-draeger/increment-semantic-version@1.0.2
         with:
           current-version: ${{steps.version.outputs.tag}}
           version-fragment: "alpha"
       - name: Set NuGet version from alpha.
-        if: ${{contains(steps.bump-alpha.outputs.next-version, 'alpha')}}
+        if: ${{contains(steps.version.outputs.tag, 'alpha')}}
         run: echo "NUGET_VERSION=${{steps.bump-alpha.outputs.next-version}}" >> $GITHUB_ENV
       - name: Bump if beta.
         if: ${{contains(steps.version.outputs.tag, 'beta')}}
@@ -40,6 +40,9 @@ jobs:
       - name: Set NuGet version from beta.
         if: ${{contains(steps.version.outputs.tag, 'beta')}}
         run: echo "NUGET_VERSION=${{steps.bump-beta.outputs.next-version}}" >> $GITHUB_ENV
+      - name: Set NuGet version as first alpha if previous tag is a main release
+        if: ${{!contains(steps.version.outputs.tag, 'beta') && !contains(steps.version.outputs.tag, 'alpha')}}
+        run: echo "NUGET_VERSION=${{steps.version.outputs.tag}}-alpha1" >> $GITHUB_ENV
       - run: dotnet build -c release -p:Version=${{ env.NUGET_VERSION }}
       - name: Publish NuGet package.
         run: |


### PR DESCRIPTION
BACKGROUND:
- CICD was failing to release alpha versions after a main release. It checks for the existence of 'alpha' or 'beta' on the previous version before incrementing, which a main release doesn't have, and so it failed.

DESCRIPTION:
- Increments version with `-alpha1` if is not already a beta or alpha release

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/491)
<!-- Reviewable:end -->
