### PR TITLE
Add an overload for Line.ExtendTo with a parameter for the maximum di…

### DIFF
--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -466,6 +466,21 @@ namespace Elements.Geometry
         /// <param name="tolerance">Optional — The amount of tolerance to include in the extension method.</param>
         public Line ExtendTo(IEnumerable<Line> otherLines, bool bothSides = true, bool extendToFurthest = false, double tolerance = Vector3.EPSILON)
         {
+            return ExtendTo(otherLines, double.MaxValue, bothSides, extendToFurthest, tolerance);
+        }
+
+        /// <summary>
+        /// Extend this line to its (nearest, by default) intersection with any other line, but no further than maxDistance.
+        /// If optional `extendToFurthest` is true, extends to furthest intersection with any other line, but no further than maxDistance.
+        /// If the distance to the intersection with the lines is greater than the maximum, the line will be returned unchanged.
+        /// </summary>
+        /// <param name="otherLines">The other lines to intersect with.</param>
+        /// <param name="maxDistance">Maximum extension distance.</param>
+        /// <param name="bothSides">Optional — if false, will only extend in the line's direction; if true will extend in both directions.</param>
+        /// <param name="extendToFurthest">Optional — if true, will extend line as far as it will go, rather than stopping at the closest intersection.</param>
+        /// <param name="tolerance">Optional — The amount of tolerance to include in the extension method.</param>
+        public Line ExtendTo(IEnumerable<Line> otherLines, double maxDistance, bool bothSides = true, bool extendToFurthest = false, double tolerance = Vector3.EPSILON)
+        {
             // this test line — inset slightly from the line — helps treat the ends as valid intersection points, to prevent
             // extension beyond an immediate intersection.
             var testLine = new Line(this.PointAt(0.001), this.PointAt(0.999));
@@ -520,8 +535,8 @@ namespace Elements.Geometry
                 .Reverse().Cast<Vector3?>();
 
             (Vector3? Start, Vector3? End) startEndCandidates = extendToFurthest ?
-                (startCandidates.LastOrDefault(), endCandidates.LastOrDefault()) :
-                (startCandidates.FirstOrDefault(), endCandidates.FirstOrDefault());
+                (startCandidates.LastOrDefault(p => p.GetValueOrDefault().DistanceTo(start) < maxDistance), endCandidates.LastOrDefault(p => p.GetValueOrDefault().DistanceTo(end) < maxDistance)) :
+                (startCandidates.FirstOrDefault(p => p.GetValueOrDefault().DistanceTo(start) < maxDistance), endCandidates.FirstOrDefault(p => p.GetValueOrDefault().DistanceTo(end) < maxDistance));
 
             if (bothSides && startEndCandidates.Start != null)
             {
@@ -547,6 +562,18 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Extend this line to its (nearest, by default) intersection with a polyline, but no further than maxDistance.
+        /// </summary>
+        /// <param name="polyline">The polyline to intersect with</param>
+        /// <param name="maxDistance">Maximum extension distance.</param>
+        /// <param name="bothSides">Optional — if false, will only extend in the line's direction; if true will extend in both directions.</param>
+        /// <param name="extendToFurthest">Optional — if true, will extend line as far as it will go, rather than stopping at the closest intersection.</param>
+        public Line ExtendTo(Polyline polyline, double maxDistance, bool bothSides = true, bool extendToFurthest = false)
+        {
+            return ExtendTo(polyline.Segments(), maxDistance, bothSides, extendToFurthest);
+        }
+
+        /// <summary>
         /// Extend this line to its (nearest, by default) intersection with a profile.
         /// </summary>
         /// <param name="profile">The profile to intersect with</param>
@@ -555,6 +582,18 @@ namespace Elements.Geometry
         public Line ExtendTo(Profile profile, bool bothSides = true, bool extendToFurthest = false)
         {
             return ExtendTo(profile.Segments(), bothSides, extendToFurthest);
+        }
+
+        /// <summary>
+        /// Extend this line to its (nearest, by default) intersection with a profile, but no further than maxDistance.
+        /// </summary>
+        /// <param name="profile">The profile to intersect with</param>
+        /// <param name="maxDistance">Maximum extension distance.</param>
+        /// <param name="bothSides">Optional — if false, will only extend in the line's direction; if true will extend in both directions.</param>
+        /// <param name="extendToFurthest">Optional — if true, will extend line as far as it will go, rather than stopping at the closest intersection.</param>
+        public Line ExtendTo(Profile profile, double maxDistance, bool bothSides = true, bool extendToFurthest = false)
+        {
+            return ExtendTo(profile.Segments(), maxDistance, bothSides, extendToFurthest);
         }
 
         /// <summary>
@@ -567,6 +606,19 @@ namespace Elements.Geometry
         public Line ExtendTo(Polygon polygon, bool bothSides = true, bool extendToFurthest = false, double tolerance = Vector3.EPSILON)
         {
             return ExtendTo(polygon.Segments(), bothSides, extendToFurthest, tolerance);
+        }
+
+        /// <summary>
+        /// Extend this line to its (nearest, by default) intersection with a polygon, but no further than maxDistance.
+        /// </summary>
+        /// <param name="polygon">The polygon to intersect with</param>
+        /// <param name="maxDistance">Maximum extension distance.</param>
+        /// <param name="bothSides">Optional — if false, will only extend in the line's direction; if true will extend in both directions.</param>
+        /// <param name="extendToFurthest">Optional — if true, will extend line as far as it will go, rather than stopping at the closest intersection.</param>
+        /// <param name="tolerance">Optional — The amount of tolerance to include in the extension method.</param>
+        public Line ExtendTo(Polygon polygon, double maxDistance, bool bothSides = true, bool extendToFurthest = false, double tolerance = Vector3.EPSILON)
+        {
+            return ExtendTo(polygon.Segments(), maxDistance, bothSides, extendToFurthest, tolerance);
         }
 
         /// <summary>

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -334,5 +334,45 @@ namespace Elements.Geometry.Tests
             Assert.Equal(line.Start.X, noIntersection.Start.X);
             Assert.Equal(line.End.X, noIntersection.End.X);
         }
+
+        [Fact]
+        public void ExtendWithMultipleIntersectionsAndMaxDistance()
+        {
+            Name = "ExtendWithMultipleIntersectionsAndMaxDistance";
+            var line = new Line(new Vector3(0, 0), new Vector3(1, 0));
+
+            var vertices = new List<Vector3>()
+                {
+                    new Vector3(-1, -1),
+                    new Vector3(2, -1),
+                    new Vector3(2, 1),
+                    new Vector3(3, 1),
+                    new Vector3(3, -1),
+                    new Vector3(4, -1),
+                    new Vector3(4, 2),
+                    new Vector3(-1, 2)
+                };
+
+            var polygon = new Polygon(vertices);
+
+            // Extends in both directions, and stops at earliest intersection.
+            var defaultExtend = line.ExtendTo(polygon, 10);
+
+            Assert.Equal(-1, defaultExtend.Start.X);
+            Assert.Equal(2, defaultExtend.End.X);
+
+            // Extends in both directions, and stops at earliest intersection.
+            // The distance from line points to polygon segments is greater than maxDistance, so the line must remain unchanged.
+            var extendWithMaxDistance = line.ExtendTo(polygon, 0.5);
+
+            Assert.Equal(line.Start.X, extendWithMaxDistance.Start.X);
+            Assert.Equal(line.End.X, extendWithMaxDistance.End.X);
+
+            // Extend both sides to furthest intersection, but no further than maxDistance.
+            var furthestExtend = line.ExtendTo(polygon, 2.5, true, true);
+
+            Assert.Equal(-1, furthestExtend.Start.X);
+            Assert.Equal(3, furthestExtend.End.X);
+        }
     }
 }


### PR DESCRIPTION
…stance the line should try to extend

BACKGROUND:
- Adding a parameter to `Line.ExtendTo` method for the maximumDistance the line should try to extend, to help the case where we want to extend only if the lines are within some tolerance. 

DESCRIPTION:
- Add overloads for `Line.ExtendTo` method with a parameter for the maximum distance. If `extendToFurthest` line is extend to furthest intersection, but no further than maxDistance. If the distance to the intersection with the lines is greater than the maximum, the line will be returned unchanged.

TESTING:
- Added a new test to LineTests
  
REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/636)
<!-- Reviewable:end -->
