### PR TITLE
fix transform orientation

### DIFF
--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -995,7 +995,6 @@ namespace Elements.Serialization.glTF
                     {
                         transform.Concatenate(i.Transform);
                         NodeUtilities.AddInstanceAsCopyOfNode(nodes, nodeElementMap[i.BaseDefinition.Id], transform);
-
                     }
                     else
                     {

--- a/Elements/src/Serialization/glTF/GltfMergingUtils.cs
+++ b/Elements/src/Serialization/glTF/GltfMergingUtils.cs
@@ -148,7 +148,7 @@ namespace Elements.Serialization.glTF
             {
                 foreach (var child in node.Children)
                 {
-                    protoNode.Children.Add(RecursivelyModifyMeshIndices(loadedNodes[child], meshIndices, loadedNodes)); ;
+                    protoNode.Children.Add(RecursivelyModifyMeshIndices(loadedNodes[child], meshIndices, loadedNodes));
                 }
             }
             return protoNode;

--- a/Elements/src/Serialization/glTF/NodeUtilities.cs
+++ b/Elements/src/Serialization/glTF/NodeUtilities.cs
@@ -72,9 +72,15 @@ namespace Elements.Serialization.glTF
                                             ProtoNode nodeToCopy,
                                             Transform transform)
         {
-            // A new node is created that contains the node to copy as it's only child.
+            var rootTransform = new Transform();
+            // glb has Y up. transform it to have Z up so we
+            // can create instances of it in a Z up world. It will get switched
+            // back to Y up further up in the node hierarchy. 
+            rootTransform.Rotate(new Vector3(1, 0, 0), 90.0);
+            rootTransform.Concatenate(transform);
+            // A new node is created that contains the node to copy as its only child.
             // We use the node to copy exactly as is, with an unmodified transform.
-            float[] matrix = TransformToMatrix(transform);
+            float[] matrix = TransformToMatrix(rootTransform);
             var newNode = new glTFLoader.Schema.Node();
             newNode.Matrix = matrix;
             nodes.Add(newNode);
@@ -106,7 +112,6 @@ namespace Elements.Serialization.glTF
             }
             if (childIndices.Count > 0)
             {
-
                 newNode.Children = childIndices.ToArray();
             }
 

--- a/Elements/test/GltfTests.cs
+++ b/Elements/test/GltfTests.cs
@@ -32,10 +32,22 @@ namespace Elements.Tests
         [Fact]
         public void InstanceContentElements()
         {
-            var cElement = new ContentElement("../../../models/MergeGlTF/multiple-instances.glb", new BBox3(new Vector3(), new Vector3(1, 1, 1)), 1, Vector3.XAxis, new Transform(), null, null, true, Guid.NewGuid(), "", "");
+            var singleElement = new ContentElement("https://hypar-content-catalogs.s3-us-west-2.amazonaws.com/a1cf1df6-0762-45e7-942b-7ba17d813ff4/HermanMiller_Collection_Eames_MoldedPlywood_DiningChair_MtlBase+-+Upholstered.glb", new BBox3(new Vector3(), new Vector3(1, 1, 1)), 1, Vector3.XAxis, new Transform(), null, null, true, Guid.NewGuid(), "", "");
+            var baseModel = new Model();
+            for (int i = 0; i < 10; i++)
+            {
+                var transform = new Transform();
+                transform.Rotate(i * 10);
+                transform.Concatenate(new Transform(i * 2, 0, 0));
+                baseModel.AddElement(singleElement.CreateInstance(transform, "Individual Element"));
+            }
+            var glbWithInstancesPath = Path.Combine("models", "multiple-instances.glb");
+            baseModel.ToGlTF(glbWithInstancesPath);
+            baseModel.ToGlTF(glbWithInstancesPath.Replace("glb", "gltf"), false);
+            var cElement = new ContentElement(glbWithInstancesPath, new BBox3(new Vector3(), new Vector3(1, 1, 1)), 1, Vector3.XAxis, new Transform(), null, null, true, Guid.NewGuid(), "", "");
 
             var model = new Model();
-            foreach (var i in Enumerable.Range(0, 5))
+            foreach (var i in Enumerable.Range(1, 5))
             {
                 var inst = cElement.CreateInstance(new Transform(new Vector3(0, i * 3, 0)), "");
                 model.AddElement(inst);


### PR DESCRIPTION
BACKGROUND:
- Transforms were coming out after our glb instancing changes. It turns out, not only were our instances-of-instances coming out oriented wrong, even just a plain old single-level-deep of content elements was also coming out wrong (for example: make a bunch of instances of a duck, duck would now be wrong way).

DESCRIPTION:
- Fixes the transform orientation for our WIP instance-merged-glbs branch

Our GLBs are composed of pairs of layers — one "layer" operates in the +Z up space, and is where we do things like instance positioning transforms, and then at the next layer up we switch everything back to being +Y up. This is my best stab at understanding what's happening:
![image](https://user-images.githubusercontent.com/31935763/121091384-c80d3100-c79e-11eb-9dce-82dc1707804a.png)
- a little cleanup elsewhere

TESTING:
- Modified test to include the creation of a "1 level deep" glb as well, and using that as the basis for the "2 levels deep" glb. 
  