### PR TITLE
remove docs step

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,6 @@ FUTURE WORK:
 
 REQUIRED:
 - [ ] All changes are up to date in `CHANGELOG.md`.
-- [ ] The docs are up to date. To update the docs run `build_docs.sh` locally, and commit the results.
 
 COMMENTS:
 - Any other notes.


### PR DESCRIPTION
BACKGROUND:
- thanks to @cdriesler, docs now automatically get updated via CICD, so no longer need to be included in our PR template

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.
- [X] The docs are up to date. To update the docs run `build_docs.sh` locally, and commit the results. (just checking this box.... one last time)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/515)
<!-- Reviewable:end -->
