### PR TITLE
fix for dangle cleanup

### DIFF
--- a/Elements/src/Spatial/HalfEdgeGraph2d.cs
+++ b/Elements/src/Spatial/HalfEdgeGraph2d.cs
@@ -179,21 +179,17 @@ namespace Elements.Spatial
             var vertices = this.Vertices;
             var newPolygons = new List<Polygon>();
 
-            var actions = new List<(string actionName, object segment)>();
-
             // construct polygons from half edge graph.
             // remove edges from edgesPerVertex as they get "consumed" by a polygon,
             // and stop when you run out of edges. 
             // Guranteed to terminate because every loop step removes at least 1 edge, and
             // edges are never added.
-            actions.Add(("starting", null));
             while (edgesPerVertex.Any(l => l.Count > 0))
             {
                 var currentEdgeList = new List<(int from, int to, int? tag)>();
                 // pick a starting point
                 var startingSet = edgesPerVertex.First(l => l.Count > 0);
                 var currentSegment = startingSet[0];
-                actions.Add(("picked a first segment", currentSegment));
                 startingSet.RemoveAt(0);
                 var initialFrom = currentSegment.from;
 
@@ -221,7 +217,6 @@ namespace Elements.Spatial
 
                     possibleNextSegments.Remove(nextSegment);
                     currentSegment = nextSegment;
-                    actions.Add(("selected next segment", currentSegment));
                 }
                 currentEdgeList.Add(currentSegment);
                 var currentVertexList = new List<Vector3>();
@@ -283,7 +278,6 @@ namespace Elements.Spatial
                     newPolygons.Add(new Polygon(currentVertexList));
                 }
             }
-            Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(actions));
             return newPolygons;
         }
     }


### PR DESCRIPTION
BACKGROUND:
- @ikeough identified a case in which the polygonizer would produce an incorrect polygon.

DESCRIPTION:
- Corrects a case in the section of the Polygonizer which is responsible for cleaning up "tails" of duplicate edges. 
This code was designed to cover this case: 
![image](https://user-images.githubusercontent.com/31935763/126576726-2cb13047-887f-40a6-8e65-4612f82da73a.png)

However, in the case that the pair of edges (0,9) being removed straddled the end of the edge list, the code would successfully remove those two edges (0, 9) and then decrement `i` in order to find the next potential pair of edges to remove. However, since it started with i=9, it would decrement to 8, and bypass the remainder of the "paired" edges. In this case we now decrement a second time, to make sure we're still addressing the correct pair of edges. 
![image](https://user-images.githubusercontent.com/31935763/126577160-fbc6f482-2bc6-4f83-8897-e84971ba7606.png)

TESTING:
- A new test is added, and all existing tests pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/632)
<!-- Reviewable:end -->
