### PR TITLE
Support non-xy splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,14 @@
 
 ### Added
 
+- `Polygon.ToTransform()`
+
 ### Removed
 
 ### Changed
 
+- `AnalysisMesh` now handles single valued analysis.
 - `Polygon.Split()` can now handle polygons that are not in the XY plane.
-- Make AnalysisMesh handle single valued analysis.
-- `Mesh.GetBuffers` now returns a `GraphicsBuffers` object.
-- `Solid.Tessellate` now returns a `GraphicsBuffers` object.
-- `CsgExtensions.Tessellate` now returns a `GraphicsBuffers` object.
 
 ### Fixed
 
@@ -20,7 +19,6 @@
 
 ### Added
 
-- `Polygon.ToTransform()`
 - `Grid2d.IsOutside()`
 - `GraphicsBuffers`
 
@@ -35,6 +33,9 @@
 - `ConstructedSolid` serializes and deserializes correctly.
 - `Solid.AddFace(Polygon, Polygon[])` can take an optional third `mergeVerticesAndEdges` argument which will automatically reuse existing edges + vertices in the solid.
 - Adds optional `tolerance` parameter to `Line.ExtendTo(Polygon)`, `Line.ExtendTo(IEnumerable<Line>)`, `Vector3.IsParallelTo(Vector3)`.
+- `Mesh.GetBuffers` now returns a `GraphicsBuffers` object.
+- `Solid.Tessellate` now returns a `GraphicsBuffers` object.
+- `CsgExtensions.Tessellate` now returns a `GraphicsBuffers` object.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Added
 
+- `Polygon.ToTransform()`
 - `Grid2d.IsOutside()`
 
 ### Removed
+
 - `BuiltInMaterials.Dirt`
 - `BuiltInMaterials.Grass`
 
@@ -16,12 +18,12 @@
 - `ConstructedSolid` serializes and deserializes correctly.
 - `Solid.AddFace(Polygon, Polygon[])` can take an optional third `mergeVerticesAndEdges` argument which will automatically reuse existing edges + vertices in the solid.
 - Adds optional `tolerance` parameter to `Line.ExtendTo(Polygon)`, `Line.ExtendTo(IEnumerable<Line>)`, `Vector3.IsParallelTo(Vector3)`.
+- `Polygon.Split()` can now handle polygons that are not in the XY plane.
 
 ### Fixed
 
 - Fixed a bug in `ConvexHull.FromPoints` when multiple X coordinates are equal.
 - Fixed a bug in `Grid2d(Polygon, Vector3, Vector3, Vector3)` where U or V directions skew slightly when they nearly parallel with a boundary edge.
-
 
 ## 0.8.5
 

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -55,6 +55,16 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Construct a transform in the plane of this polygon, with its Z axis along the polygon's normal.
+        /// </summary>
+        /// <returns></returns>
+        public Transform ToTransform()
+        {
+            var normal = Normal();
+            return new Transform(Vertices[0], Vertices[1] - Vertices[0], normal);
+        }
+
+        /// <summary>
         /// Tests if the supplied Vector3 is within this Polygon without coincidence with an edge when compared on a shared plane.
         /// </summary>
         /// <param name="vector">The Vector3 to compare to this Polygon.</param>
@@ -362,14 +372,10 @@ namespace Elements.Geometry
         /// <param name="pl">The polyline with which to split.</param>
         public List<Polygon> Split(Polyline pl)
         {
-            var plXform = this.Vertices.ToTransform();
+            var plXform = this.ToTransform();
             var inverse = new Transform(plXform);
             inverse.Invert();
             var thisInXY = this.TransformedPolygon(inverse);
-            if (thisInXY.IsClockWise())
-            {
-                thisInXY = thisInXY.Reversed();
-            }
             // Construct a half-edge graph from the polygon and the polyline
             var graph = Elements.Spatial.HalfEdgeGraph2d.Construct(thisInXY, pl.TransformedPolyline(inverse));
             // Find closed regions in that graph
@@ -382,14 +388,10 @@ namespace Elements.Geometry
         /// <param name="polylines">The polylines with which to split.</param>
         public List<Polygon> Split(IEnumerable<Polyline> polylines, Model m = null)
         {
-            var plXform = this.Vertices.ToTransform();
+            var plXform = this.ToTransform();
             var inverse = new Transform(plXform);
             inverse.Invert();
             var thisInXY = this.TransformedPolygon(inverse);
-            if (thisInXY.IsClockWise())
-            {
-                thisInXY = thisInXY.Reversed();
-            }
             // Construct a half-edge graph from the polygon and the polylines
             m?.AddElement(this.TransformedPolygon(inverse));
             m?.AddElements(polylines.Select(p => new ModelCurve(p.TransformedPolyline(inverse))));

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -386,15 +386,13 @@ namespace Elements.Geometry
         /// Split this polygon with a collection of open polylines.
         /// </summary>
         /// <param name="polylines">The polylines with which to split.</param>
-        public List<Polygon> Split(IEnumerable<Polyline> polylines, Model m = null)
+        public List<Polygon> Split(IEnumerable<Polyline> polylines)
         {
             var plXform = this.ToTransform();
             var inverse = new Transform(plXform);
             inverse.Invert();
             var thisInXY = this.TransformedPolygon(inverse);
             // Construct a half-edge graph from the polygon and the polylines
-            m?.AddElement(this.TransformedPolygon(inverse));
-            m?.AddElements(polylines.Select(p => new ModelCurve(p.TransformedPolyline(inverse))));
             var graph = Elements.Spatial.HalfEdgeGraph2d.Construct(new[] { thisInXY }, polylines.Select(p => p.TransformedPolyline(inverse)));
             // Find closed regions in that graph
             return graph.Polygonize().Select(p => p.TransformedPolygon(plXform)).ToList();

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -893,7 +893,7 @@ namespace Elements.Serialization.glTF
                                                                 textures,
                                                                 images,
                                                                 samplers,
-                                                                false
+                                                                true
                                                                 );
 
 
@@ -1096,7 +1096,7 @@ namespace Elements.Serialization.glTF
             }
         }
 
-        public static Dictionary<string, MemoryStream> gltfCache = new Dictionary<string, MemoryStream>();
+        private static Dictionary<string, MemoryStream> gltfCache = new Dictionary<string, MemoryStream>();
 
         internal static Stream GetGlbStreamFromPath(string gltfLocation)
         {

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -893,7 +893,7 @@ namespace Elements.Serialization.glTF
                                                                 textures,
                                                                 images,
                                                                 samplers,
-                                                                true
+                                                                false
                                                                 );
 
 
@@ -1096,7 +1096,7 @@ namespace Elements.Serialization.glTF
             }
         }
 
-        private static Dictionary<string, MemoryStream> gltfCache = new Dictionary<string, MemoryStream>();
+        public static Dictionary<string, MemoryStream> gltfCache = new Dictionary<string, MemoryStream>();
 
         internal static Stream GetGlbStreamFromPath(string gltfLocation)
         {

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -901,6 +901,26 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
+        public void ToTransformOrientation()
+        {
+            var polygon = new Polygon(new[] {
+                        new Vector3(3,0,1),
+                        new Vector3(1,0,10),
+                        new Vector3(10,0,17),
+                        new Vector3(21,0,14),
+                        new Vector3(12,0,11),
+                        new Vector3(15,0,5),
+                        new Vector3(22,0,8),
+                        new Vector3(22,0,2),
+                        new Vector3(13,0,2),
+                        new Vector3(13,0,1)
+                        });
+            var polygonNormal = polygon.Normal();
+            var transform = polygon.ToTransform();
+            Assert.Equal(1, transform.ZAxis.Dot(polygonNormal));
+        }
+
+        [Fact]
         public void DeserializesWithoutDiscriminator()
         {
             // We've received a Polygon and we know that we're receiving

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -893,7 +893,7 @@ namespace Elements.Geometry.Tests
                         })
                         };
 
-            var results = shape.Split(polylines, Model);
+            var results = shape.Split(polylines);
             Assert.True(results.Count == 5);
             Assert.Equal(Math.Abs(shape.Area()), results.Sum(r => Math.Abs(r.Area())));
             var rand = new Random(4);

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -864,6 +864,43 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
+        public void NonXYSplit()
+        {
+            Name = nameof(NonXYSplit);
+            var shape = new Polygon(new[] {
+                        new Vector3(3,0,1),
+                        new Vector3(1,0,10),
+                        new Vector3(10,0,17),
+                        new Vector3(21,0,14),
+                        new Vector3(12,0,11),
+                        new Vector3(15,0,5),
+                        new Vector3(22,0,8),
+                        new Vector3(22,0,2),
+                        new Vector3(13,0,2),
+                        new Vector3(13,0,1)
+                        });
+            var polylines = new List<Polyline> {
+                        new Polyline(new [] {
+                        new Vector3(1,0,16),
+                        new Vector3(7,0,9),
+                        new Vector3(7,0,-1)
+                        }),
+                        new Polyline(new [] {
+                        new Vector3(-2,0,5),
+                        new Vector3(10,0,5),
+                        new Vector3(17,0,9),
+                        new Vector3(14,0,18)
+                        })
+                        };
+
+            var results = shape.Split(polylines, Model);
+            Assert.True(results.Count == 5);
+            Assert.Equal(Math.Abs(shape.Area()), results.Sum(r => Math.Abs(r.Area())));
+            var rand = new Random(4);
+            Model.AddElements(results.Select(r => new Panel(r, rand.NextMaterial())));
+        }
+
+        [Fact]
         public void DeserializesWithoutDiscriminator()
         {
             // We've received a Polygon and we know that we're receiving
@@ -1316,7 +1353,8 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
-        public void VerticalContainment() {
+        public void VerticalContainment()
+        {
             var point = new Vector3(8.874555, 6.112945, 30);
             var polygon = new Polygon(new List<Vector3>() {
                 new Vector3(11.37475, 8.56224, -3),


### PR DESCRIPTION
BACKGROUND:
- Polygon.Split would fail or give incorrect results for polygons not in the world XY plane, or not counter-clockwise wound.

DESCRIPTION:
- Transforms a polygon into its XY plane before trying to split it, and then transforms its results back.
- Adds a `ToTransform()` method to `Polygon` which produces a consistent transform with its Z axis along the polygon's normal. Using `Vertices.ToTransform()` was not yielding consistent results.

TESTING:
- Added new tests, verified old split tests still pass.

FUTURE WORK:
- We might want to enable `Profile` methods to be more tolerant of non-XY orientations as well

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/584)
<!-- Reviewable:end -->
