### PR TITLE
Dmuravskyi/tranform of vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Code-generated constructors now get default arguments for inherited properties.
 - `IsDegenerate()` method was reversed.
 - Adding content elements that contain multiple nodes used to only add the first mesh, now it adds all the nodes in the referenced glb hierarchy.
+- `Transform.OfVector(Vector)` is not applying translation anymore as vector doesn't have a position by definition.
 
 ## 0.9.0
 

--- a/Elements.Components/src/Rules/PolylinePlacementRule.cs
+++ b/Elements.Components/src/Rules/PolylinePlacementRule.cs
@@ -90,7 +90,7 @@ namespace Elements.Components
                 var displacementForVertex = definition.AnchorDisplacements[anchorIndex];
 
                 // transform from reference anchor to polyline vertex
-                var transform = new Transform(definition.OrientationGuide.OfVector(rule.AnchorDisplacements[i]));
+                var transform = new Transform(definition.OrientationGuide.OfPoint(rule.AnchorDisplacements[i]));
 
                 transform.Concatenate(new Transform(displacementForVertex));
 

--- a/Elements.Components/src/Rules/SizeBasedPlacementRule.cs
+++ b/Elements.Components/src/Rules/SizeBasedPlacementRule.cs
@@ -146,7 +146,7 @@ namespace Elements.Components
                 var displacementForVertex = definition.AnchorDisplacements[anchorIndex];
 
                 // transform from reference anchor to polyline vertex
-                var transform = new Transform(definition.OrientationGuide.OfVector(rule.AnchorDisplacements[i]));
+                var transform = new Transform(definition.OrientationGuide.OfPoint(rule.AnchorDisplacements[i]));
 
                 transform.Concatenate(new Transform(displacementForVertex));
 

--- a/Elements/src/Geometry/Ray.cs
+++ b/Elements/src/Geometry/Ray.cs
@@ -96,12 +96,7 @@ namespace Elements.Geometry
             var transformFromElement = new Transform(element.Transform);
             transformFromElement.Invert();
             var transformToElement = new Transform(element.Transform);
-            var transformMinusTranslation = new Transform(transformFromElement);
-
-            // This transform ignores position so it can be used to transform the ray direction vector
-            transformMinusTranslation.Move(transformMinusTranslation.Origin.Negate());
-
-            var transformedRay = new Ray(transformFromElement.OfPoint(Origin), transformMinusTranslation.OfVector(Direction));
+            var transformedRay = new Ray(transformFromElement.OfPoint(Origin), transformFromElement.OfVector(Direction));
             //TODO: extend to handle voids when void solids in Representations are supported generally
             var intersects = false;
             foreach (var solidOp in element.Representation.SolidOperations.Where(e => !e.IsVoid))
@@ -169,7 +164,7 @@ namespace Elements.Geometry
                 var transformToPolygon = new Transform(plane.Origin, plane.Normal);
                 var transformFromPolygon = new Transform(transformToPolygon);
                 transformFromPolygon.Invert();
-                var transformedIntersection = transformFromPolygon.OfVector(intersection);
+                var transformedIntersection = transformFromPolygon.OfPoint(intersection);
                 IEnumerable<Line> curveList = boundaryPolygon.Segments();
                 if (voids != null)
                 {
@@ -201,7 +196,7 @@ namespace Elements.Geometry
                 var transformToPolygon = new Transform(plane.Origin, plane.Normal);
                 var transformFromPolygon = new Transform(transformToPolygon);
                 transformFromPolygon.Invert();
-                var transformedIntersection = transformFromPolygon.OfVector(intersection);
+                var transformedIntersection = transformFromPolygon.OfPoint(intersection);
                 IEnumerable<Line> curveList = polygon.Segments();
                 curveList = curveList.Select(l => l.TransformedLine(transformFromPolygon));
 

--- a/Elements/src/Geometry/Transform.cs
+++ b/Elements/src/Geometry/Transform.cs
@@ -168,7 +168,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Transform a vector into the coordinate space defined by this transform ignoring the translation.
+        /// Transform a vector into the coordinate space defined by this transform.
         /// </summary>
         /// <param name="vector">The vector to transform.</param>
         /// <returns>A new vector transformed by this transform.</returns>
@@ -178,17 +178,16 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Transform a vector into the coordinate space defined by this transform.
+        /// Transform a vector into the coordinate space defined by this transform ignoring the translation.
         /// </summary>
         /// <param name="vector">The vector to transform.</param>
         /// <returns>A new vector transformed by this transform.</returns>
         public Vector3 OfVector(Vector3 vector)
         {
-            var m = new Matrix(this.XAxis, this.YAxis, this.ZAxis, this.Origin);
             return new Vector3(
-                vector.X * m.XAxis.X + vector.Y * YAxis.X + vector.Z * ZAxis.X + this.Origin.X,
-                vector.X * m.XAxis.Y + vector.Y * YAxis.Y + vector.Z * ZAxis.Y + this.Origin.Y,
-                vector.X * m.XAxis.Z + vector.Y * YAxis.Z + vector.Z * ZAxis.Z + this.Origin.Z
+                vector.X * XAxis.X + vector.Y * YAxis.X + vector.Z * ZAxis.X,
+                vector.X * XAxis.Y + vector.Y * YAxis.Y + vector.Z * ZAxis.Y,
+                vector.X * XAxis.Z + vector.Y * YAxis.Z + vector.Z * ZAxis.Z
             );
         }
 
@@ -246,10 +245,7 @@ namespace Elements.Geometry
         /// <returns>A new plane transformed by this transform.</returns>
         public Plane OfPlane(Plane plane)
         {
-            // The normal vector must be transformed in a way
-            // that considers only orientation and not position
-            var tempXform = new Transform(Vector3.Origin, this.XAxis, this.ZAxis);
-            return new Plane(OfPoint(plane.Origin), tempXform.OfVector(plane.Normal));
+            return new Plane(OfPoint(plane.Origin), OfVector(plane.Normal));
         }
 
         /// <summary>

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -1024,7 +1024,7 @@ namespace Elements.Serialization.glTF
                             {
                                 foreach (var edge in solidOp.Solid.Edges.Values)
                                 {
-                                    lines.AddRange(new[] { i.Transform.OfVector(edge.Left.Vertex.Point), i.Transform.OfVector(edge.Right.Vertex.Point) });
+                                    lines.AddRange(new[] { i.Transform.OfPoint(edge.Left.Vertex.Point), i.Transform.OfPoint(edge.Right.Vertex.Point) });
                                 }
                             }
                         }

--- a/Elements/src/StandardWall.cs
+++ b/Elements/src/StandardWall.cs
@@ -112,7 +112,7 @@ namespace Elements
             var yAxis = xAxis.Cross(Vector3.ZAxis.Negate());
             var wallTransform = new Transform(this.CenterLine.Start, xAxis, Vector3.ZAxis);
 
-            var m = wallTransform.OfVector(new Vector3(x, 0, y));
+            var m = wallTransform.OfPoint(new Vector3(x, 0, y));
             var openingTransform = new Transform(m, xAxis, xAxis.Cross(Vector3.ZAxis));
             return openingTransform;
         }

--- a/Elements/test/RayTests.cs
+++ b/Elements/test/RayTests.cs
@@ -286,6 +286,22 @@ namespace Elements.Tests
             Assert.False(new Ray(new Vector3(-1, -1, -1), new Vector3(0, 0, 1)).Intersects(polygon, out var _));
         }
 
+        [Fact]
+        private static void RayIntersectsPolygonWithTransformation()
+        {
+            var outer = Polygon.Rectangle(6, 6);
+            var mass = new Mass(new Profile(outer), 2);
+            var ray = new Ray(new Vector3(3.5, 0, -4), new Vector3(0, 0, 1));
+            //The mass (-3,-3,0);(3,3,2) not intersects with the ray
+            Assert.False(ray.Intersects(mass, out var _));
+            //Rotated mass (0,-3,3);(2,3,-3)
+            mass.Transform.Rotate(Vector3.YAxis, 90);
+            //Translated mass (2,-3,3);(4,3,-3) and it crosses the ray
+            mass.Transform.Move(new Vector3(2, 0, 0));
+            mass.UpdateRepresentations();
+            Assert.True(ray.Intersects(mass, out var _));
+        }
+
         private static Vector3 Center(Triangle t)
         {
             return new Vector3[] { t.Vertices[0].Position, t.Vertices[1].Position, t.Vertices[2].Position }.Average();

--- a/Elements/test/RayTests.cs
+++ b/Elements/test/RayTests.cs
@@ -287,7 +287,7 @@ namespace Elements.Tests
         }
 
         [Fact]
-        private static void RayIntersectsPolygonWithTransformation()
+        private static void RayIntersectsGeometryWithTransformation()
         {
             var outer = Polygon.Rectangle(6, 6);
             var mass = new Mass(new Profile(outer), 2);

--- a/Elements/test/TransformTests.cs
+++ b/Elements/test/TransformTests.cs
@@ -39,12 +39,40 @@ namespace Elements.Tests
         [Fact]
         public void Transform_OfPoint()
         {
-            var t = new Transform(Vector3.Origin, Vector3.XAxis, Vector3.YAxis.Negate());
+            var o = new Vector3(1, 1, 0);
+            var t = new Transform(o, Vector3.XAxis, Vector3.YAxis.Negate());
             var v = new Vector3(0.5, 0.5, 0.0);
             var vt = t.OfPoint(v);
+            Assert.Equal(1.5, vt.X);
+            Assert.Equal(1.0, vt.Y);
+            Assert.Equal(0.5, vt.Z);
+        }
+
+        [Fact]
+        public void Transform_OfVector()
+        {
+            var o = new Vector3(1, 1, 0);
+            var t = new Transform(o, Vector3.XAxis, Vector3.YAxis.Negate());
+            var v = new Vector3(0.5, 0.5, 0.0);
+            var vt = t.OfVector(v);
             Assert.Equal(0.5, vt.X);
             Assert.Equal(0.0, vt.Y);
             Assert.Equal(0.5, vt.Z);
+        }
+
+        [Fact]
+        public void Transform_OfPlane()
+        {
+            var o = new Vector3(1, 1, 0);
+            var t = new Transform(o, Vector3.XAxis, Vector3.YAxis.Negate());
+            var p = new Plane( new Vector3(0.5, 0.5, 0.0), new Vector3(0, 0, 1) );
+            var pt = t.OfPlane(p);
+            Assert.Equal(1.5, pt.Origin.X);
+            Assert.Equal(1.0, pt.Origin.Y);
+            Assert.Equal(0.5, pt.Origin.Z);
+            Assert.Equal(0.0, pt.Normal.X);
+            Assert.Equal(-1.0, pt.Normal.Y);
+            Assert.Equal(0.0, pt.Normal.Z);
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
Right now, OfPoint and OfVector produce the same result. Then vector is multiplied by the matrix it's 4th coordinate is considered to be 0, as vector doesn't have a position by definition.

DESCRIPTION:
Changed Transform.OfVector: removed unnecessary copying and translation is no longer added.
Removed workaround code needed to ignore translation from Transform.OfPlane and Ray.Intersects
Vector3.PlaneAngleTo left untouched, since it cares only about rotation.
All other places are changed from OfVector to OfPoint to prevent regressions

TESTING:
Added test cases for Ray.Intersects with transformation, Transform.OfVector and Transform.OfPlane
  
FUTURE WORK:

REQUIRED:
- [ x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
There may be places that are now broken after changing Transform.OfVector and, as a result, replacing one by another in the code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/603)
<!-- Reviewable:end -->
