### PR TITLE
handle when the span is 0 for an analysis grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.9.1
+
+### Added
+
+### Removed
+
+### Changed
+- Make AnalysisMesh handle single valued analysis.
+
+### Fixed
+
 ## 0.9.0
 
 ### Added
@@ -21,7 +32,6 @@
 
 - Fixed a bug in `ConvexHull.FromPoints` when multiple X coordinates are equal.
 - Fixed a bug in `Grid2d(Polygon, Vector3, Vector3, Vector3)` where U or V directions skew slightly when they nearly parallel with a boundary edge.
-- Make AnalysisMesh handle single valued analysis.
 
 
 ## 0.8.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - Fixed a bug in `ConvexHull.FromPoints` when multiple X coordinates are equal.
 - Fixed a bug in `Grid2d(Polygon, Vector3, Vector3, Vector3)` where U or V directions skew slightly when they nearly parallel with a boundary edge.
+- Make AnalysisMesh handle single valued analysis.
 
 
 ## 0.8.5

--- a/Elements/src/Analysis/AnalysisMesh.cs
+++ b/Elements/src/Analysis/AnalysisMesh.cs
@@ -92,7 +92,7 @@ namespace Elements.Analysis
             foreach (var result in this._results)
             {
                 var center = result.cell.Center();
-                var vertexColor = this.Perimeter.Contains(center) ? this.ColorScale.GetColor((result.value - this._min) / span) : Colors.White;
+                var vertexColor = this.Perimeter.Contains(center) ? this.ColorScale.GetColor(span == 0 ? result.value : (result.value - this._min) / span) : Colors.White;
                 var min = result.cell.Min;
                 var max = result.cell.Max;
                 var v1 = mesh.AddVertex(min, color: vertexColor);

--- a/Elements/test/AnalysisMeshTests.cs
+++ b/Elements/test/AnalysisMeshTests.cs
@@ -45,5 +45,17 @@ namespace Elements.Tests
 
             this.Model.AddElement(analysisMesh);
         }
+
+        [Fact]
+        public void SingleValueAnalysisMesh()
+        {
+            this.Name = "SingleValueAnalysis";
+            var perimeter = Polygon.Ngon(5, 5);
+            var colorScale = new ColorScale(new List<Color>() { Colors.Cyan, Colors.Orange }, 10);
+            var analysisMesh = new AnalysisMesh(perimeter, 0.2, 0.2, colorScale, (Vector3 vector) => { return 1; });
+            analysisMesh.Analyze();
+
+            this.Model.AddElement(analysisMesh);
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- I made an analysis mesh in a "all one color" situation, and it crashed

DESCRIPTION:
- Help the analysis mesh handle the case where there's just one value, and so min==max and then span / 0.

TESTING:
- I've used this in a function.
- The new test passes.
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/583)
<!-- Reviewable:end -->
