### PR TITLE
Add more explanation for IsClockwise.

### DIFF
--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -390,6 +390,9 @@ namespace Elements.Geometry
 
         /// <summary>
         /// Calculates whether this polygon is configured clockwise.
+        /// This method only works for 2D polygons. For 3D polygons, you
+        /// will need to transform your polygon into the XY plane, then
+        /// run this method on that polygon.
         /// </summary>
         /// <returns>True if this polygon is oriented clockwise.</returns>
         public bool IsClockWise()


### PR DESCRIPTION
BACKGROUND:
- Daniel Fink noted that the `Polygon.IsClockwise` method doesn't work for 3d polygons.

DESCRIPTION:
- This adds a note (yes, we should add a function), that clarifies that the method is only appropriate for 2D polygons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/599)
<!-- Reviewable:end -->
