### PR TITLE
unitize axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bbox3.ToModelCurves()
 ### Changed
 - Make MeshConverter deserialization more flexible to accommodate a schema used in function `input_schema`.
+- new Transform(Vector3 origin, Vector3 xAxis, Vector3 yAxis, Vector3 zAxis) did not unitize its axes, this is fixed.
 
 ### Fixed
 - Fixed a bug where Polygon.UnionAll was sometimes returning null when it shouldn't (Thanks @M-Juliani !)

--- a/Elements/src/Geometry/Transform.cs
+++ b/Elements/src/Geometry/Transform.cs
@@ -138,7 +138,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Create a transform by origin, X, Y, and Z axes.
+        /// Create a transform by origin, X, Y, and Z axes. Axes are automatically unitized — to create non-uniform transforms, use Transform.Scale.
         /// </summary>
         /// <param name="origin">The origin of the transform.</param>
         /// <param name="xAxis">The X axis of the transform.</param>
@@ -149,7 +149,7 @@ namespace Elements.Geometry
                          Vector3 yAxis,
                          Vector3 zAxis)
         {
-            this.Matrix = new Matrix(xAxis, yAxis, zAxis, origin);
+            this.Matrix = new Matrix(xAxis.Unitized(), yAxis.Unitized(), zAxis.Unitized(), origin);
         }
 
         /// <summary>


### PR DESCRIPTION
BACKGROUND:
- A user assumed that the Transform constructor would unitize direction axes, when this was not the case. This is a pretty reasonable assumption to make, so let's make it true (non-uniform transforms can still be created with Transform.Scale).

DESCRIPTION:
- unitizes axis vectors

TESTING:
- Tests continue to pass

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.
- [ ] The docs are up to date. To update the docs run `build_docs.sh` locally, and commit the results. — isn't this automatic now?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/511)
<!-- Reviewable:end -->
