### PR TITLE
Cache glb streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changed
 - `Elements.DirectionalLight` now inherits from `Elements.Light`.
+- Adding glb elements to a model uses a cache rather than fetching the stream every time.
 
 ## 0.8.3
 

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -223,7 +223,7 @@ namespace Elements.Serialization.glTF
                     m.NormalTexture = ti;
                     ti.Index = normalTexId;
                     ti.Scale = 1.0f;
-                    // Use the same texture coordinate as the 
+                    // Use the same texture coordinate as the
                     // base texture.
                     ti.TexCoord = 0;
 
@@ -974,7 +974,7 @@ namespace Elements.Serialization.glTF
                 var transform = new Transform();
                 if (i.BaseDefinition is ContentElement contentBase)
                 {
-                    // If there is a transform stored for the content base definition we 
+                    // If there is a transform stored for the content base definition we
                     // should apply it when creating instances.
                     if (meshTransformMap.TryGetValue(i.BaseDefinition.Id, out var baseTransform))
                     {
@@ -1097,9 +1097,21 @@ namespace Elements.Serialization.glTF
             }
         }
 
+        private static Dictionary<string, MemoryStream> gltfCache = new Dictionary<string, MemoryStream>();
+
         internal static Stream GetGlbStreamFromPath(string gltfLocation)
         {
             var responseStream = new MemoryStream();
+
+            if (gltfCache.TryGetValue(gltfLocation, out var foundStream))
+            {
+                Console.WriteLine("cache hit: " + gltfLocation);
+                foundStream.Position = 0;
+                foundStream.CopyTo(responseStream);
+                responseStream.Position = 0;
+                return responseStream;
+            }
+
             if (File.Exists(gltfLocation))
             {
                 File.OpenRead(gltfLocation).CopyTo(responseStream);
@@ -1115,6 +1127,12 @@ namespace Elements.Serialization.glTF
                 return Stream.Null;
             }
             responseStream.Position = 0;
+            if (!gltfCache.ContainsKey(gltfLocation))
+            {
+                var cacheStream = new MemoryStream();
+                responseStream.CopyTo(cacheStream);
+                gltfCache.Add(gltfLocation, cacheStream);
+            }
             return responseStream;
         }
 
@@ -1139,8 +1157,8 @@ namespace Elements.Serialization.glTF
             geometricElement.UpdateRepresentations();
 
             // TODO: Remove this when we get rid of UpdateRepresentation.
-            // The only reason we don't fully exclude openings from processing 
-            // is to ensure that openings have some geometry that will be used 
+            // The only reason we don't fully exclude openings from processing
+            // is to ensure that openings have some geometry that will be used
             // to compute csgs for their hosts.
             if (e.GetType() == typeof(Opening))
             {
@@ -1192,8 +1210,8 @@ namespace Elements.Serialization.glTF
             // To properly compute csgs, all solid operation csgs need
             // to be transformed into their final position. Then the csgs
             // can be computed and the final csg can have the inverse of the
-            // geometric element's transform applied to "reset" it. 
-            // The transforms applied to each node in the glTF will then 
+            // geometric element's transform applied to "reset" it.
+            // The transforms applied to each node in the glTF will then
             // ensure that the elements are correctly transformed.
             Csg.Solid csg = new Csg.Solid();
 

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -1105,7 +1105,6 @@ namespace Elements.Serialization.glTF
 
             if (gltfCache.TryGetValue(gltfLocation, out var foundStream))
             {
-                Console.WriteLine("cache hit: " + gltfLocation);
                 foundStream.Position = 0;
                 foundStream.CopyTo(responseStream);
                 responseStream.Position = 0;

--- a/Elements/src/Serialization/glTF/GltfMergingUtils.cs
+++ b/Elements/src/Serialization/glTF/GltfMergingUtils.cs
@@ -25,6 +25,7 @@ namespace Elements.Serialization.glTF
                                         )
         {
             var loadingStream = new MemoryStream();
+            glbStream.Position = 0;
             glbStream.CopyTo(loadingStream);
             loadingStream.Position = 0;
             var loaded = Interface.LoadModel(loadingStream);

--- a/Elements/test/ContentTests.cs
+++ b/Elements/test/ContentTests.cs
@@ -92,8 +92,12 @@ namespace Elements.Tests
             var twoDuck = duckType.CreateInstance(new Transform(new Vector3(15, 0, 0)), "A Duck");
             model.AddElement(twoDuck);
             // </example>
-            model.ToGlTF("./models/ContentInstancing.gltf", false);
+            var sw = System.Diagnostics.Stopwatch.StartNew();
             model.ToGlTF("./models/ContentInstancing.glb");
+            var firstRun = sw.Elapsed.TotalSeconds;
+            sw.Restart();
+            model.ToGlTF("./models/ContentInstancing.gltf", false);
+            var secondRun = sw.Elapsed.TotalSeconds;
         }
     }
 }

--- a/Elements/test/ContentTests.cs
+++ b/Elements/test/ContentTests.cs
@@ -98,6 +98,7 @@ namespace Elements.Tests
             sw.Restart();
             model.ToGlTF("./models/ContentInstancing.gltf", false);
             var secondRun = sw.Elapsed.TotalSeconds;
+            Assert.True(firstRun > secondRun); // caching should result in faster model generation second time.
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- Adding content elements to the GLTF was slow, partly because we repeatedly fetch the glb from the url.

DESCRIPTION:
- Create a cache for memory streams that will be used anytime a url is recognized.

TESTING:
- there's a test that asserts the speed difference.
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [ x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/539)
<!-- Reviewable:end -->
