### PR TITLE
Serialize the solid associated w/ a constructedSolid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
+## 0.9.0
+
+### Changed
+
+- `ConstructedSolid` serializes and deserializes correctly.
+
 ## 0.8.5
 
 ### Added
+
 - `Elements.Spatial.CellComplex`
 - `Grid2d.ToModelCurves()`
 - Alpha release of `Hypar.Elements.Components`
@@ -13,14 +20,17 @@
 - `void Topography.Trim(Polygon perimeter)`
 
 ### Changed
+
 - `ColorScale` no longer bands colors but returns smooth gradient interpolation. It additionally now supports a list of values that correspond with the provided colors, allowing intentionally skewed interpolation.
 - `Solids.Import` is now public.
 - `Polygon.Contains` was modified to better handle polygons that are not on the XY plane.
 
 ### Fixed
+
 ## 0.8.4
 
 ### Added
+
 - `BBox3.IsValid()`
 - `BBox3.IsDegenerate()`
 - `Elements.Light`
@@ -44,6 +54,7 @@
 - Release helper github action
 
 ### Changed
+
 - `Elements.DirectionalLight` now inherits from `Elements.Light`.
 - `Elements.ContentCatalog` now has a `ReferenceConfiguration` property.
 - `SHSProfile`
@@ -62,6 +73,7 @@
 ## 0.8.3
 
 ### Added
+
 - `Profile.ToModelCurves()`
 - `Profile.Difference()`
 - `Profile.Intersection()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - `ConstructedSolid` serializes and deserializes correctly.
+- `Solid.AddFace(Polygon, Polygon[])` can take an optional third `mergeVerticesAndEdges` argument which will automatically reuse existing edges + vertices in the solid.
 
 ## 0.8.5
 

--- a/Elements/src/Geometry/Solids/ConstructedSolid.cs
+++ b/Elements/src/Geometry/Solids/ConstructedSolid.cs
@@ -1,3 +1,6 @@
+using Elements.Serialization.JSON;
+using Newtonsoft.Json;
+
 namespace Elements.Geometry.Solids
 {
     /// <summary>
@@ -15,5 +18,11 @@ namespace Elements.Geometry.Solids
             this._solid = solid;
             this._csg = solid.ToCsg();
         }
+
+        // This is a hack to get the normally JsonIgnored
+        // `Solid` property to serialize.
+        [JsonProperty("Solid")]
+        [JsonConverter(typeof(SolidConverter))]
+        internal Solid InternalSolid => base.Solid;
     }
 }

--- a/Elements/src/Serialization/JSON/SolidConverter.cs
+++ b/Elements/src/Serialization/JSON/SolidConverter.cs
@@ -200,26 +200,15 @@ namespace Elements.Serialization.JSON
             writer.WriteEndObject();
         }
 
-        private void WriteHalfEdge(HalfEdge leftEdge, JsonWriter writer, object value)
+        private void WriteHalfEdge(HalfEdge he, JsonWriter writer, object value)
         {
-            // TODO: figure out why we're only ever passing 
-            // left edges to this method
             writer.WriteStartObject();
             writer.WritePropertyName("vertex_id");
-            writer.WriteValue(leftEdge.Vertex.Id);
+            writer.WriteValue(he.Vertex.Id);
             writer.WritePropertyName("edge_id");
-            writer.WriteValue(leftEdge.Edge.Id);
+            writer.WriteValue(he.Edge.Id);
             writer.WritePropertyName("edge_side");
-            writer.WriteValue("left");
-            writer.WriteEndObject();
-            var rightEdge = leftEdge.Edge.Right;
-            writer.WriteStartObject();
-            writer.WritePropertyName("vertex_id");
-            writer.WriteValue(rightEdge.Vertex.Id);
-            writer.WritePropertyName("edge_id");
-            writer.WriteValue(rightEdge.Edge.Id);
-            writer.WritePropertyName("edge_side");
-            writer.WriteValue("right");
+            writer.WriteValue(he.Edge.Left == he ? "left" : "right");
             writer.WriteEndObject();
         }
     }

--- a/Elements/src/Serialization/JSON/SolidConverter.cs
+++ b/Elements/src/Serialization/JSON/SolidConverter.cs
@@ -200,15 +200,26 @@ namespace Elements.Serialization.JSON
             writer.WriteEndObject();
         }
 
-        private void WriteHalfEdge(HalfEdge he, JsonWriter writer, object value)
+        private void WriteHalfEdge(HalfEdge leftEdge, JsonWriter writer, object value)
         {
+            // TODO: figure out why we're only ever passing 
+            // left edges to this method
             writer.WriteStartObject();
             writer.WritePropertyName("vertex_id");
-            writer.WriteValue(he.Vertex.Id);
+            writer.WriteValue(leftEdge.Vertex.Id);
             writer.WritePropertyName("edge_id");
-            writer.WriteValue(he.Edge.Id);
+            writer.WriteValue(leftEdge.Edge.Id);
             writer.WritePropertyName("edge_side");
-            writer.WriteValue(he.Edge.Left == he ? "left" : "right");
+            writer.WriteValue("left");
+            writer.WriteEndObject();
+            var rightEdge = leftEdge.Edge.Right;
+            writer.WriteStartObject();
+            writer.WritePropertyName("vertex_id");
+            writer.WriteValue(rightEdge.Vertex.Id);
+            writer.WritePropertyName("edge_id");
+            writer.WriteValue(rightEdge.Edge.Id);
+            writer.WritePropertyName("edge_side");
+            writer.WriteValue("right");
             writer.WriteEndObject();
         }
     }

--- a/Elements/test/SolidTests.cs
+++ b/Elements/test/SolidTests.cs
@@ -210,12 +210,12 @@ namespace Elements.Tests
             var F = new Vector3(1, 0, 1);
             var G = new Vector3(1, 1, 1);
             var H = new Vector3(0, 1, 1);
-            solid.AddFace(new Polygon(new[] { A, B, C, D }));
-            solid.AddFace(new Polygon(new[] { E, F, G, H }));
-            solid.AddFace(new Polygon(new[] { A, B, F, E }));
-            solid.AddFace(new Polygon(new[] { B, C, G, F }));
-            solid.AddFace(new Polygon(new[] { C, D, H, G }));
-            solid.AddFace(new Polygon(new[] { D, A, E, H }));
+            solid.AddFace(new Polygon(new[] { A, B, C, D }), mergeVerticesAndEdges: true);
+            solid.AddFace(new Polygon(new[] { E, F, G, H }), mergeVerticesAndEdges: true);
+            solid.AddFace(new Polygon(new[] { A, B, F, E }), mergeVerticesAndEdges: true);
+            solid.AddFace(new Polygon(new[] { B, C, G, F }), mergeVerticesAndEdges: true);
+            solid.AddFace(new Polygon(new[] { C, D, H, G }), mergeVerticesAndEdges: true);
+            solid.AddFace(new Polygon(new[] { D, A, E, H }), mergeVerticesAndEdges: true);
 
             var emptySolid = new ConstructedSolid(new Solid(), false);
             var import = new ConstructedSolid(solid, false);

--- a/Elements/test/SolidTests.cs
+++ b/Elements/test/SolidTests.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using Elements.Serialization.glTF;
 using Elements.Serialization.JSON;
+using System.Linq;
 
 namespace Elements.Tests
 {
@@ -198,6 +199,7 @@ namespace Elements.Tests
         [Fact]
         public void ConstructedSolid()
         {
+            GenerateIfc = false;
             Name = nameof(ConstructedSolid);
             var solid = new Solid();
             var A = new Vector3(0, 0, 0);
@@ -220,9 +222,18 @@ namespace Elements.Tests
             var representation = new Representation(new[] { import });
             var emptyRep = new Representation(new[] { emptySolid });
             var userElement = new GeometricElement(new Transform(), BuiltInMaterials.Default, representation, false, Guid.NewGuid(), "Import");
-            var userElementWithEmptySolid = new GeometricElement(new Transform(), BuiltInMaterials.Default, emptyRep, false, Guid.NewGuid(), "Import");
+            var userElementWithEmptySolid = new GeometricElement(new Transform(), BuiltInMaterials.Default, emptyRep, false, Guid.NewGuid(), "Import Empty");
             Model.AddElement(userElement);
             Model.AddElement(userElementWithEmptySolid);
+
+            // ensure serialized solid
+            var modelJson = Model.ToJson();
+
+            var deserializedModel = Model.FromJson(modelJson);
+            var userElemDeserialized = deserializedModel.GetElementByName<GeometricElement>("Import");
+            var opDeserialized = userElemDeserialized.Representation.SolidOperations.First();
+            var solidDeserialized = opDeserialized?.Solid;
+            Assert.NotNull(solidDeserialized);
         }
     }
 


### PR DESCRIPTION
BACKGROUND:
- #572 
- We need to be able to pass the Solid held by a Constructed Solid from function to function

DESCRIPTION:
- Ensures the `Solid` of a `ConstructedSolid` serializes.

TESTING:
- Added a test which serializes + deserializes a model containing ConstructedSolid
  
FUTURE WORK:
- `ConstructedSolids` don't convert to IFC correctly, this should be corrected.

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/574)
<!-- Reviewable:end -->
