### PR TITLE
allow isTrimmed to return true for cells outside the boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Changelog
 
+## 0.9.0
+
+### Added
+
+- `Grid2d.IsOutside()`
+
+### Changed
+
+- `Grid2d.IsTrimmed()` now takes an optional boolean parameter `treatFullyOutsideAsTrimmed`
+
 ## 0.8.5
 
 ### Added
+
 - `Elements.Spatial.CellComplex`
 - `Grid2d.ToModelCurves()`
 - Alpha release of `Hypar.Elements.Components`
@@ -13,14 +24,17 @@
 - `void Topography.Trim(Polygon perimeter)`
 
 ### Changed
+
 - `ColorScale` no longer bands colors but returns smooth gradient interpolation. It additionally now supports a list of values that correspond with the provided colors, allowing intentionally skewed interpolation.
 - `Solids.Import` is now public.
 - `Polygon.Contains` was modified to better handle polygons that are not on the XY plane.
 
 ### Fixed
+
 ## 0.8.4
 
 ### Added
+
 - `BBox3.IsValid()`
 - `BBox3.IsDegenerate()`
 - `Elements.Light`
@@ -44,6 +58,7 @@
 - Release helper github action
 
 ### Changed
+
 - `Elements.DirectionalLight` now inherits from `Elements.Light`.
 - `Elements.ContentCatalog` now has a `ReferenceConfiguration` property.
 - `SHSProfile`
@@ -62,6 +77,7 @@
 ## 0.8.3
 
 ### Added
+
 - `Profile.ToModelCurves()`
 - `Profile.Difference()`
 - `Profile.Intersection()`

--- a/Elements/src/Spatial/Grid2d.cs
+++ b/Elements/src/Spatial/Grid2d.cs
@@ -761,22 +761,6 @@ namespace Elements.Spatial
             return IsOutside(baseRect);
         }
 
-        private bool IsOutside(Polygon baseRect)
-        {
-            var perimeter = boundariesInGridSpace.First();
-            // if any vertex of the rect is fully outside, we are trimmed
-            perimeter.Contains(baseRect.Vertices.First(), out var containment);
-            if (containment == Containment.Outside)
-            {
-                return true;
-            }
-            if (boundariesInGridSpace.Count() > 1)
-            {
-                return boundariesInGridSpace.Skip(1).Any(boundary => boundary.Covers(baseRect));
-            }
-            return false;
-        }
-
         #endregion
 
         #region Private/Internal Methods
@@ -792,6 +776,22 @@ namespace Elements.Spatial
                 throw new NotSupportedException("An attempt was made to modify the underlying U or V grid of a 2D Grid, after some of its cells had already been further subdivided.");
             }
             this.cells = null;
+        }
+
+        private bool IsOutside(Polygon baseRect)
+        {
+            var perimeter = boundariesInGridSpace.First();
+            // if any vertex of the rect is fully outside, we are trimmed
+            perimeter.Contains(baseRect.Vertices.First(), out var containment);
+            if (containment == Containment.Outside)
+            {
+                return true;
+            }
+            if (boundariesInGridSpace.Count() > 1)
+            {
+                return boundariesInGridSpace.Skip(1).Any(boundary => boundary.Covers(baseRect));
+            }
+            return false;
         }
 
         private void InitializeUV(Domain1d uDomain, Domain1d vDomain)

--- a/Elements/test/Grid2dTests.cs
+++ b/Elements/test/Grid2dTests.cs
@@ -77,20 +77,23 @@ namespace Elements.Tests
             var trimmedCells = grid.GetCells().Select(c =>
                 (TrimmedGeometry: c.GetTrimmedCellGeometry(),
                 BaseRect: c.GetCellGeometry(),
-                IsTrimmed: c.IsTrimmed()));
+                IsTrimmed: c.IsTrimmed(),
+                IsTrimmedButNotOutside: c.IsTrimmed(false)));
 
             foreach (var trimGeometry in trimmedCells)
             {
                 var trimGeo = trimGeometry.TrimmedGeometry.OfType<Polygon>();
-                var material = trimGeometry.IsTrimmed ? BuiltInMaterials.XAxis : BuiltInMaterials.ZAxis;
+                var material = trimGeometry.IsTrimmed ? (trimGeometry.IsTrimmedButNotOutside ? BuiltInMaterials.XAxis : BuiltInMaterials.YAxis) : BuiltInMaterials.ZAxis;
                 foreach (var t in trimGeo)
                 {
                     Model.AddElement(new ModelCurve(t));
-                    Model.AddElement(new Mass(t, 1, material, new Transform(0, 0, -1.001)));
+                    Model.AddElement(new Mass(t, 0.1, material, new Transform(0, 0, -1.001)));
                 }
+                Model.AddElement(new ModelCurve(trimGeometry.BaseRect, material, new Transform(0, 0, 1)));
             }
             Assert.Equal(87, trimmedCells.Count());
-            Assert.Equal(18, trimmedCells.Count(c => c.IsTrimmed));
+            Assert.Equal(18, trimmedCells.Count(c => c.IsTrimmedButNotOutside));
+            Assert.Equal(35, trimmedCells.Count(c => c.IsTrimmed));
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
- We had a request from some customers to simplify excluding incomplete cells from a grid2d. Prior to this PR, you had to do this to get "untrimmed cells within the boundary":
```
Grid2d.GetCells().Where(c => c.IsTrimmed() && c.GetTrimmedCellGeometry.Count() > 0);
```
which is cumbersome.

DESCRIPTION:
- Adds a `treatFullyOutsideAsTrimmed` flag to `IsTrimmed()` (true by default) which counts cells entirely outside of the boundary as "trimmed." This is left as a flag, in case a user wants the old behavior (for instance, tallying facade panels that are odd shapes and need a different manufacturing process — in this case we would not want to consider non-existent panels.)

TESTING:
- Updated the test 
![image](https://user-images.githubusercontent.com/31935763/116447165-adea4580-a825-11eb-928b-6511b7d0b7d7.png)


REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/576)
<!-- Reviewable:end -->
