### PR TITLE
Handle no symbols on content element

### DIFF
--- a/Elements.Serialization.DXF/src/ContentElementToDxf.cs
+++ b/Elements.Serialization.DXF/src/ContentElementToDxf.cs
@@ -62,7 +62,7 @@ namespace Elements.Serialization.DXF
             var drawingRangeTransform = context.DrawingRange?.Transform ?? new Transform();
             //TODO — pick an appropriate symbol based on the context orientation
 
-            var symbol = contentElement.Symbols.FirstOrDefault(s => s.CameraPosition == SymbolCameraPosition.Top);
+            var symbol = contentElement?.Symbols?.FirstOrDefault(s => s.CameraPosition == SymbolCameraPosition.Top);
             return symbol;
         }
     }


### PR DESCRIPTION
BACKGROUND:
- DXF export would fail if any content elements didn't have the new Symbols property

DESCRIPTION:
- Allows export to ignore content elements w/o symbols

FUTURE WORK:
- render *something*, like a bounding box, if a content element has no symbol.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/628)
<!-- Reviewable:end -->
