### PR TITLE
Set Operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - Support for DXF from many basic elements.
 - `SetClassification`
-- `SetOperationsClassifySegments2d(Polygon a, Polygon b, Func<(Vector3 from, Vector3 to, SetClassification classification), bool> filter = null)`
+- `SetOperations.ClassifySegments2d(Polygon a, Polygon b, Func<(Vector3 from, Vector3 to, SetClassification classification), bool> filter = null)`
+- `SetOperations.BuildGraph(List<(Vector3 from, Vector3 to, SetClassification classification)> set, SetClassification shared)`
 - `RandomExtensions.NextRayInPlane(this Random random, Vector3 origin, Vector3 normal)`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 
 - Support for DXF from many basic elements.
+- `SetClassification`
+- `SetOperationsClassifySegments2d(Polygon a, Polygon b, Func<(Vector3 from, Vector3 to, SetClassification classification), bool> filter = null)`
+- `RandomExtensions.NextRayInPlane(this Random random, Vector3 origin, Vector3 normal)`
 
 ### Changed
 

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -255,6 +255,38 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Intersect this polygon with the provided polygon in 2d.
+        /// </summary>
+        /// <param name="polygon">The target polygon.</param>
+        /// <param name="results">The points resulting from the intersection of
+        /// the two polygons.</param>
+        /// <param name="includeEnds">Should intersection with segment ends be included?</param>
+        /// <returns>True if this polygon intersects the provided polygon,
+        /// otherwise false.</returns>
+        internal bool Intersects2d(Polygon polygon,
+                                   out List<(Vector3 result, int aSegmentIndices, int bSegmentIndices)> results,
+                                   bool includeEnds = false)
+        {
+            var aSegs = this.Segments();
+            results = new List<(Vector3, int, int)>();
+
+            for (var i = 0; i < aSegs.Length; i++)
+            {
+                var a = aSegs[i];
+                var bSegs = polygon.Segments();
+                for (var j = 0; j < bSegs.Length; j++)
+                {
+                    var b = bSegs[j];
+                    if (a.Intersects(b, out Vector3 result, includeEnds: includeEnds))
+                    {
+                        results.Add((result, i, j));
+                    }
+                }
+            }
+            return results.Count > 0;
+        }
+
+        /// <summary>
         /// Intersect this polygon with the provided polygon in 3d.
         /// Unlike other methods that do 2d intersection, this method is able to 
         /// calculate intersections in 3d by doing planar intersections and

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -796,6 +796,11 @@ namespace Elements.Geometry
             Split(points);
         }
 
+        /// <summary>
+        /// Split a polyline at the provided points, by inserting new vertices.
+        /// </summary>
+        /// <param name="points">The points at which to split.</param>
+        /// <param name="closed">Should the polyline be considered closed?</param>
         protected void Split(IList<Vector3> points, bool closed = false)
         {
             for (var i = 0; i < this.Vertices.Count; i++)

--- a/Elements/src/Geometry/Ray.cs
+++ b/Elements/src/Geometry/Ray.cs
@@ -314,17 +314,31 @@ namespace Elements.Geometry
         /// <returns>True if the rays intersect, otherwise false.</returns>
         public bool Intersects(Line line, out Vector3 result)
         {
-            var otherRay = new Ray(line.Start, line.Direction());
+            return Intersects(line.Start, line.End, out result);
+        }
+
+        /// <summary>
+        /// Does this ray intersect a line segment defined by start and end?
+        /// </summary>
+        /// <param name="start">The start of the line segment.</param>
+        /// <param name="end">The end of the line segment.</param>
+        /// <param name="result">The location of the intersection.</param>
+        /// <returns>True if the ray intersects, otherwise false.</returns>
+        public bool Intersects(Vector3 start, Vector3 end, out Vector3 result)
+        {
+            var d = (end - start).Unitized();
+            var l = start.DistanceTo(end);
+            var otherRay = new Ray(start, d);
             if (Intersects(otherRay, out Vector3 rayResult))
             {
                 // Quick out if the result is exactly at the 
                 // start or the end of the line.
-                if (rayResult.IsAlmostEqualTo(line.Start) || rayResult.IsAlmostEqualTo(line.End))
+                if (rayResult.IsAlmostEqualTo(start) || rayResult.IsAlmostEqualTo(end))
                 {
                     result = rayResult;
                     return true;
                 }
-                else if ((rayResult - line.Start).Length() > line.Length())
+                else if ((rayResult - start).Length() > l)
                 {
                     result = default(Vector3);
                     return false;

--- a/Elements/src/RandomExtensions.cs
+++ b/Elements/src/RandomExtensions.cs
@@ -27,6 +27,22 @@ namespace Elements
             var color = random.NextColor();
             return new Material(color.ToString(), color, 0.1, 0.3, null, unlit, true);
         }
+
+        /// <summary>
+        /// Generate a 
+        /// </summary>
+        /// <param name="random"></param>
+        /// <param name="origin">The origin of the ray.</param>
+        /// <param name="normal">The normal of the plane in which the
+        /// resulting ray will lie.</param>
+        /// <returns>A ray pointing in a random direction, along
+        /// the plane.</returns>
+        public static Ray NextRayInPlane(this Random random, Vector3 origin, Vector3 normal)
+        {
+            var v1 = new Vector3(random.NextDouble(), random.NextDouble(), random.NextDouble()).Unitized();
+            var d = v1.Cross(normal);
+            return new Ray(origin, d);
+        }
     }
 
 }

--- a/Elements/src/SetOperations.cs
+++ b/Elements/src/SetOperations.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using Elements.Geometry;
+using Elements.Spatial;
+
+namespace Elements
+{
+    /// <summary>
+    /// A set containment classification.
+    /// </summary>
+    public enum SetClassification
+    {
+        AInsideB, AOutsideB, BInsideA, BOutsideA
+    }
+
+    /// <summary>
+    /// Operations on sets of edges.
+    /// </summary>
+    public static class SetOperations
+    {
+        /// <summary>
+        /// Classify a segment against a polygon by shooting a random
+        /// ray in the plane and counting the intersections.
+        /// </summary>
+        public static List<(Vector3 from, Vector3 to, SetClassification classification)> ClassifySegments2d(Polygon a, Polygon b, Func<(Vector3 from, Vector3 to, SetClassification classification), bool> filter = null)
+        {
+            var ap = a.Plane();
+            var bp = b.Plane();
+            if (!ap.IsCoplanar(bp))
+            {
+                throw new System.Exception("Set classification failed. The polygons are not coplanar.");
+            }
+
+            var r = new System.Random();
+            var classifications = new List<(Vector3 from, Vector3 Topography, SetClassification classification)>();
+
+            ClassifySet(ap, r, a, b, Elements.SetClassification.AInsideB, Elements.SetClassification.AOutsideB, classifications, filter);
+            ClassifySet(ap, r, b, a, Elements.SetClassification.BInsideA, Elements.SetClassification.BOutsideA, classifications, filter);
+
+            return classifications;
+        }
+
+        private static void ClassifySet(Plane p,
+                                        System.Random r,
+                                        Polygon a,
+                                        Polygon b,
+                                        SetClassification insideClassification,
+                                        SetClassification outsideClassification,
+                                        List<(Vector3 from, Vector3 to, SetClassification classification)> classifications,
+                                        Func<(Vector3 from, Vector3 to, SetClassification classification), bool> filter)
+        {
+            // A tests
+            for (var i = 0; i < a.Vertices.Count; i++)
+            {
+                var intersections = 0;
+                var v1 = a.Vertices[i];
+                var v2 = i == a.Vertices.Count - 1 ? a.Vertices[0] : a.Vertices[i + 1];
+                var ray = r.NextRayInPlane(v1.Average(v2), p.Normal);
+
+                // B tests
+                for (var j = 0; j < b.Vertices.Count; j++)
+                {
+                    var v3 = b.Vertices[j];
+                    var v4 = j == b.Vertices.Count - 1 ? b.Vertices[0] : b.Vertices[j + 1];
+                    if (ray.Intersects(v3, v4, out _))
+                    {
+                        intersections++;
+                    }
+                }
+                if (intersections % 2 == 0)
+                {
+                    var edge = (v1, v2, outsideClassification);
+                    if (filter != null)
+                    {
+                        if (filter(edge))
+                        {
+                            classifications.Add(edge);
+                        }
+                    }
+                    else
+                    {
+                        classifications.Add(edge);
+                    }
+                }
+                else
+                {
+                    var edge = (v1, v2, insideClassification);
+                    if (filter != null)
+                    {
+                        if (filter(edge))
+                        {
+                            classifications.Add(edge);
+                        }
+                    }
+                    else
+                    {
+                        classifications.Add(edge);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Build a half edge graph from a collection of segments.
+        /// </summary>
+        /// <param name="set">A collection of classified segments.</param>
+        /// <param name="shared">The classification of shared segments.</param>
+        /// <returns></returns>
+        public static HalfEdgeGraph2d BuildGraph(List<(Vector3 from, Vector3 to, SetClassification classification)> set,
+                                                 SetClassification shared)
+        {
+            var vertices = new List<Vector3>();
+            var epv = new List<List<(int from, int to, int? tag)>>();
+
+            // Fill vertex collection
+            foreach (var edge in set)
+            {
+                if (!vertices.Contains(edge.from))
+                {
+                    vertices.Add(edge.from);
+                    epv.Add(new List<(int from, int to, int? tag)>());
+                }
+
+                if (!vertices.Contains(edge.to))
+                {
+                    vertices.Add(edge.to);
+                    epv.Add(new List<(int from, int to, int? tag)>());
+                }
+            }
+
+            // Create edges
+            foreach (var edge in set)
+            {
+                var l = epv[vertices.IndexOf(edge.from)];
+                l.Add((vertices.IndexOf(edge.from), vertices.IndexOf(edge.to), null));
+
+                if (edge.classification == shared)
+                {
+                    var l1 = epv[vertices.IndexOf(edge.to)];
+                    l1.Add((vertices.IndexOf(edge.to), vertices.IndexOf(edge.from), null));
+                }
+            }
+
+            var heg = new HalfEdgeGraph2d()
+            {
+                Vertices = vertices,
+                EdgesPerVertex = epv
+            };
+
+            return heg;
+        }
+    }
+}

--- a/Elements/src/SetOperations.cs
+++ b/Elements/src/SetOperations.cs
@@ -10,7 +10,22 @@ namespace Elements
     /// </summary>
     public enum SetClassification
     {
-        AInsideB, AOutsideB, BInsideA, BOutsideA
+        /// <summary>
+        /// A segments inside B.
+        /// </summary>
+        AInsideB,
+        /// <summary>
+        /// A segments outside B.
+        /// </summary>
+        AOutsideB,
+        /// <summary>
+        /// B segments inside A.
+        /// </summary>
+        BInsideA,
+        /// <summary>
+        /// B segments outside A.
+        /// </summary>
+        BOutsideA
     }
 
     /// <summary>

--- a/Elements/test/SetOperationsTests.cs
+++ b/Elements/test/SetOperationsTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Linq;
+using Elements.Geometry;
+using Xunit;
+
+namespace Elements.Tests
+{
+    public class SetOperationsTests
+    {
+        [Fact]
+        public void OverlappingSets()
+        {
+            var a = Polygon.Rectangle(5, 5);
+            var b = Polygon.Rectangle(5, 5).TransformedPolygon(new Transform((2.5, 2.5)));
+
+            if (a.Intersects2d(b, out List<(Vector3 result, int, int)> results))
+            {
+                var locations = results.Select(r => r.result).ToList();
+                a.Split(locations);
+                b.Split(locations);
+            }
+
+            Assert.Equal(6, a.Vertices.Count);
+            Assert.Equal(6, b.Vertices.Count);
+
+            var set = SetOperations.ClassifySegments2d(a, b);
+
+            Assert.Equal(4, set.Where(c => c.classification == SetClassification.AOutsideB).Count());
+            Assert.Equal(4, set.Where(c => c.classification == SetClassification.BOutsideA).Count());
+            Assert.Equal(2, set.Where(c => c.classification == SetClassification.AInsideB).Count());
+            Assert.Equal(2, set.Where(c => c.classification == SetClassification.BInsideA).Count());
+        }
+
+        [Fact]
+        public void DisjointSets()
+        {
+            var a = Polygon.Rectangle(5, 5);
+            var b = Polygon.Rectangle(5, 5).TransformedPolygon(new Transform((10, 10)));
+
+            var set = SetOperations.ClassifySegments2d(a, b);
+
+            Assert.Equal(4, set.Where(c => c.classification == SetClassification.AOutsideB).Count());
+            Assert.Equal(4, set.Where(c => c.classification == SetClassification.BOutsideA).Count());
+
+            Assert.Equal(0, set.Where(c => c.classification == SetClassification.AInsideB).Count());
+            Assert.Equal(0, set.Where(c => c.classification == SetClassification.BInsideA).Count());
+        }
+
+        [Fact]
+        public void TouchingSets()
+        {
+            var a = Polygon.Rectangle(5, 5);
+            var b = Polygon.Rectangle(5, 5).TransformedPolygon(new Transform((5, 5)));
+
+            var set = SetOperations.ClassifySegments2d(a, b);
+
+            Assert.Equal(4, set.Where(c => c.classification == SetClassification.AOutsideB).Count());
+            Assert.Equal(4, set.Where(c => c.classification == SetClassification.BOutsideA).Count());
+
+            Assert.Equal(0, set.Where(c => c.classification == SetClassification.AInsideB).Count());
+            Assert.Equal(0, set.Where(c => c.classification == SetClassification.BInsideA).Count());
+        }
+
+        [Fact]
+        public void AdjacentSets()
+        {
+            var a = Polygon.Rectangle(5, 5);
+            var b = Polygon.Rectangle(5, 2.5).TransformedPolygon(new Transform((5, 5)));
+
+            var set = SetOperations.ClassifySegments2d(a, b);
+
+            Assert.Equal(4, set.Where(c => c.classification == SetClassification.AOutsideB).Count());
+            Assert.Equal(4, set.Where(c => c.classification == SetClassification.BOutsideA).Count());
+
+            Assert.Equal(0, set.Where(c => c.classification == SetClassification.AInsideB).Count());
+            Assert.Equal(0, set.Where(c => c.classification == SetClassification.BInsideA).Count());
+        }
+
+        [Fact]
+        public void OverlappingSetsFilterAndGraphCorrectly()
+        {
+            var a = Polygon.Rectangle(5, 5);
+            var b = Polygon.Rectangle(5, 5).TransformedPolygon(new Transform((2.5, 2.5)));
+
+            if (a.Intersects2d(b, out List<(Vector3 result, int, int)> results))
+            {
+                var locations = results.Select(r => r.result).ToList();
+                a.Split(locations);
+                b.Split(locations);
+            }
+            var set = SetOperations.ClassifySegments2d(a, b, ((Vector3, Vector3, SetClassification classification) e) =>
+            {
+                return e.classification == SetClassification.AOutsideB || e.classification == SetClassification.BInsideA || e.classification == SetClassification.AInsideB;
+            });
+
+            Assert.Equal(0, set.Where(c => c.classification == SetClassification.BOutsideA).Count());
+
+            var graph = SetOperations.BuildGraph(set, SetClassification.BInsideA);
+
+            Assert.Equal(7, graph.Vertices.Count);
+
+            var polys = graph.Polygonize();
+
+            Assert.Equal(2, polys.Count);
+        }
+
+    }
+}


### PR DESCRIPTION
BACKGROUND:
When working with sets of edges we would like a way to classify them according to their set inclusion. An example of this is the processing of two overlapping bounded spaces like a polygon or a brep face.

DESCRIPTION:
- Introduces set classifications and a couple of exemplary methods for working on polygon splitting. 
- Several helper methods to aid in random planar ray casting are added to classify linear segments. 
- A method for building a `HalfEdgeGraph2d` from a classified set is added.

TESTING:
A small set of tests has been included in `SetOperationsTests` that demonstrates the use of these new APIs.
  
FUTURE WORK:
Currently this work assumes `Vector3` and `Polygon` types. They should be made generic so that they can support line segments, solid face edges, or cell complex edges. 

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/633)
<!-- Reviewable:end -->
