### PR TITLE
Ensure CellComplex examples show up in docs

### DIFF
--- a/Elements/src/Spatial/CellComplex/CellComplex.cs
+++ b/Elements/src/Spatial/CellComplex/CellComplex.cs
@@ -10,7 +10,7 @@ namespace Elements.Spatial.CellComplex
     /// A non-manifold cellular structure.
     /// </summary>
     /// <example>
-    /// [!code-csharp[Main](../../Elements/test/CellComplexTests.cs?name=Elements_CellComplex_Example)]
+    /// [!code-csharp[Main](../../Elements/test/CellComplexTests.cs?name=example)]
     /// </example>
     public class CellComplex : Elements.Element
     {

--- a/Elements/test/CellComplexTests.cs
+++ b/Elements/test/CellComplexTests.cs
@@ -67,10 +67,12 @@ namespace Elements.Tests
             return cellComplex;
         }
 
-        [Fact]
+        [Fact, Trait("Category", "Examples")]
         public void CellComplexExample()
         {
-            this.Name = "Elements_CellComplex_Example";
+            this.Name = "Elements_Spatial_CellComplex_CellComplex";
+
+            // <example>
 
             // Assemble CellComplex from Grid2d
             var numLevels = 10;
@@ -123,12 +125,13 @@ namespace Elements.Tests
                 curCell = curCell.GetClosestNeighbor(end);
                 j += 1;
             }
+            // </example>
         }
 
         [Fact]
         public void CellComplexSerializesAndDeserializes()
         {
-            this.Name = "Elements_CellComplex_Serialization";
+            this.Name = "Elements_Spatial_CellComplex_Serialization";
 
             var uDirection = new Vector3(1, 1, 0).Unitized();
             var cellComplex = MakeASimpleCellComplex(uDirection: uDirection);
@@ -194,7 +197,7 @@ namespace Elements.Tests
         [Fact]
         public void CellComplexTraversal()
         {
-            this.Name = "Elements_CellComplex_Traversal";
+            this.Name = "Elements_Spatial_CellComplex_Traversal";
 
             var cellComplex = MakeASimpleCellComplex(numLevels: 10, uNumCells: 5, vNumCells: 10);
 


### PR DESCRIPTION
BACKGROUND:
- #546 deployed, but an example was missing in the docs for `CellComplex`

DESCRIPTION:
- Tweaks test names and comments so that the example for `CellComplex` shows up in my local docs build

TESTING:
- Build docs
  
FUTURE WORK:
- N/A

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`. (Not required: documentation change only)

COMMENTS:
- N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/568)
<!-- Reviewable:end -->
