### PR TITLE
Fix: Grid2d from origin, U, and V directions may change the axes slightly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixed
 
 - Fixed a bug in `ConvexHull.FromPoints` when multiple X coordinates are equal.
+- Fixed a bug in `Grid2d(Polygon, Vector3, Vector3, Vector3)` where U or V directions skew slightly when they nearly parallel with a boundary edge.
 
 
 ## 0.8.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `Grid2d.IsTrimmed()` now takes an optional boolean parameter `treatFullyOutsideAsTrimmed`
 - `ConstructedSolid` serializes and deserializes correctly.
 - `Solid.AddFace(Polygon, Polygon[])` can take an optional third `mergeVerticesAndEdges` argument which will automatically reuse existing edges + vertices in the solid.
+- Adds optional `tolerance` parameter to `Line.ExtendTo(Polygon)`, `Line.ExtendTo(IEnumerable<Line>)`, `Vector3.IsParallelTo(Vector3)`.
 
 ### Fixed
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -462,7 +462,8 @@ namespace Elements.Geometry
         /// <param name="otherLines">The other lines to intersect with</param>
         /// <param name="bothSides">Optional — if false, will only extend in the line's direction; if true will extend in both directions.</param>
         /// <param name="extendToFurthest">Optional — if true, will extend line as far as it will go, rather than stopping at the closest intersection.</param>
-        public Line ExtendTo(IEnumerable<Line> otherLines, bool bothSides = true, bool extendToFurthest = false)
+        /// <param name="tolerance">Optional — The amount of tolerance to include in the extension method.</param>
+        public Line ExtendTo(IEnumerable<Line> otherLines, bool bothSides = true, bool extendToFurthest = false, double tolerance = Vector3.EPSILON)
         {
             // this test line — inset slightly from the line — helps treat the ends as valid intersection points, to prevent
             // extension beyond an immediate intersection.
@@ -472,9 +473,12 @@ namespace Elements.Geometry
             foreach (var segment in segments)
             {
                 bool pointAdded = false;
-                // special case for parallel + collinear lines
-                if (segment.Direction().IsParallelTo(testLine.Direction()) && // if the two lines are parallel
-                    (new[] { segment.End, testLine.Start, testLine.End }).AreCollinear())// and collinear
+                // Special case for parallel + collinear lines:
+                // ____   |__________
+                // We want to extend only to the first corner of the other lines,
+                // not all the way through to the other end
+                if (segment.Direction().IsParallelTo(testLine.Direction(), tolerance) && // if the two lines are parallel
+                    (new[] { segment.End, segment.Start, testLine.Start, testLine.End }).AreCollinear())// and collinear
                 {
                     if (!this.PointOnLine(segment.End, true))
                     {
@@ -558,9 +562,10 @@ namespace Elements.Geometry
         /// <param name="polygon">The polygon to intersect with</param>
         /// <param name="bothSides">Optional — if false, will only extend in the line's direction; if true will extend in both directions.</param>
         /// <param name="extendToFurthest">Optional — if true, will extend line as far as it will go, rather than stopping at the closest intersection.</param>
-        public Line ExtendTo(Polygon polygon, bool bothSides = true, bool extendToFurthest = false)
+        /// <param name="tolerance">Optional — The amount of tolerance to include in the extension method.</param>
+        public Line ExtendTo(Polygon polygon, bool bothSides = true, bool extendToFurthest = false, double tolerance = Vector3.EPSILON)
         {
-            return ExtendTo(polygon.Segments(), bothSides, extendToFurthest);
+            return ExtendTo(polygon.Segments(), bothSides, extendToFurthest, tolerance);
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -492,11 +492,12 @@ namespace Elements.Geometry
         /// Determine whether this vector is parallel to v.
         /// </summary>
         /// <param name="v">The vector to compare to this vector.</param>
+        /// <param name="tolerance">The amount of tolerance in the parallel comparison.</param>
         /// <returns>True if the vectors are parallel, otherwise false.</returns>
-        public bool IsParallelTo(Vector3 v)
+        public bool IsParallelTo(Vector3 v, double tolerance = Vector3.EPSILON)
         {
             var result = Math.Abs(this.Unitized().Dot(v.Unitized()));
-            return result.ApproximatelyEquals(1);
+            return result.ApproximatelyEquals(1, tolerance);
         }
 
         /// <summary>

--- a/Elements/src/Spatial/Grid2d.cs
+++ b/Elements/src/Spatial/Grid2d.cs
@@ -954,7 +954,7 @@ namespace Elements.Spatial
         /// when gridlines were close to but not quite parallel to a polygon edge.
         /// We pass along a much smaller tolerance when we run our line extensions for Grid2d.
         /// </summary>
-        private static readonly double ExtensionTolerance = Vector3.EPSILON * Vector3.EPSILON;
+        private const double ExtensionTolerance = Vector3.EPSILON * Vector3.EPSILON;
 
         /// <summary>
         /// Modifies a list of lines intended to represent uv guides in place to hit the bounds.

--- a/Elements/src/Spatial/Grid2d.cs
+++ b/Elements/src/Spatial/Grid2d.cs
@@ -950,6 +950,13 @@ namespace Elements.Spatial
         }
 
         /// <summary>
+        /// The default extension tolerances of Vector3.EPSILON were creating funny conditions
+        /// when gridlines were close to but not quite parallel to a polygon edge.
+        /// We pass along a much smaller tolerance when we run our line extensions for Grid2d.
+        /// </summary>
+        private static readonly double ExtensionTolerance = Vector3.EPSILON * Vector3.EPSILON;
+
+        /// <summary>
         /// Modifies a list of lines intended to represent uv guides in place to hit the bounds.
         /// Accounts for skewed, parallel lists of 2. If list contains more lines, those will be ignored.
         /// </summary>
@@ -962,7 +969,7 @@ namespace Elements.Spatial
 
             for (var i = 0; i < lines.Count(); i++)
             {
-                lines[i] = lines[i].ExtendTo(boundary, true, true);
+                lines[i] = lines[i].ExtendTo(boundary, true, true, ExtensionTolerance);
             }
 
             var new1 = ExtendLineSkewed(bounds, lines[0], lines[1]);
@@ -997,12 +1004,12 @@ namespace Elements.Spatial
                 // move to start and extend
                 var toStart = possiblySkewedLine.Start - intersection;
                 newLine = newLine.TransformedLine(new Transform(toStart));
-                newLine = newLine.ExtendTo(boundary, true, true);
+                newLine = newLine.ExtendTo(boundary, true, true, ExtensionTolerance);
 
                 // move to end and extend
                 var toEnd = possiblySkewedLine.End - possiblySkewedLine.Start;
                 newLine = newLine.TransformedLine(new Transform(toEnd));
-                newLine = newLine.ExtendTo(boundary, true, true);
+                newLine = newLine.ExtendTo(boundary, true, true, ExtensionTolerance);
 
                 // move back to original
                 var toBeginning = intersection - possiblySkewedLine.End;

--- a/Elements/test/Grid2dTests.cs
+++ b/Elements/test/Grid2dTests.cs
@@ -394,6 +394,43 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void SkewedGridsWithNearlyParallelBoundary()
+        {
+            var transformStr = @"{
+                ""Matrix"": {
+                ""Components"": [
+                    0.9999947633971941,
+                    -0.009614940148020392,
+                    0,
+                    -10.992100150908389,
+                    -0.003236229007759388,
+                    -0.9999537753946179,
+                    0,
+                    17.971426034076142,
+                    0,
+                    0,
+                    1.0000000000000004,
+                    0
+                ]
+                }
+            }";
+            var transform = JsonConvert.DeserializeObject<Transform>(transformStr);
+            var origin = transform.Origin;
+            var uDirection = transform.XAxis;
+            var vDirection = transform.YAxis;
+            var boundary = new Polygon(new List<Vector3>()
+            {
+                new Vector3(-12.0362, -34.1879, 0.0000),
+                new Vector3(28.8939, -34.3204, 0.0000),
+                new Vector3(29.0811, 23.5186, 0.0000),
+                new Vector3(-11.8491, 23.6511, 0.0000)
+            });
+            var grid = new Grid2d(boundary, origin, uDirection, vDirection);
+            Assert.True(uDirection.Unitized().Equals((grid.U.Curve.PointAt(1) - grid.U.Curve.PointAt(0)).Unitized()));
+            Assert.True(vDirection.Unitized().Equals((grid.V.Curve.PointAt(1) - grid.V.Curve.PointAt(0)).Unitized()));
+        }
+
+        [Fact]
         public void CustomUVAndBounds()
         {
             var boundary = Polygon.Rectangle(new Vector3(), new Vector3(1, 1));

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -307,27 +307,5 @@ namespace Elements.Geometry.Tests
             Assert.Equal(line.Start.X, noIntersection.Start.X);
             Assert.Equal(line.End.X, noIntersection.End.X);
         }
-
-        [Fact]
-        public void ExtendDebug()
-        {
-            this.Name = "ExtendDebug";
-            var line = new Line(new Vector3(-12.5391, -34.3170, 0.0000), new Vector3(28.5783, -34.4500, 0.0000));
-            var boundary = new Polygon(new List<Vector3>(){
-                new Vector3(-12.0362, -34.3204, 0.0000 ),
-                new Vector3(29.0811, -34.3204, 0.0000 ),
-                new Vector3(29.0811, 23.6511, 0.0000),
-                new Vector3(-12.0362, 23.6511, 0.0000)
-            });
-            this.Model.AddElement(new ModelCurve(line, new Material("Red", Colors.Red)));
-            this.Model.AddElement(new ModelCurve(boundary, new Material("Blue", Colors.Blue)));
-            var newLine = line.ExtendTo(boundary, true, true);
-            // this.Model.AddElement(new ModelCurve(line, new Material("Green", Colors.Green)));
-
-            var dirBefore = (line.End - line.Start).Unitized();
-            var dirAfter = (newLine.End - newLine.Start).Unitized();
-
-            Assert.True(dirBefore.Equals(dirAfter));
-        }
     }
 }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -302,10 +302,32 @@ namespace Elements.Geometry.Tests
             Assert.Equal(4, singleFurthestExtend.End.X);
 
             // If no intersections found, returns line with same endpoints
-            var noIntersection = line.ExtendTo(Polygon.Rectangle(new Vector3(1,1), new Vector3(2, 2)));
+            var noIntersection = line.ExtendTo(Polygon.Rectangle(new Vector3(1, 1), new Vector3(2, 2)));
 
             Assert.Equal(line.Start.X, noIntersection.Start.X);
             Assert.Equal(line.End.X, noIntersection.End.X);
+        }
+
+        [Fact]
+        public void ExtendDebug()
+        {
+            this.Name = "ExtendDebug";
+            var line = new Line(new Vector3(-12.5391, -34.3170, 0.0000), new Vector3(28.5783, -34.4500, 0.0000));
+            var boundary = new Polygon(new List<Vector3>(){
+                new Vector3(-12.0362, -34.3204, 0.0000 ),
+                new Vector3(29.0811, -34.3204, 0.0000 ),
+                new Vector3(29.0811, 23.6511, 0.0000),
+                new Vector3(-12.0362, 23.6511, 0.0000)
+            });
+            this.Model.AddElement(new ModelCurve(line, new Material("Red", Colors.Red)));
+            this.Model.AddElement(new ModelCurve(boundary, new Material("Blue", Colors.Blue)));
+            var newLine = line.ExtendTo(boundary, true, true);
+            // this.Model.AddElement(new ModelCurve(line, new Material("Green", Colors.Green)));
+
+            var dirBefore = (line.End - line.Start).Unitized();
+            var dirAfter = (newLine.End - newLine.Start).Unitized();
+
+            Assert.True(dirBefore.Equals(dirAfter));
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- A Grid2d created in a workflow had U and V curves that did not match the input directions.

DESCRIPTION:
- Adds optional `tolerance` parameter to `Line.ExtendTo(Polygon)`, `Line.ExtendTo(IEnumerable<Line>)`, `Vector3.IsParallelTo(Vector3)`.
- Uses these parameters to override tolerances for `Grid2d` constructor.

TESTING:
- Run the new test `SkewedGridsWithNearlyParallelBoundary`.
  
FUTURE WORK:
- We may want to add `tolerance` parameter to the rest of `Line.ExtendTo` signatures, if this approach works well.
- This may also be relevant in the `AreCollinear` method as well.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/580)
<!-- Reviewable:end -->
