### PR TITLE
Polygon.Contains expanded 3D support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `Polyline.OffsetOnSide`
 ### Changed
 - `Solids.Import` is now public.
+- `Polygon.Contains` was modified to better handle polygons that are not on the XY plane.
 
 ### Fixed
 ## 0.8.4
@@ -30,7 +31,7 @@
 - `Profile.Split(IEnumerable<Profile>, IEnumerable<Polyline> p)`
 - `Elements.Spatial.HalfEdgeGraph2d`
   - `.Construct()`
-  - `.Polygonize()` 
+  - `.Polygonize()`
 - Release helper github action
 
 ### Changed

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -75,7 +75,31 @@ namespace Elements.Geometry
         /// <returns>Returns true if the supplied Vector3 is within this polygon.</returns>
         public bool Contains(Vector3 vector, out Containment containment)
         {
-            return Contains(Segments(), vector, out containment);
+            return Contains3D(Segments(), vector, out containment);
+        }
+
+        // Projects non-flat containment request into XY plane and returns the answer for this projection
+        internal static bool Contains3D(IEnumerable<Line> segments, Vector3 location, out Containment containment)
+        {
+            var is3D = false;
+            var vertices = segments.Select(segment =>
+            {
+                if (segment.Start.Z != 0)
+                {
+                    is3D = true;
+                }
+                return segment.Start;
+            }).ToList();
+            if (!is3D)
+            {
+                return Contains(segments, location, out containment);
+            }
+            var transformTo3D = vertices.ToTransform();
+            var transformToGround = new Transform(transformTo3D);
+            transformToGround.Invert();
+            var groundSegments = segments.Select(segment =>  (Line)segment.Transformed(transformToGround)).ToList();
+            var groundLocation = transformToGround.OfPoint(location);
+            return Contains(groundSegments, groundLocation, out containment);
         }
 
         // Adapted from https://stackoverflow.com/questions/46144205/point-in-polygon-using-winding-number/46144206
@@ -786,8 +810,8 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Find the minimum-area rotated rectangle containing a set of points, 
-        /// calculated without regard for Z coordinate. 
+        /// Find the minimum-area rotated rectangle containing a set of points,
+        /// calculated without regard for Z coordinate.
         /// </summary>
         /// <param name="points">The points to contain within the rectangle</param>
         /// <returns>A rectangular polygon that contains all input points</returns>
@@ -836,9 +860,9 @@ namespace Elements.Geometry
                     return centroid;
                 }
                 // find midpoint of the diagonal between two non-adjacent vertices.
-                // At any convex corner, this will be inside the boundary 
+                // At any convex corner, this will be inside the boundary
                 // (unless it passes all the way through to the other side — but
-                // this can't be true for all corners). Inspired by 
+                // this can't be true for all corners). Inspired by
                 // http://apodeline.free.fr/FAQ/CGAFAQ/CGAFAQ-3.html 3.6
                 var a = Vertices[currentIndex];
                 var b = Vertices[(currentIndex + 2) % Vertices.Count];
@@ -1189,8 +1213,8 @@ namespace Elements.Geometry
             }
             catch
             {
-                // Often, the polygons coming back from clipper will have self-intersections, in the form of lines that go out and back. 
-                // here we make a last-ditch attempt to fix this and construct a new polygon. 
+                // Often, the polygons coming back from clipper will have self-intersections, in the form of lines that go out and back.
+                // here we make a last-ditch attempt to fix this and construct a new polygon.
                 var cleanedVertices = Vector3.AttemptPostClipperCleanup(converted);
                 try
                 {

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -81,15 +81,8 @@ namespace Elements.Geometry
         // Projects non-flat containment request into XY plane and returns the answer for this projection
         internal static bool Contains3D(IEnumerable<Line> segments, Vector3 location, out Containment containment)
         {
-            var is3D = false;
-            var vertices = segments.Select(segment =>
-            {
-                if (segment.Start.Z != 0)
-                {
-                    is3D = true;
-                }
-                return segment.Start;
-            }).ToList();
+            var vertices = segments.Select(segment => segment.Start).ToList();
+            var is3D = vertices.Any(vertex => vertex.Z != 0);
             if (!is3D)
             {
                 return Contains(segments, location, out containment);
@@ -97,7 +90,7 @@ namespace Elements.Geometry
             var transformTo3D = vertices.ToTransform();
             var transformToGround = new Transform(transformTo3D);
             transformToGround.Invert();
-            var groundSegments = segments.Select(segment =>  (Line)segment.Transformed(transformToGround)).ToList();
+            var groundSegments = segments.Select(segment =>  segment.TransformedLine(transformToGround));
             var groundLocation = transformToGround.OfPoint(location);
             return Contains(groundSegments, groundLocation, out containment);
         }

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -1314,5 +1314,18 @@ namespace Elements.Geometry.Tests
 
             Assert.Throws<Exception>(() => circle.TransformSegment(t, 0));
         }
+
+        [Fact]
+        public void VerticalContainment() {
+            var point = new Vector3(8.874555, 6.112945, 30);
+            var polygon = new Polygon(new List<Vector3>() {
+                new Vector3(11.37475, 8.56224, -3),
+                new Vector3(6.37436, 3.66365, -3),
+                new Vector3(6.37436, 3.66365, 0),
+                new Vector3(11.37475, 8.56224, 0)
+            });
+            var contains = polygon.Contains(point, out var type);
+            Assert.Equal(contains, false);
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- I found some cases where polygons reported a false containment with a vertex that was above the polygon

DESCRIPTION:
- Adds an internal middleware function that checks for vertices on the XY plane, and runs the calculation on a transformed polygon and point if it is not an XY plane polygon

TESTING:
- See the new test for the previously failing case
  
FUTURE WORK:
- Make more cohesive our strategy for 2D and 3D geometries.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/565)
<!-- Reviewable:end -->
