### PR TITLE
Internals for revit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
+
 ## 0.9.1
 
 ### Added
-- `GetSolid()` method on GeometricElement that returns the Csg solid.
+- ~~`GetSolid()` method on GeometricElement that returns the Csg solid.~~
+- `ToMesh()` method on GeometricElement that return the mesh of a processed solid.
 - `Polygon.ToTransform()`
 - `Elements.Anaysis.AnalysisImage`
 
@@ -16,6 +18,7 @@
 - Leave the discriminator property during deserialization.  It will go to AdditionalProperties.
 
 ### Fixed
+- Guard against missing transforms while generating CSGs.
 
 ## 0.9.0
 

--- a/Elements/src/GeometricElement.cs
+++ b/Elements/src/GeometricElement.cs
@@ -40,6 +40,10 @@ namespace Elements
         /// </summary>
         public Mesh ToMesh()
         {
+            if (this.Representation == null || this.Representation.SolidOperations.Count == 0)
+            {
+                this.UpdateRepresentations();
+            }
             var mesh = new Mesh();
             var solid = this.GetSolid();
             solid.Tessellate(ref mesh);

--- a/Elements/src/GeometricElement.cs
+++ b/Elements/src/GeometricElement.cs
@@ -35,9 +35,21 @@ namespace Elements
         }
 
         /// <summary>
+        /// Get the complete final mesh of this geometric element.  This mesh is centered about the origin, and meant to be transformed
+        /// into the final location using the Geometric Element's Transform property.
+        /// </summary>
+        public Mesh ToMesh()
+        {
+            var mesh = new Mesh();
+            var solid = this.GetSolid();
+            solid.Tessellate(ref mesh);
+            return mesh;
+        }
+
+        /// <summary>
         /// Get the computed csg solid centered about the origin.
         /// </summary>
-        public Csg.Solid GetSolid()
+        internal Csg.Solid GetSolid()
         {
             // To properly compute csgs, all solid operation csgs need
             // to be transformed into their final position. Then the csgs

--- a/Elements/src/Geometry/CsgExtensions.cs
+++ b/Elements/src/Geometry/CsgExtensions.cs
@@ -12,7 +12,7 @@ namespace Elements.Geometry
         /// <summary>
         /// Write the csg into a mesh.
         /// </summary>
-        internal static void Tessellate(this Csg.Solid csg, ref Mesh mesh, Transform transform = null, Color color = default(Color))
+        internal static void Tessellate(this Csg.Solid csg, ref Mesh mesh, Transform transform = null)
         {
             foreach (var p in csg.Polygons)
             {

--- a/Elements/src/Geometry/Solids/Solid.cs
+++ b/Elements/src/Geometry/Solids/Solid.cs
@@ -392,6 +392,16 @@ namespace Elements.Geometry.Solids
         }
 
         /// <summary>
+        /// Get the Mesh of this Solid.
+        /// </summary>
+        public Mesh ToMesh()
+        {
+            var mesh = new Mesh();
+            this.Tessellate(ref mesh);
+            return mesh;
+        }
+
+        /// <summary>
         /// Triangulate this solid.
         /// </summary>
         /// <param name="mesh">The mesh to which the solid's tessellated data will be added.</param>
@@ -452,6 +462,8 @@ namespace Elements.Geometry.Solids
                 mesh.AddMesh(faceMesh);
             }
         }
+
+
 
         /// <summary>
         /// Triangulate this solid and pack the triangulated data into buffers
@@ -686,7 +698,7 @@ namespace Elements.Geometry.Solids
         private Loop SweepPolygonBetweenPlanes(Polygon p, Transform start, Transform end, double rotation = 0.0)
         {
             // Transform the polygon to the mid plane between two transforms
-            // then project onto the end transforms. We do this so that we 
+            // then project onto the end transforms. We do this so that we
             // do not introduce shear into the transform.
             var v = (start.Origin - end.Origin).Unitized();
             var midTrans = new Transform(end.Origin.Average(start.Origin), start.YAxis.Cross(v), v);

--- a/Elements/test/GeometricElementTests.cs
+++ b/Elements/test/GeometricElementTests.cs
@@ -1,0 +1,19 @@
+using Elements.Geometry;
+using Xunit;
+
+namespace Elements.Tests
+{
+    public class GeometricElementTests : ModelTest
+    {
+        [Fact]
+        public void ToMesh()
+        {
+            var profile = Polygon.Rectangle(1.0, 1.0);
+            var mass = new Mass(profile, 5.0, BuiltInMaterials.Mass, new Transform());
+            var mesh = mass.ToMesh();
+
+            Assert.Equal(24, mesh.Vertices.Count);
+            Assert.Equal(12, mesh.Triangles.Count);
+        }
+    }
+}

--- a/Elements/test/SolidTests.cs
+++ b/Elements/test/SolidTests.cs
@@ -173,6 +173,19 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void SolidToMesh()
+        {
+            var n = 4;
+            var outer = Polygon.Ngon(n, 2);
+            var inner = Polygon.Ngon(n, 1.75).Reversed();
+
+            var solid = Solid.SweepFace(outer, new[] { inner }, new Vector3(0.5, 0.5, 0.5), 5);
+            var mesh = solid.ToMesh();
+            var subtraction = mesh.ToCsg().Substract(solid.ToCsg());
+            Assert.Equal(0, subtraction.Polygons.Count);
+        }
+
+        [Fact]
         public void Serialization()
         {
             var n = 4;


### PR DESCRIPTION
BACKGROUND:
- We don't actually want to expose the Csg library and it's classes to external users so we make it possible to get the complete mesh of a geometric object for the cases when access to the complete solid would be desired.
 
DESCRIPTION:
- Make a public method called `ToMesh()` that is responsible for returning a tessellated solid.
- Guard against null transforms during csg construction.
- Add a utility method on `Solid` to get the mesh of a solid.

TESTING:
- Tests have been added.

FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.
