### PR TITLE
supply local document path for codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `Vector3.>=`
 - `Vector3.<=`
 - `Plane.Intersects(Plane a, Plane b)`
+- [#616](https://github.com/hypar-io/Elements/issues/616) Code generation from local files now supplies a directory path to help resolve local references
 
 ## 0.9.1
 

--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -354,7 +354,7 @@ namespace Elements.Generate
                 {
                     throw new Exception($"The specified schema, {uri}, can not be found at the path {path}.");
                 }
-                return await JsonSchema.FromJsonAsync(File.ReadAllText(path));
+                return await JsonSchema.FromJsonAsync(File.ReadAllText(path), Directory.GetCurrentDirectory() + "/");
             }
         }
 

--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -29,6 +29,15 @@ namespace Elements.Generate
             // Console.WriteLine(typeNameHint + ":" + schema.InheritedSchema ?? "none");
             if (schema.IsEnumeration || String.IsNullOrEmpty(schema.Title))
             {
+                if (typeNameHint == null)
+                {
+                    // Normally we will have either a schema Title or a type
+                    // name hint, which comes from the property name. This is a
+                    // last ditch save — NJSonSchema natively would call this "Anonymous."
+                    var identifier = $"UnknownType_{Guid.NewGuid().ToString().Replace("-", "").Substring(5)}";
+                    Console.WriteLine($"Encountered a schema with no Title property. This class will be called {identifier}. To fix this, add a Title to your schema.");
+                    return identifier;
+                }
                 return typeNameHint;
             }
             else
@@ -403,7 +412,14 @@ namespace Elements.Generate
             var typeFiles = new Dictionary<string, string>();
             // We still need this call to GenerateFile() even though we don't use the file's
             // text.  It is already a documented issue https://github.com/RicoSuter/NJsonSchema/issues/893
-            var file = generator.GenerateFile();
+            try
+            {
+                var file = generator.GenerateFile();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
             var typeArtifacts = generator.GenerateTypes();
 
             foreach (var fileArtifact in typeArtifacts)


### PR DESCRIPTION
BACKGROUND:
- https://github.com/hypar-io/Elements/issues/616

DESCRIPTION:
- Supplies a document path to the NJsonSchema code generator utilized by `generate-types`

TESTING:
- I utilized the test examples provided by @Gytaco and verified that the local reference to Vector2 was resolved and generated. `hypar generate-types -u `
  
FUTURE WORK:
- We'll need to release a CLI Alpha built against this version of elements for it to be useful 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/617)
<!-- Reviewable:end -->
