### PR TITLE
use stored transform for base and remove dead code

### DIFF
--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -989,20 +989,16 @@ namespace Elements.Serialization.glTF
                     // if we have a stored node for this object, we use that when adding it to the gltf.
                     if (nodeElementMap.TryGetValue(i.BaseDefinition.Id, out var nodeToCopy))
                     {
-                        transform.Concatenate(i.Transform);
-                        NodeUtilities.AddInstanceAsCopyOfNode(nodes, nodeElementMap[i.BaseDefinition.Id], transform);
-                    }
-                    else
-                    {
-                        // If there is a transform stored for the content base definition we
-                        // should apply it when creating instances.
-                        // TODO check if this meshTransformMap ever does anything.
                         if (meshTransformMap.TryGetValue(i.BaseDefinition.Id, out var baseTransform))
                         {
                             transform.Concatenate(baseTransform);
                         }
                         transform.Concatenate(i.Transform);
-                        NodeUtilities.AddInstanceNode(nodes, meshElementMap[i.BaseDefinition.Id], transform);
+                        NodeUtilities.AddInstanceAsCopyOfNode(nodes, nodeElementMap[i.BaseDefinition.Id], transform);
+                    }
+                    else
+                    {
+                        throw new Exception("Missing node element map for ContentElement base Definition.  This can happen if the ContentElement was not loaded before this instance is being placed.  Please check for deserialization errors and ");
                     }
                 }
                 else


### PR DESCRIPTION
BACKGROUND:
- want to fix glb instancing when content has a transformation

DESCRIPTION:
- include the base transform when adding mesh to glb
- put an error where I think some dead code lived.

TESTING:
- before fix 
![image](https://user-images.githubusercontent.com/5872187/123102151-c3818300-d402-11eb-90cf-1ac5f2a63684.png)
- after fix 
![image](https://user-images.githubusercontent.com/5872187/123102175-c8decd80-d402-11eb-9afc-6ae73d5fedb6.png)

  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/606)
<!-- Reviewable:end -->
