### PR TITLE
Doc path update

### DIFF
--- a/docs/Revit.html
+++ b/docs/Revit.html
@@ -72,7 +72,7 @@
 <img src="images/RevitHyparAddin.png" alt=""></p>
 <h2 id="installation-beta">Installation (beta)</h2>
 <ul>
-<li>Download and install the latest Revit plugin installer from <a href="https://github.com/hypar-io/Elements/releases">releases page</a>.</li>
+<li>Download and install the latest Revit plugin installer from <a href="https://github.com/hypar-io/Hypar-Revit-Installers/releases">releases page</a>. You'll find the installer inside the zip file.</li>
 <li><a href="https://hypar-io.github.io/Elements/C-Sharp.html#installing-and-using-the-hypar-cli">Install the latest Hypar CLI</a>. You'll need this to use the <code>hub</code> command.
 <ul>
 <li><strong>NOTE: For betas, you'll need to install a beta release of the Hypar CLI which has a slightly different syntax.</strong></li>

--- a/docs/Revit.html
+++ b/docs/Revit.html
@@ -123,7 +123,15 @@
 <p>Loading Elements into your Revit model requires converters that are designed to
 work with a given Revit template / project.<br>
 <img src="images/RevitHyparAddinFromHypar.png" alt=""></p>
-<p>There are currently no converters installed by default, but we have designed the system so that you can build your own specific to your company's needs.  See the sample sample converter and documentation <a href="https://github.com/hypar-io/ElementConverterSamples">here</a>.  In the future as more converters come online we will be looking at ways for hte community to automatically share their converters, and if you would like further assistance please reach out to support@hypar.io</p>
+<p>There are currently a few converters installed by default for extracting Walls, Floors, and Columns.  If that is all you need to extract, you're ready to go, but we have designed the system so that you can build your own converters that are specific to your company's needs.  In the future as more converters come online we will be looking at ways for the community to automatically share their converters.</p>
+<h2 id="writing-a-converter">Writing your own converter</h2>
+<p>Here are some resources for writing your own converters.  If you would like further assistance please reach out to support@hypar.io. </p>
+<ul>
+  <li><a href="https://www.notion.so/hyparaec/Making-a-Revit-Converter-c592068692d747d98e312a5823a74514">Making a Revit Converter </a> for a written doc of the process to make a converter.</li>
+  <li><a href="https://www.youtube.com/watch?v=si__iV6oJKw&feature=youtu.be">Video Tutorial</a> for a quick hands on description of how to get up and running.</li>
+  <li><a href="https://github.com/hypar-io/ElementConverterSamples">Sample converter</a> for sample code.</li>
+  <li><a href="https://github.com/hypar-io/ElementConverterSamples">Hypar Live Session</a> for a long, but entertaining deep dive about Revit converters.</li>
+</ul>
 </article>
           </div>
           


### PR DESCRIPTION
BACKGROUND:
- We now use a separate repo for Revit addon releases and we have much more documentation around converters.

DESCRIPTION:
- Change a link to point to the newer installer locations
- Add more links to further documentation about authoring converters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/578)
<!-- Reviewable:end -->
