### PR TITLE
Follow-on cleanup to color scale interpolation

### DIFF
--- a/Elements/src/Analysis/ColorScale.cs
+++ b/Elements/src/Analysis/ColorScale.cs
@@ -35,6 +35,10 @@ namespace Elements.Analysis
         [JsonProperty]
         private Boolean Discrete { get; } = false;
 
+        /// <summary>
+        /// Create a ColorScale from a list of colors. The scale will automatically have a domain from 0 to 1.
+        /// </summary>
+        /// <param name="colors"></param>
         public ColorScale(List<Color> colors)
         {
             this.Colors = colors;
@@ -49,7 +53,7 @@ namespace Elements.Analysis
         /// <param name="discrete">Whether this color scale uses discrete values.</param>
         /// <param name="domains">The domains which the colors map to</param>
         [JsonConstructor]
-        public ColorScale(List<Color> colors, Boolean discrete, List<Domain1d> domains = null)
+        internal ColorScale(List<Color> colors, Boolean discrete, List<Domain1d> domains = null)
         {
             this.Colors = colors;
             this.Discrete = discrete;
@@ -132,7 +136,6 @@ namespace Elements.Analysis
         /// approximating the provided value.
         /// </summary>
         /// <param name="t">A number within the numerical parameters from when you constructed your color scale. If this was initiated with colorCount, must be between 0 and 1.</param>
-        /// <param name="discrete">If true, returns exactly one of the colors initially created, rather than a smoothly interpolated value.</param>
         /// <returns>A color.</returns>
         public Color GetColor(double t)
         {


### PR DESCRIPTION
BACKGROUND:
- Merged #532 and realized I forgot to address a final comment from the PR

DESCRIPTION:
- Makes non-public constructor internal
- Cleans up comments that were throwing linter errors

TESTING:
- Ran deserialization test again and ensured that it passed.
  
FUTURE WORK:
- N/A

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`. (N/A)

COMMENTS:
- N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/569)
<!-- Reviewable:end -->
