### PR TITLE
Discriminator warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Leave the discriminator property during deserialization. It will go to AdditionalProperties.
 - `Grid1d.ClosestPosition` now does a better job finding points on polyline axes.
 - Code-generated constructors now get default arguments for inherited properties.
+- Deserialization no longer uses throw to catch all missing type exceptions.
 
 ### Fixed
 

--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -68,7 +68,7 @@ namespace Elements
 
             // TODO: This is really expensive. This should be removed
             // when all internal types have been updated to not create elements
-            // during UpdateRepresentation. This is now possible because 
+            // during UpdateRepresentation. This is now possible because
             // geometry operations are reactive to changes in their properties.
             if (element is GeometricElement)
             {
@@ -191,7 +191,7 @@ namespace Elements
         /// </summary>
         /// <param name="json">The JSON representing the model.</param>
         /// <param name="errors">A collection of deserialization errors.</param>
-        /// <param name="forceTypeReload">Option to force reloading the inernal type cache. Use if you add types dynamically in your code.</param>
+        /// <param name="forceTypeReload">Option to force reloading the internal type cache. Use if you add types dynamically in your code.</param>
         public static Model FromJson(string json, out List<string> errors, bool forceTypeReload = false)
         {
             // When user elements have been loaded into the app domain, they haven't always been
@@ -212,6 +212,7 @@ namespace Elements
                     args.ErrorContext.Handled = true;
                 }
             });
+            deserializationErrors.AddRange(JsonInheritanceConverter.GetAndClearDeserializationWarnings());
             errors = deserializationErrors;
             JsonInheritanceConverter.Elements.Clear();
             return model;

--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -268,7 +268,7 @@ namespace Elements.Serialization.JSON
 
                 if (discriminator != null)
                 {
-                    _deserializationDiscriminatorWarnings.Add($"An object with the discriminator, {discriminator}, could not be deserialized. {baseMessage} {moreInfoMessage}");
+                    _deserializationDiscriminatorWarnings.Add($"An object with the discriminator, {discriminator}, could not be deserialized. {baseMessage}");
                     return null;
                 }
                 else

--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -51,6 +51,8 @@ namespace Elements.Serialization.JSON
             }
         }
 
+        private static List<string> _deserializationDiscriminatorWarnings = new List<string>();
+
         public JsonInheritanceConverter()
         {
             _discriminator = DefaultDiscriminatorName;
@@ -195,6 +197,13 @@ namespace Elements.Serialization.JSON
             return true;
         }
 
+        public static List<string> GetAndClearDeserializationWarnings()
+        {
+            var warnings = _deserializationDiscriminatorWarnings.ToList();
+            _deserializationDiscriminatorWarnings.Clear();
+            return warnings;
+        }
+
         public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
         {
             // The serialized value is an identifier, so the expectation is
@@ -259,7 +268,8 @@ namespace Elements.Serialization.JSON
 
                 if (discriminator != null)
                 {
-                    throw new Exception($"An object with the discriminator, {discriminator}, could not be deserialized. {baseMessage} {moreInfoMessage}", ex);
+                    _deserializationDiscriminatorWarnings.Add($"An object with the discriminator, {discriminator}, could not be deserialized. {baseMessage} {moreInfoMessage}");
+                    return null;
                 }
                 else
                 {


### PR DESCRIPTION
BACKGROUND:
- When working with local elements it is frustrating to deserialize a model where many elements are unknown, because you get a caught exception for every single element that can't be serialized.

DESCRIPTION:
- Rather than throwing a new exception when an object fails to be de-serialized, we gather the messages up in a private static list and when we access the list after de-serialization we clear it.

TESTING:
- Functionality should be unchanged.
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/595)
<!-- Reviewable:end -->
