### PR TITLE
remove docs build from not-docs-build step

### DIFF
--- a/.github/workflows/build-and-publish-alpha.yml
+++ b/.github/workflows/build-and-publish-alpha.yml
@@ -42,12 +42,6 @@ jobs:
         run: echo "NUGET_VERSION=${{steps.bump-beta.outputs.next-version}}" >> $GITHUB_ENV
       - name: Build Elements
         run: dotnet build -c release -p:Version=${{ env.NUGET_VERSION }}
-      - name: Build docs
-        run: sh ./build_docs.sh
-      - name: Commit docs
-        uses: EndBug/add-and-commit@v7
-        with:
-          message: "Updated docs for Elements ${{ env.NUGET_VERISION }}"
       - name: Publish NuGet package.
         run: |
           dotnet nuget push ./nupkg/Hypar.Elements.${{ env.NUGET_VERSION }}.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}


### PR DESCRIPTION
BACKGROUND:
- I left out two critical steps from #506

DESCRIPTION:
- Removes copy of build docs step in main alpha release workflow (since it lives in its own step now)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/508)
<!-- Reviewable:end -->
