### PR TITLE
Set correct last cell typename in Grid1d.DivideByPattern when there i…

### DIFF
--- a/Elements/src/Spatial/Grid1d.cs
+++ b/Elements/src/Spatial/Grid1d.cs
@@ -717,6 +717,11 @@ namespace Elements.Spatial
                 runningPosition += patternSegments[i].length;
                 SplitAtOffset(runningPosition);
             }
+            if (Cells == null && patternSegments.Count == 1)
+            {
+                Type = patternSegments[0].typeName;
+                return;
+            }
             for (int i = 0; i < patternSegments.Count; i++)
             {
                 var cellOffset = offset > 0 ? 1 : 0;
@@ -739,7 +744,7 @@ namespace Elements.Spatial
             {
                 var segmentToAdd = lengthPattern[i % lengthPattern.Count];
                 runningLength += segmentToAdd.length;
-                if (runningLength < Domain.Length)
+                if (runningLength <= Domain.Length)
                 {
                     patternSegments.Add(segmentToAdd);
 

--- a/Elements/test/Grid1dTests.cs
+++ b/Elements/test/Grid1dTests.cs
@@ -272,6 +272,25 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void DivideByPatternWithoutRemainder()
+        {
+            var grid = new Grid1d(6);
+            var pattern = new List<(string typename, double length)>
+            {
+                ("A", 2),
+                ("B", 1)
+            };
+            grid.DivideByPattern(pattern, PatternMode.Cycle, FixedDivisionMode.RemainderAtEnd);
+            var cells = grid.GetCells();
+
+            for (int i = 0; i < cells.Count; i++)
+            {
+                Assert.Equal(pattern[i % pattern.Count].typename, cells[i].Type);
+                Assert.Equal(pattern[i % pattern.Count].length, cells[i].Domain.Length, 3);
+            }
+        }
+
+        [Fact]
         public void PatternTooLongThrowsException()
         {
             var grid = new Grid1d(4);


### PR DESCRIPTION
…s no remainder

BACKGROUND:
- If the grid1d length is a multiple of the total pattern length, after DivideByPattern call last cell of grid does not receive a type name according to the pattern.

DESCRIPTION:
- Include last cell segment to patternSegments in Cycle function.
  - After this fix if grid length is equal to first pattern item length, NullReferenceException is thrown in DivideWithPatternAndOffset method. Add handling for this case.

TESTING:
- Added a new test, which used to fail, and now succeeds
  
REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/581)
<!-- Reviewable:end -->
