### PR TITLE
Add Profile.UnionAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Added
 
+- `Profile.UnionAll(...)` - Create a new set of profiles, merging any overlapping profiles and preserving internal voids.
 - `Polyline.SharedSegments()` - Enables search for segments shared between two polylines.
 - `Polyline.TransformSegment(...)` - Allows transforms for individual polyline segments. May be optionally flagged as polygon and/or planar motion.
 

--- a/Elements/test/ProfileTests.cs
+++ b/Elements/test/ProfileTests.cs
@@ -50,6 +50,29 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void ProfileUnionAll()
+        {
+            this.Name = "ProfileUnionAll";
+            var outer1 = new Circle(Vector3.Origin, 5).ToPolygon(10);
+            var inner1 = new Circle(Vector3.Origin, 4).ToPolygon(10);
+            var outer2 = new Circle(new Vector3(9, 0, 0), 5).ToPolygon(10);
+            var inner2 = new Circle(new Vector3(9, 0, 0), 4).ToPolygon(10);
+            var outer3 = new Circle(new Vector3(4.5, 12, 0), 5).ToPolygon(10);
+            var inner3 = new Circle(new Vector3(4.5, 12, 0), 4).ToPolygon(10);
+            var p1 = new Profile(outer1, inner1);
+            var p2 = new Profile(outer2, inner2);
+            var p3 = new Profile(outer3, inner3);
+            var union = Elements.Geometry.Profile.UnionAll(new[] { p1, p2, p3 });
+            foreach (var profile in union)
+            {
+                var floor = new Floor(profile, 1);
+                this.Model.AddElement(floor);
+            }
+            Assert.Equal(2, union.Count);
+            
+        }
+
+        [Fact]
         public void VoidsOrientedCorrectly()
         {
             this.Name = "VoidsOrientedCorrectly";


### PR DESCRIPTION
BACKGROUND:
- There did not exist a method to join multiple regions including their internal voids. This is useful for operations like combining overlapping sets of corridor geometry, which may be simple closed curves or contain inner loops.

DESCRIPTION:
- Adds a static `Profile.UnionAll(IEnumerable<Profile> profiles, double tolerance = Vector3.Epsilon)` method which takes a list of profiles, merges them together using clipper, and constructs new profiles from the results.
- Adds a (fairly barebones) test to ensure this works correctly

TESTING:
- Have tested by running the test
- Have tested in use by referring to this method in some private functions
  
FUTURE WORK:
- We should probably expose other kinds of boolean operations on `Profile`
- We should probably write a few more tests for this
- We might want to expose other solve options for union (more of the clipper configuration stuff)

CHANGELOG:
- [x] `CHANGELOG.md` is updated as necessary. 

