### PR TITLE
Fix equality comparison of floating point numbers in Line.Thicken method

### DIFF
--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -109,7 +109,7 @@ namespace Elements.Geometry
         /// <param name="amount">The amount to thicken the line.</param>
         public Polygon Thicken(double amount)
         {
-            if (Start.Z != End.Z)
+            if (!Start.Z.ApproximatelyEquals(End.Z))
             {
                 throw new Exception("The line could not be thickened. Only lines with their start and end at the same elevation can be thickened.");
             }


### PR DESCRIPTION
BACKGROUND:
- The `Line.Thicken` method did not work for lines where the z-values of the start and end points are almost equal (for example, 0 and 1.7763568394002505E-15)

DESCRIPTION:
- What does this PR specifically accomplish?

TESTING:
- How should a reviewer observe the behavior desired by this pull request?

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/635)
<!-- Reviewable:end -->
