### PR TITLE
Add Polygon.CollinearPointsRemoved and Vector3.AreCollinear(a,b,c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   - `Face.TraverseNeighbors(Vector3 target, double? completedRadius)`
   - `Face.TraverseNeighbors(Vector3 target, bool? parallel, bool? includeSharedVertices, double? completedRadius)`
 - Dxf creation framework with first Dxf converter.
+- `Vector3.AreCollinear(Vector3 a, Vector3 b, Vector3 c)`
+- `Polygon.CollinearPointsRemoved()`
 
 ### Changed
 

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -1131,6 +1131,30 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Remove collinear points from this Polygon.
+        /// </summary>
+        /// <returns>New Polygon without collinear points.</returns>
+        public Polygon CollinearPointsRemoved()
+        {
+            int count = this.Vertices.Count;
+            var unique = new List<Vector3>(count);
+
+            if (!Vector3.AreCollinear(Vertices[count - 1], Vertices[0], Vertices[1]))
+                unique.Add(Vertices[0]);
+
+            for (int i = 1; i < count - 1; i++)
+            {
+                if (!Vector3.AreCollinear(Vertices[i - 1], Vertices[i], Vertices[i + 1]))
+                    unique.Add(Vertices[i]);
+            }
+
+            if (!Vector3.AreCollinear(Vertices[count - 2], Vertices[count - 1], Vertices[0]))
+                unique.Add(Vertices[count - 1]);
+
+            return new Polygon(unique);
+        }
+
+        /// <summary>
         /// Get the transforms used to transform a Profile extruded along this Polyline.
         /// </summary>
         /// <param name="startSetback"></param>

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -686,6 +686,24 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Check whether three points are on the same line.
+        /// </summary>
+        /// <param name="a">The first point.</param>
+        /// <param name="b">The second point.</param>
+        /// <param name="c">The third point.</param>
+        /// <returns>True if the points are on the same line, false otherwise.</returns>
+        public static bool AreCollinear(Vector3 a, Vector3 b, Vector3 c)
+        {
+            var ba = (b - a).Unitized();
+            var cb = (c - b).Unitized();
+
+            if (ba.IsZero() || cb.IsZero())
+                return true;
+
+            return Math.Abs(cb.Dot(ba)) > (1 - Vector3.EPSILON);
+        }
+
+        /// <summary>
         /// Compute basis vectors for this vector.
         /// By default, the cross product of the world Z axis and this vector
         /// are used to compute the U direction. If this vector is parallel

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -1463,5 +1463,22 @@ namespace Elements.Geometry.Tests
                 Assert.True(results[i].X > results[i - 1].X);
             }
         }
+
+        [Fact]
+        public void CollinearPointCanBeRemoved()
+        {
+            var points = new Vector3[6]{
+                new Vector3( 0, 0, 0),
+                new Vector3( 10,0,0),
+                new Vector3(20,0,0),
+                new Vector3( 20, 20, 0),
+                new Vector3( 10, 20, 0),
+                new Vector3( 0, 20 , 0)
+                };
+
+            var polygon = new Polygon(points);
+            polygon = polygon.CollinearPointsRemoved();
+            Assert.True(polygon.Vertices.Count == 4);
+        }
     }
 }

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -387,5 +387,17 @@ namespace Elements.Tests
                 Assert.True(includes == pt.Value);
             }
         }
+
+        [Fact]
+        public void Collinear()
+        {
+            Vector3 p0 = new Vector3( 0, 0, 0);
+            Vector3 p1 = new Vector3( 10, 10, 10);
+            Vector3 p2 = new Vector3( 20, 20, 20);
+            Vector3 p3 = new Vector3( 15, 5, 20);
+
+            Assert.True( Vector3.AreCollinear( p0, p1, p2 ) );
+            Assert.False( Vector3.AreCollinear( p0, p1, p3 ) );
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- The CollinearPointsRemoved  is to be used in the function for lights placement.

DESCRIPTION:
- The AreCollinear for 3 points is used in CollinearPointsRemoved. CollinearPointsRemoved is good to have for the algorithms that work on Polygon and, for example, wants to know which segment is the longest.

TESTING:
- CollinearPointCanBeRemoved is added to PolygonTests and Collinear to VectorTests
  
FUTURE WORK:

REQUIRED:
- [x ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
There is AreCollinear extension of the list of Vector3d but it's not convenient for the case if you don't have a list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/600)
<!-- Reviewable:end -->
