### PR TITLE
allow alternative mesh deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.8.3
+
+### Changed
+- Make MeshConverter deserialization more flexible to accommodate a schema used in function `input_schema`.
+
 ## 0.8.2
 
 ### Changed


### PR DESCRIPTION
BACKGROUND:
- There is an alternative schema format that is used in the front end that we would like to be able to deserialize when it is in the present on an input_schema.

DESCRIPTION:
- Identify the other schema type by the presence of the "vertices" property.
- If this is the "input mesh" then deserialize into the mesh type in a slightly different way.

TESTING:
- The Roof By Sketch function is proof of this functionality working, it has temporarily been published with a local elements reference.
  
FUTURE WORK:
- We should make an effort on both the Hypar web app and in this library to converge on a single mesh schema representation, as outlines in the note above the converter code.

CHANGELOG:
- [x ] `CHANGELOG.md` is updated as necessary. 

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/492)
<!-- Reviewable:end -->
