### PR TITLE
csg union flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Added `Symbols` property to `ContentElement`.
+- Introduce a `SkipCSGUnion` flag on Representation, as a hack to get around CSG failures.
 
 ## 0.9.2
 

--- a/Elements/src/GeometricElement.cs
+++ b/Elements/src/GeometricElement.cs
@@ -119,6 +119,23 @@ namespace Elements
             }
         }
 
+        internal Csg.Solid[] GetSolids(bool transformed = false)
+        {
+            var solids = Representation.SolidOperations.Where(op => op.IsVoid == false)
+                                                       .Select(op => TransformedSolidOperation(op))
+                                                       .ToArray();
+            if (Transform == null || transformed)
+            {
+                return solids;
+            }
+            else
+            {
+                var inverse = new Transform(Transform);
+                inverse.Invert();
+                return solids.Select(s => s.Transform(inverse.ToMatrix4x4())).ToArray();
+            }
+        }
+
         private Csg.Solid TransformedSolidOperation(Geometry.Solids.SolidOperation op)
         {
             if (Transform == null)

--- a/Elements/src/Geometry/Representation.cs
+++ b/Elements/src/Geometry/Representation.cs
@@ -23,5 +23,13 @@ namespace Elements.Geometry
         {
             return new Representation(solidOperation);
         }
+
+        /// <summary>
+        /// A flag to disable CSG operations on this representation. Instead,
+        /// all solids will be meshed, and all voids will be ignored.
+        /// </summary>
+        [Newtonsoft.Json.JsonIgnore]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public bool SkipCSGUnion { get; set; } = false;
     }
 }

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -1200,8 +1200,20 @@ namespace Elements.Serialization.glTF
                                       List<Vector3> lines,
                                       Transform t = null)
         {
-            var csg = geometricElement.GetFinalCsgFromSolids();
-            var buffers = csg.Tessellate();
+            GraphicsBuffers buffers = null;
+            if (geometricElement.Representation.SkipCSGUnion)
+            {
+                // There's a special flag on Representation that allows you to
+                // skip CSG unions. In this case, we tesselate all solids
+                // individually, and do no booleaning. Voids are also ignored.
+                var solids = geometricElement.GetSolids();
+                buffers = solids.Tesselate();
+            }
+            else
+            {
+                var csg = geometricElement.GetFinalCsgFromSolids();
+                buffers = csg.Tessellate();
+            }
 
             if (buffers.Vertices.Count == 0)
             {


### PR DESCRIPTION
BACKGROUND:
- A customer is having trouble with complex geometries rendering strangely in the UI, due to CSG failures.

DESCRIPTION:
- Adds a `SkipCSGUnion` flag to `Representation`, which is hidden from docs + not included in `Representation`'s serialized form.
- If present on a representation, its solids are meshed without being unioned, and its void forms are discarded.

TESTING:
- I created a function that utilized this flag w/ a local version of elements to verify it handled a large collection of "pixelated" geometry. https://dev.hypar.io/workflows/233c4148-ee66-4a5d-ac43-486907b9ff6b
  
FUTURE WORK:
- We should move towards an easier way for users to produce lightweight, mesh-based representations for situations like these.

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- This feels like a hack. We should move to remove this flag eventually if we can.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/623)
<!-- Reviewable:end -->
