### PR TITLE
Grid2d updated from axis change fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fixed #483 `Deserialization of profiles created in UpdateRepresentation`
 - Fixed #484 `Failure to deserialize Model if any assembly can't be loaded.`
+- Fixed an issue where updates to a `Grid2d`'s component `Grid1d` axes would not propagate to the `Grid2d`.  
 
 ### Added
 

--- a/Elements/src/Spatial/Grid1d.cs
+++ b/Elements/src/Spatial/Grid1d.cs
@@ -24,7 +24,19 @@ namespace Elements.Spatial
         /// <summary>
         /// Child cells of this Grid. If null, this Grid is a complete cell with no subdivisions.
         /// </summary>
-        public List<Grid1d> Cells { get; private set; }
+        public List<Grid1d> Cells
+        {
+            get => cells;
+            private set
+            {
+                if (this.parent != null)
+                {
+                    //invalidate previously generated 2d grid
+                    parent.TryInvalidateGrid();
+                }
+                cells = value;
+            }
+        }
 
         /// <summary>
         /// Numerical domain of this Grid
@@ -53,6 +65,7 @@ namespace Elements.Spatial
 
         // if this 1d grid is the axis of a 2d grid, this is where we store that reference. If not, it will be null
         private Grid2d parent;
+        private List<Grid1d> cells;
 
         #endregion
 

--- a/Elements/src/Spatial/Grid2d.cs
+++ b/Elements/src/Spatial/Grid2d.cs
@@ -390,7 +390,7 @@ namespace Elements.Spatial
                 }
                 return cells;
             }
-            private set => cells = value;
+            internal set => cells = value;
         }
 
         /// <summary>
@@ -586,7 +586,21 @@ namespace Elements.Spatial
 
         #endregion
 
-        #region Private Methods
+        #region Private/Internal Methods
+        /// <summary>
+        /// Invalidate the `Cells` property, used by child (axis) 1d grids to tell the parent that they've been updated.
+        /// This sort of change is not allowed if the sub-cells already have been further subdivided, as regenerating them
+        /// would wipe out these subcells, so in this case an error is thrown.
+        /// </summary>
+        internal void TryInvalidateGrid()
+        {
+            if (this.cells != null && this.CellsFlat.Any(c => !c.IsSingleCell))
+            {
+                throw new NotSupportedException("An attempt was made to modify the underlying U or V grid of a 2D Grid, after some of its cells had already been further subdivided.");
+            }
+            this.cells = null;
+        }
+
         private void InitializeUV(Domain1d uDomain, Domain1d vDomain)
         {
             var uCrv = new Line(new Vector3(uDomain.Min, 0, 0), new Vector3(uDomain.Max, 0, 0));

--- a/Elements/test/Grid2dTests.cs
+++ b/Elements/test/Grid2dTests.cs
@@ -94,6 +94,27 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void ChildGridUpdatesParent()
+        {
+            var u = new Grid1d(10);
+            var v = new Grid1d(5);
+            var grid2d = new Grid2d(u, v);
+            Assert.Equal(1, grid2d.CellsFlat.Count);
+            grid2d.U.DivideByCount(10);
+            grid2d.V.DivideByCount(5);
+            Assert.Equal(50, grid2d.CellsFlat.Count);
+        }
+
+        [Fact]
+        public void DisallowedGridEditingThrowsException()
+        {
+            var grid2d = new Grid2d(5, 5);
+            grid2d.V.DivideByCount(5);
+            grid2d.CellsFlat[2].U.DivideByCount(5);
+            Assert.Throws<NotSupportedException>(() => grid2d.U.DivideByCount(2));
+        }
+
+        [Fact]
         public void CellSeparatorsTrimmed()
         {
             Name = "CellSeparatorsTrimmed";


### PR DESCRIPTION
BACKGROUND:
- trying to update a grid2d's component 1d grid axis after creation would fail to update its 2d cells, if the `Cells` property on the 2d grid had already been accessed

DESCRIPTION:
- Allows invalidation of the parent 2d grid's cells if the child U or V grid is modified
- Prevents invalidation of the parent grid and throws an exception if a user attempts to modify the axis grid when there has already been 2d subdivision (as this would destroy the already-modified inner 2d cell) 

TESTING:
- New tests have been added 
- This change is being used already in functions for a customer

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.
- [ ] The docs are up to date. To update the docs run `build_docs.sh` locally, and commit the results. 
     (no public method / docs changes)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/497)
<!-- Reviewable:end -->
