### PR TITLE
Improved get previous tag

### DIFF
--- a/.github/workflows/build-and-publish-alpha.yml
+++ b/.github/workflows/build-and-publish-alpha.yml
@@ -19,7 +19,9 @@ jobs:
           dotnet-version: 3.1.x
       - name: Get previous tag.
         id: version
-        uses: "WyriHaximus/github-action-get-previous-tag@master"
+        run: |
+          lastTag=`git tag -l --sort=-creatordate --format='%(refname:short)' | head -n 1`
+          echo "::set-output name=tag::$lastTag"
       - name: Bump if alpha.
         id: bump-with-alpha
         uses: actions/github-script@v3

--- a/.github/workflows/build-and-publish-alpha.yml
+++ b/.github/workflows/build-and-publish-alpha.yml
@@ -47,14 +47,14 @@ jobs:
         run: echo "NUGET_VERSION=${{steps.bump-with-alpha.outputs.result}}" >> $GITHUB_ENV
       - name: Build Elements
         run: dotnet build -c release -p:Version=${{ env.NUGET_VERSION }}
+      - name: Create alpha tag.
+        uses: tvdias/github-tagger@v0.0.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.bump-with-alpha.outputs.result }}
       - name: Publish NuGet package.
         run: |
           dotnet nuget push ./nupkg/Hypar.Elements.${{ env.NUGET_VERSION }}.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}
           dotnet nuget push ./nupkg/Hypar.Elements.CodeGeneration.${{ env.NUGET_VERSION }}.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}
           dotnet nuget push ./nupkg/Hypar.Elements.Serialization.IFC.${{ env.NUGET_VERSION }}.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}
           dotnet nuget push ./nupkg/Hypar.Elements.Components.${{ env.NUGET_VERSION }}.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}
-      - name: Create alpha tag.
-        uses: tvdias/github-tagger@v0.0.1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.bump-with-alpha.outputs.result }}


### PR DESCRIPTION
BACKGROUND:
- we have a better strategy for getting the most recent tag, based on date.
- We have had recent failures to publish Elements alphas, but because tags are created after publish, this resulted in cascading failures as nuget version was ahead of the tag version in our repo.

DESCRIPTION:
- Use a custom git command to get the lastest tag based on creatordate
- move the creation of the alpha tag prior to nuget publishing, so we continue to increment repo tags even if nuget publish fails for some reason.

TESTING:
- new version command works in the `Hypar` repo.
  
FUTURE WORK:
- Monitoring.

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`. N/A CI/CD only.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/564)
<!-- Reviewable:end -->
