### PR TITLE
better handle closestPosition on polyline axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.9.1
 
 ### Added
+
 - `GetSolid()` method on GeometricElement that returns the Csg solid.
 - `Polygon.ToTransform()`
 - `Elements.Anaysis.AnalysisImage`
@@ -13,7 +14,8 @@
 
 - `AnalysisMesh` now handles single valued analysis.
 - `Polygon.Split()` can now handle polygons that are not in the XY plane.
-- Leave the discriminator property during deserialization.  It will go to AdditionalProperties.
+- Leave the discriminator property during deserialization. It will go to AdditionalProperties.
+- `Grid1d.ClosestPosition` now does a better job finding points on polyline axes.
 
 ### Fixed
 

--- a/Elements/src/Spatial/Grid1d.cs
+++ b/Elements/src/Spatial/Grid1d.cs
@@ -394,6 +394,32 @@ namespace Elements.Spatial
             {
                 point = parent.toGrid.OfPoint(point);
             }
+            if (Curve is Polyline pl && pl.Segments().Count() > 1)
+            {
+                var minDist = Double.MaxValue;
+                Vector3 closestPoint = Vector3.Origin;
+                Line[] segments = pl.Segments();
+                int closestSegment = -1;
+                for (int i = 0; i < segments.Length; i++)
+                {
+                    Line seg = segments[i];
+                    var cp = point.ClosestPointOn(seg);
+                    var dist = cp.DistanceTo(point);
+                    if (dist < minDist)
+                    {
+                        closestPoint = cp;
+                        minDist = dist;
+                        closestSegment = i;
+                    }
+                }
+                double curvePosition = 0.0;
+                for (int i = 0; i < closestSegment; i++)
+                {
+                    curvePosition += segments[i].Length();
+                }
+                curvePosition += segments[closestSegment].Start.DistanceTo(point);
+                return curvePosition;
+            }
             var A = Curve.PointAt(0);
             var B = Curve.PointAt(1);
             var C = point;

--- a/Elements/test/Grid1dTests.cs
+++ b/Elements/test/Grid1dTests.cs
@@ -91,6 +91,23 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void SplitAtPositionsInRightPlace()
+        {
+            var simpleLine = new Line(Vector3.Origin, new Vector3(10, 0, 0));
+            var lineGrid = new Grid1d(simpleLine);
+            var splitLocation = new Vector3(3, 0, 0);
+            lineGrid.SplitAtPoint(splitLocation);
+            Assert.True(lineGrid[0].GetCellGeometry().PointAt(1.0).DistanceTo(splitLocation) < 0.01);
+
+            var polyline = new Polyline(new[] { Vector3.Origin, new Vector3(3, 5), new Vector3(6, 2), new Vector3(10, -3) });
+            var polylineGrid = new Grid1d(polyline);
+            var polylineSplitLocation = new Vector3(3, 5);
+            polylineGrid.SplitAtPoint(polylineSplitLocation);
+            Assert.True(polylineGrid[0].GetCellGeometry().PointAt(1.0).DistanceTo(polylineSplitLocation) < 0.01);
+
+        }
+
+        [Fact]
         public void AlreadySplitGridsThrowsExceptionWhenDividedByN()
         {
             var grid = new Grid1d();


### PR DESCRIPTION
BACKGROUND:
- Previously, Grid.SplitAtPoint() and other methods would wind up splitting at the wrong point, due to their reliance on a dumb algorithm, which ignored the length of segments and calculated a position that assumed a straight-line axis.

DESCRIPTION:
- Adds a more sophisticated ClosestPosition algorithm that actually calculates the closest point on a polyline axis and computes the cumulative length up to that point.

TESTING:
- Added a new test that failed in previous versions of Elements, and passes now. 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/590)
<!-- Reviewable:end -->
