### PR TITLE
Remove unnecessary cicd steps

### DIFF
--- a/.github/workflows/build-and-publish-alpha.yml
+++ b/.github/workflows/build-and-publish-alpha.yml
@@ -17,10 +17,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.x
-      - name: Setup mono
-        run: sudo apt install mono-complete
-      - name: Setup docfx
-        run: brew install docfx
       - name: Get previous tag.
         id: version
         uses: "WyriHaximus/github-action-get-previous-tag@master"


### PR DESCRIPTION
BACKGROUND:
- I just merged #505 but accidentally left unnecessary (and long-running steps) in the `build-and-publish-alpha` workflow

DESCRIPTION:
- Removes unnecessary steps (install mono + docfx) from the alpha release job

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/506)
<!-- Reviewable:end -->
