### PR TITLE
Geometry comparers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,18 @@
   - `Polygon.Difference(params Polygon[] polygons)`
   - `Polygon.Union(params Polygon[] polygons)`
 - `Profile.Offset()`
+- IEqualityComparer for line with corresponding tests.
+- IEqualityComparer for triangle with corresponding tests.
+- Line IsApproximatelyEqual and HashCode with optional tolerance.
+- Triangle IsApproximatelyEqual and HashCode with optional tolerance.
 
 ### Changed
 
 - Some changes to `ContentElement` instance glTF serialization to allow selectability and transformability in the Hypar UI.
 - Added `Symbols` property to `ContentElement`.
 - Introduce a `SkipCSGUnion` flag on Representation, as a hack to get around CSG failures.
+- Improve speed of Vector3 hashing, and allow specifying tolerance.
+- Make Vector3Comparer public
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,8 @@
-# Changelog
-
-## 0.9.3
-
-### Added
-
-- Support for DXF from many basic elements.
-
-### Changed
-
-- Added `Symbols` property to `ContentElement`.
-- Introduce a `SkipCSGUnion` flag on Representation, as a hack to get around CSG failures.
-
 ## 0.9.2
 
 ### Added
 
+- Support for DXF from many basic elements.
 - `Polyline.Split(List<Vector3> point)`
 - `Polygon.Split(List<Vector3> point)`
 - `Polygon.TrimmedTo(List<Polygon> polygons)`
@@ -41,6 +29,8 @@
 ### Changed
 
 - Some changes to `ContentElement` instance glTF serialization to allow selectability and transformability in the Hypar UI.
+- Added `Symbols` property to `ContentElement`.
+- Introduce a `SkipCSGUnion` flag on Representation, as a hack to get around CSG failures.
 
 ### Fixed
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -173,7 +173,7 @@ namespace Elements.Geometry
 
                 if (endValue < startValue)
                 {
-                    obj.Reversed();
+                    obj = obj.Reversed();
                 }
 
                 // If these values are equal then the sort will fail, so we sort the end points by X, then Y, then Z.
@@ -209,8 +209,10 @@ namespace Elements.Geometry
             unchecked
             {
                 int hash = 17;
-                hash = hash * 23 + obj.Start.Rounded(tolerance).GetHashCode();
-                hash = hash * 23 + obj.End.Rounded(tolerance).GetHashCode();
+                var s = obj.Start.GetHashCode(tolerance);
+                hash = hash * 23 + s;
+                var e = +obj.End.GetHashCode(tolerance);
+                hash = hash * 23 + e;
                 return hash;
             }
         }

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -773,6 +773,73 @@ namespace Elements.Geometry
             Descending
         }
         #endregion
+    }
 
+    /// <summary>
+    /// Geometric line comparer for use in HashSets and Dictionaries.
+    /// </summary>
+    public class LineComparer : IEqualityComparer<Line>
+    {
+        private double _precision = 5;
+        private bool _directionIndependent = true;
+
+        /// <summary>
+        /// Create a comparer setting wether this comparer cares about direction and also the precision.
+        /// </summary>
+        public LineComparer(bool directionIndependent = true, double precision = Vector3.EPSILON)
+        {
+            _precision = precision;
+            _directionIndependent = directionIndependent;
+        }
+
+        /// <summary>
+        /// Are the two lines equal according to the LineComparer settings.
+        /// </summary>
+        public bool Equals(Line x, Line y)
+        {
+            return (x.Start.IsAlmostEqualTo(y.Start, _precision) && x.End.IsAlmostEqualTo(y.End, _precision))
+                    || (_directionIndependent
+                        && (x.Start.IsAlmostEqualTo(y.End, _precision) && x.End.IsAlmostEqualTo(y.Start, _precision)));
+        }
+
+        /// <summary>
+        /// Retrieve a hashcode for this line that is consistent with the precision and direction dependance.
+        /// </summary>
+        public int GetHashCode(Line obj)
+        {
+            // If the direction doesn't matter, then we always sort the end points by X, then Y, then Z to have a consistent basis for forming the hash code.
+            if (_directionIndependent)
+            {
+                if (obj.Start.X != obj.End.X)
+                {
+                    if (obj.Start.X > obj.End.X)
+                    {
+                        obj = obj.Reversed();
+                    }
+                }
+                else if (obj.Start.Y != obj.End.Y)
+                {
+                    if (obj.Start.Y > obj.End.Y)
+                    {
+                        obj = obj.Reversed();
+                    }
+                }
+                else if (obj.Start.Z != obj.End.Z)
+                {
+                    if (obj.Start.Z > obj.End.Z)
+                    {
+                        obj = obj.Reversed();
+                    }
+                }
+                else
+                {
+                    throw new Exception("Invalid line, start and end are identical, cannot create hashcode");
+                }
+            }
+            int hash = 17;
+            hash = hash * 23 + obj.Start.Rounded(_precision).GetHashCode();
+            hash = hash * 23 + obj.End.Rounded(_precision).GetHashCode();
+            return hash;
+        }
     }
 }

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -139,10 +139,10 @@ namespace Elements.Geometry
         /// <summary>
         /// Are the two lines almost equal?
         /// </summary>
-        public bool IsAlmostEqualTo(Line other, bool directionIndependent, double tolerance = Vector3.EPSILON)
+        public bool IsAlmostEqualTo(Line other, bool directionDependent, double tolerance = Vector3.EPSILON)
         {
             return (Start.IsAlmostEqualTo(other.Start, tolerance) && End.IsAlmostEqualTo(other.End, tolerance))
-                    || (directionIndependent
+                    || (!directionDependent
                         && (Start.IsAlmostEqualTo(other.End, tolerance) && End.IsAlmostEqualTo(other.Start, tolerance)));
         }
 
@@ -151,17 +151,17 @@ namespace Elements.Geometry
         /// </summary>
         public override int GetHashCode()
         {
-            return GetHashCode(false);
+            return GetHashCode(true);
         }
 
         /// <summary>
         /// Get the hash code for the line allowing for geometric approximations.
         /// </summary>
-        public int GetHashCode(bool directionIndependent, double tolerance = Vector3.EPSILON)
+        public int GetHashCode(bool directionDependent, double tolerance = Vector3.EPSILON)
         {
             var obj = this;
             // If the direction doesn't matter, then we always sort the end points by X, then Y, then Z to have a consistent basis for forming the hash code.
-            if (directionIndependent)
+            if (!directionDependent)
             {
                 if (Start.X != End.X)
                 {
@@ -833,15 +833,15 @@ namespace Elements.Geometry
     public class LineComparer : IEqualityComparer<Line>
     {
         private double _tolerance = 5;
-        private bool _directionIndependent = true;
+        private bool _directionDependent = true;
 
         /// <summary>
         /// Construct a comparer setting wether the direction matters and optionally the tolerance.
         /// </summary>
-        public LineComparer(bool directionIndependent, double tolerance = Vector3.EPSILON)
+        public LineComparer(bool directionDependant, double tolerance = Vector3.EPSILON)
         {
             _tolerance = tolerance;
-            _directionIndependent = directionIndependent;
+            _directionDependent = directionDependant;
         }
 
         /// <summary>
@@ -849,7 +849,7 @@ namespace Elements.Geometry
         /// </summary>
         public bool Equals(Line a, Line b)
         {
-            return a.IsAlmostEqualTo(b, _directionIndependent, _tolerance);
+            return a.IsAlmostEqualTo(b, _directionDependent, _tolerance);
         }
 
         /// <summary>
@@ -857,7 +857,7 @@ namespace Elements.Geometry
         /// </summary>
         public int GetHashCode(Line line)
         {
-            return line.GetHashCode(_directionIndependent, _tolerance);
+            return line.GetHashCode(_directionDependent, _tolerance);
         }
     }
 }

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -796,6 +796,13 @@ namespace Elements.Geometry
             Split(points);
         }
 
+        /// <summary>
+        /// Insert a point into the polyline if it lies along one
+        /// of the polyline's segments with the option to keep the polyline closed.
+        /// </summary>
+        /// <param name="points">The points at which to split the polyline.</param>
+        /// <param name="closed">Should the polyline be closed</param>
+        /// <returns>The index of the new vertex.</returns>
         protected void Split(IList<Vector3> points, bool closed = false)
         {
             for (var i = 0; i < this.Vertices.Count; i++)

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -802,7 +802,6 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="points">The points at which to split the polyline.</param>
         /// <param name="closed">Should the polyline be closed</param>
-        /// <returns>The index of the new vertex.</returns>
         protected void Split(IList<Vector3> points, bool closed = false)
         {
             for (var i = 0; i < this.Vertices.Count; i++)

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -33,7 +33,7 @@ namespace Elements.Geometry
         /// </summary>
         public override int GetHashCode()
         {
-            return this.GetHashCode(EPSILON);
+            return GetHashCode(EPSILON);
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -42,7 +42,7 @@ namespace Elements.Geometry
         public int GetHashCode(double precision)
         {
             var alt = 17;
-            var rounded = new Vector3(Math.Round(X / precision) * precision, Math.Round(Y / precision) * precision, Math.Round(Z / precision) * precision);
+            var rounded = Rounded(precision);
             alt = alt * 23 + rounded.X.GetHashCode();
             alt = alt * 23 + rounded.Y.GetHashCode();
             alt = alt * 23 + rounded.Z.GetHashCode();
@@ -150,6 +150,14 @@ namespace Elements.Geometry
                 return this;
             }
             return new Vector3(X / length, Y / length, Z / length);
+        }
+
+        /// <summary>
+        /// Return the Vector3 with its values rounded to the default EPSILON or the provided precision.
+        /// </summary>
+        public Vector3 Rounded(double precision = EPSILON)
+        {
+            return new Vector3(Math.Round(X / precision) * precision, Math.Round(Y / precision) * precision, Math.Round(Z / precision) * precision);
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -33,7 +33,7 @@ namespace Elements.Geometry
         /// </summary>
         public override int GetHashCode()
         {
-            return GetHashCode(double.MinValue);
+            return GetHashCode(0);
         }
 
         /// <summary>
@@ -162,6 +162,10 @@ namespace Elements.Geometry
         /// </summary>
         public Vector3 Rounded(double precision = EPSILON)
         {
+            if (precision == 0)
+            {
+                return this;
+            }
             return new Vector3(Math.Round(X / precision) * precision, Math.Round(Y / precision) * precision, Math.Round(Z / precision) * precision);
         }
 

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -33,20 +33,25 @@ namespace Elements.Geometry
         /// </summary>
         public override int GetHashCode()
         {
-            return GetHashCode(EPSILON);
+            return GetHashCode(double.MinValue);
         }
 
         /// <summary>
         /// Get the hash code for this vector using precision based rounding.
+        /// This HashCode is strictly speaking an imperfect implementation and should be used
+        /// with caution.  It may occasionally create two different HashCodes for two Vector3s
+        /// that are actually within the precision's value.
         /// </summary>
         public int GetHashCode(double precision)
         {
-            var alt = 17;
-            var rounded = Rounded(precision);
-            alt = alt * 23 + rounded.X.GetHashCode();
-            alt = alt * 23 + rounded.Y.GetHashCode();
-            alt = alt * 23 + rounded.Z.GetHashCode();
-            return alt;
+            unchecked
+            {
+                var rounded = Rounded(precision);
+                var hash = 391 + rounded.X.GetHashCode();
+                hash = hash * 23 + rounded.Y.GetHashCode();
+                hash = hash * 23 + rounded.Z.GetHashCode();
+                return hash;
+            }
         }
 
         /// <summary>
@@ -1020,8 +1025,11 @@ namespace Elements.Geometry
     /// <summary>
     /// An equality comparer used for Dictionaries and HashSets.
     /// It uses geometric properties for equality, and allows you to specify the tolerance.
+    /// This comparer is strictly speaking an imperfect implementation of IEqualityComparer — and so should be used
+    /// with caution in collections and Linq methods. It may occasionally indicate that two Vector3 are distinct when
+    /// they are within the specified tolerance of each other.
     /// </summary>
-    public class Vector3Comparer : EqualityComparer<Vector3>
+    public class Vector3Comparer : IEqualityComparer<Vector3>
     {
         private double _precision = Vector3.EPSILON;
         /// <summary>
@@ -1035,7 +1043,7 @@ namespace Elements.Geometry
         /// <summary>
         /// Are the two Vector3 geometrically equal within the tolerance.
         /// </summary>
-        public override bool Equals(Vector3 x, Vector3 y)
+        public bool Equals(Vector3 x, Vector3 y)
         {
             return x.IsAlmostEqualTo(y, _precision);
         }
@@ -1043,7 +1051,7 @@ namespace Elements.Geometry
         /// <summary>
         /// Get a hashcode for the Vector3 object.
         /// </summary>
-        public override int GetHashCode(Vector3 vector)
+        public int GetHashCode(Vector3 vector)
         {
             return vector.GetHashCode();
         }

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -33,7 +33,20 @@ namespace Elements.Geometry
         /// </summary>
         public override int GetHashCode()
         {
-            return this.ToString().GetHashCode();
+            return this.GetHashCode(EPSILON);
+        }
+
+        /// <summary>
+        /// Get the hash code for this vector using precision based rounding.
+        /// </summary>
+        public int GetHashCode(double precision)
+        {
+            var alt = 17;
+            var rounded = new Vector3(Math.Round(X / precision) * precision, Math.Round(Y / precision) * precision, Math.Round(Z / precision) * precision);
+            alt = alt * 23 + rounded.X.GetHashCode();
+            alt = alt * 23 + rounded.Y.GetHashCode();
+            alt = alt * 23 + rounded.Z.GetHashCode();
+            return alt;
         }
 
         /// <summary>
@@ -996,16 +1009,35 @@ namespace Elements.Geometry
         }
     }
 
-    internal class Vector3Comparer : EqualityComparer<Vector3>
+    /// <summary>
+    /// An equality comparer used for Dictionaries and HashSets.
+    /// It uses geometric properties for equality, and allows you to specify the tolerance.
+    /// </summary>
+    public class Vector3Comparer : EqualityComparer<Vector3>
     {
-        public override bool Equals(Vector3 x, Vector3 y)
+        private double _precision = Vector3.EPSILON;
+        /// <summary>
+        /// Construct a Vector3Comparer, specify a tolerance if you want something other than the default Vector3 tolerance.
+        /// </summary>
+        public Vector3Comparer(double precision = Vector3.EPSILON)
         {
-            return x.IsAlmostEqualTo(y);
+            _precision = precision;
         }
 
-        public override int GetHashCode(Vector3 obj)
+        /// <summary>
+        /// Are the two Vector3 geometrically equal within the tolerance.
+        /// </summary>
+        public override bool Equals(Vector3 x, Vector3 y)
         {
-            return obj.GetHashCode();
+            return x.IsAlmostEqualTo(y, _precision);
+        }
+
+        /// <summary>
+        /// Get a hashcode for the Vector3 object.
+        /// </summary>
+        public override int GetHashCode(Vector3 vector)
+        {
+            return vector.GetHashCode();
         }
     }
 }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -41,10 +41,10 @@ namespace Elements.Geometry.Tests
             Assert.Equal(lineA, lineC);
             Assert.NotEqual(lineA, lineA.Reversed());
 
-            var standardComparer = new LineComparer(false);
-            Assert.NotEqual(lineA, lineB, standardComparer);
-            Assert.Equal(lineA, lineC, standardComparer);
-            Assert.Equal(lineA, lineA.Reversed(), standardComparer);
+            var comparer = new LineComparer(false);
+            Assert.NotEqual(lineA, lineB, comparer);
+            Assert.Equal(lineA, lineC, comparer);
+            Assert.Equal(lineA, lineA.Reversed(), comparer);
 
             var pickyComparer = new LineComparer(true, 1E-7);
             Assert.NotEqual(lineA, lineB, pickyComparer);
@@ -53,8 +53,8 @@ namespace Elements.Geometry.Tests
 
             // Check that a line will succeed in creating identical hashcode even if the two endpoints are equidistant from origin
             var lineD = new Line(new Vector3(1, 0, 0), new Vector3(0, 1, 0));
-            var h1 = standardComparer.GetHashCode(lineD);
-            var h2 = standardComparer.GetHashCode(lineD.Reversed());
+            var h1 = comparer.GetHashCode(lineD);
+            var h2 = comparer.GetHashCode(lineD.Reversed());
             Assert.Equal(h1, h2);
         }
 

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -28,9 +28,19 @@ namespace Elements.Geometry.Tests
 
             this.Model.AddElement(new ModelCurve(l));
         }
+        [Fact]
+        public void Equality_SlightlyOffCenter_Failing()
+        {
+            // Test when lines are almost centered around origin
+            var line1 = new Line((-1.001, -1.001), (1, 1));
+            var line2 = new Line((-0.999, -0.999), (1, 1));
+            var hash1 = line1.GetHashCode(false, 0.0001);
+            var hash2 = line2.GetHashCode(false, 0.0001);
+            Assert.Equal(hash1, hash2);
+        }
 
         [Fact]
-        public void Equality()
+        public void EqualityComparers()
         {
             var p = new Vector3(1, 1, 1);
             var lineA = new Line(Vector3.Origin, p);
@@ -51,7 +61,7 @@ namespace Elements.Geometry.Tests
             Assert.NotEqual(lineA, lineC, pickyComparer);
             Assert.NotEqual(lineA, lineA.Reversed(), pickyComparer);
 
-            // Test slightly off sorting for direction dependance.
+            // Test slightly off axis sorting for direction dependance.
             var line1 = new Line((0, 0), (-0.000001, 3));
             var line2 = new Line((0, 0), (0, 3));
             var hash1 = line1.GetHashCode(false, 0.0001);

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -53,6 +53,7 @@ namespace Elements.Geometry.Tests
 
             // Check that a line will succeed in creating identical hashcode even if the two endpoints are equidistant from origin
             var lineD = new Line(new Vector3(1, 0, 0), new Vector3(0, 1, 0));
+            Assert.Equal(lineD.Start.DistanceTo(Vector3.Origin), lineD.End.DistanceTo(Vector3.Origin));
             var h1 = comparer.GetHashCode(lineD);
             var h2 = comparer.GetHashCode(lineD.Reversed());
             Assert.Equal(h1, h2);

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -51,6 +51,13 @@ namespace Elements.Geometry.Tests
             Assert.NotEqual(lineA, lineC, pickyComparer);
             Assert.NotEqual(lineA, lineA.Reversed(), pickyComparer);
 
+            // Test slightly off sorting for direction dependance.
+            var line1 = new Line((0, 0), (-0.000001, 3));
+            var line2 = new Line((0, 0), (0, 3));
+            var hash1 = line1.GetHashCode(false, 0.0001);
+            var hash2 = line2.GetHashCode(false, 0.0001);
+            Assert.Equal(hash1, hash2);
+
             // Check that a line will succeed in creating identical hashcode even if the two endpoints are equidistant from origin
             var lineD = new Line(new Vector3(1, 0, 0), new Vector3(0, 1, 0));
             Assert.Equal(lineD.Start.DistanceTo(Vector3.Origin), lineD.End.DistanceTo(Vector3.Origin));

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -41,12 +41,12 @@ namespace Elements.Geometry.Tests
             Assert.Equal(lineA, lineC);
             Assert.NotEqual(lineA, lineA.Reversed());
 
-            var standardComparer = new LineComparer();
+            var standardComparer = new LineComparer(false);
             Assert.NotEqual(lineA, lineB, standardComparer);
             Assert.Equal(lineA, lineC, standardComparer);
             Assert.Equal(lineA, lineA.Reversed(), standardComparer);
 
-            var pickyComparer = new LineComparer(false, 1E-7);
+            var pickyComparer = new LineComparer(true, 1E-7);
             Assert.NotEqual(lineA, lineB, pickyComparer);
             Assert.NotEqual(lineA, lineC, pickyComparer);
             Assert.NotEqual(lineA, lineA.Reversed(), pickyComparer);

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -30,6 +30,35 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
+        public void Equality()
+        {
+            var p = new Vector3(1, 1, 1);
+            var lineA = new Line(Vector3.Origin, p);
+            var lineB = new Line(Vector3.Origin, p + new Vector3(1E-4, 1E-4, 1E-4));
+            var lineC = new Line(Vector3.Origin, p + new Vector3(1E-6, 1E-6, 1E-6));
+
+            Assert.NotEqual(lineA, lineB);
+            Assert.Equal(lineA, lineC);
+            Assert.NotEqual(lineA, lineA.Reversed());
+
+            var standardComparer = new LineComparer();
+            Assert.NotEqual(lineA, lineB, standardComparer);
+            Assert.Equal(lineA, lineC, standardComparer);
+            Assert.Equal(lineA, lineA.Reversed(), standardComparer);
+
+            var pickyComparer = new LineComparer(false, 1E-7);
+            Assert.NotEqual(lineA, lineB, pickyComparer);
+            Assert.NotEqual(lineA, lineC, pickyComparer);
+            Assert.NotEqual(lineA, lineA.Reversed(), pickyComparer);
+
+            // Check that a line will succeed in creating identical hashcode even if the two endpoints are equidistant from origin
+            var lineD = new Line(new Vector3(1, 0, 0), new Vector3(0, 1, 0));
+            var h1 = standardComparer.GetHashCode(lineD);
+            var h2 = standardComparer.GetHashCode(lineD.Reversed());
+            Assert.Equal(h1, h2);
+        }
+
+        [Fact]
         public void Construct()
         {
             var a = new Vector3();

--- a/Elements/test/TriangleTests.cs
+++ b/Elements/test/TriangleTests.cs
@@ -22,18 +22,18 @@ namespace Elements.Geometry.Tests
             var triangle = new Triangle(new[] { v0, v1, v2 }, Vector3.ZAxis);
             var triangleRotated = new Triangle(new[] { v1, v2, v0 }, Vector3.ZAxis);
 
-            var tASmallShift = new Triangle(new[] { v0, v1, v2BiggerShift }, Vector3.ZAxis);
-            var tATinyShift = new Triangle(new[] { v0, v1, v2SmallShift }, Vector3.ZAxis);
+            var triangleSmallShift = new Triangle(new[] { v0, v1, v2BiggerShift }, Vector3.ZAxis);
+            var triangleTinyShift = new Triangle(new[] { v0, v1, v2SmallShift }, Vector3.ZAxis);
 
             var comparer = new TriangleComparer(false);
             Assert.Equal(triangle, triangleRotated, comparer);
-            Assert.NotEqual(triangle, tASmallShift, comparer);
-            Assert.Equal(triangle, tATinyShift, comparer);
+            Assert.NotEqual(triangle, triangleSmallShift, comparer);
+            Assert.Equal(triangle, triangleTinyShift, comparer);
 
             var pickyComparer = new TriangleComparer(true, 1E-7);
             Assert.NotEqual(triangle, triangleRotated, pickyComparer);
-            Assert.NotEqual(triangle, tASmallShift);
-            Assert.NotEqual(triangle, tATinyShift);
+            Assert.NotEqual(triangle, triangleSmallShift);
+            Assert.NotEqual(triangle, triangleTinyShift);
 
             // Check that comparer can create identical hashcodes for vertices equidistant from origin.
             var v3 = new Vertex(new Vector3(-1, 1, 0));
@@ -45,6 +45,13 @@ namespace Elements.Geometry.Tests
             var h1 = comparer.GetHashCode(triangleSymmetric);
             var h2 = comparer.GetHashCode(triangleSymmetricFlipped);
             Assert.Equal(h1, h2);
+
+            // Check that comparer can create identical hashcodes for vertices where a line is slightly off axis.
+            var v2OffAxis = new Vertex(v2.Position + new Vector3(-1E-9, 0, 0), Vector3.ZAxis);
+            var triangleOffAxis = new Triangle(new[] { v1, v2OffAxis, v0 }, Vector3.ZAxis);
+            var h = comparer.GetHashCode(triangle);
+            var hOffAxis = comparer.GetHashCode(triangleOffAxis);
+            Assert.Equal(h, hOffAxis);
         }
     }
 }

--- a/Elements/test/TriangleTests.cs
+++ b/Elements/test/TriangleTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Elements.Tests;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Elements.Geometry.Tests
+{
+    public class TriangleTests
+    {
+        [Fact]
+        public void Equality()
+        {
+            var v0 = new Vertex(Vector3.Origin);
+            var v1 = new Vertex(new Vector3(1, 1, 0));
+            var v2 = new Vertex(new Vector3(0, 2, 0));
+            var v2SmallShift = new Vertex(v2.Position + new Vector3(0, 0, 1E-6));
+            var v2BiggerShift = new Vertex(v2.Position + new Vector3(0, 0, 1E-4));
+
+            var triangle = new Triangle(new[] { v0, v1, v2 }, Vector3.ZAxis);
+            var triangleRotated = new Triangle(new[] { v1, v2, v0 }, Vector3.ZAxis);
+
+            var tASmallShift = new Triangle(new[] { v0, v1, v2BiggerShift }, Vector3.ZAxis);
+            var tATinyShift = new Triangle(new[] { v0, v1, v2SmallShift }, Vector3.ZAxis);
+
+            var comparer = new TriangleComparer(false);
+            Assert.Equal(triangle, triangleRotated, comparer);
+            Assert.NotEqual(triangle, tASmallShift, comparer);
+            Assert.Equal(triangle, tATinyShift, comparer);
+
+            var pickyComparer = new TriangleComparer(true, 1E-7);
+            Assert.NotEqual(triangle, triangleRotated, pickyComparer);
+            Assert.NotEqual(triangle, tASmallShift);
+            Assert.NotEqual(triangle, tATinyShift);
+
+            // Check that comparer can create identical hashcodes for vertices equidistant from origin.
+            var v3 = new Vertex(new Vector3(-1, 1, 0));
+            var triangleSymmetric = new Triangle(new[] { v0, v1, v3 }, Vector3.ZAxis);
+            var triangleSymmetricFlipped = new Triangle(new[] { v0, v3, v1 }, Vector3.ZAxis);
+            Assert.Equal(triangleSymmetric.Vertices[1].Position.DistanceTo(Vector3.Origin), triangleSymmetric.Vertices[2].Position.DistanceTo(Vector3.Origin));
+            Assert.Equal(triangleSymmetricFlipped.Vertices[1].Position.DistanceTo(Vector3.Origin), triangleSymmetricFlipped.Vertices[2].Position.DistanceTo(Vector3.Origin));
+
+            var h1 = comparer.GetHashCode(triangleSymmetric);
+            var h2 = comparer.GetHashCode(triangleSymmetricFlipped);
+            Assert.Equal(h1, h2);
+        }
+    }
+}

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -169,6 +169,16 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void Equality()
+        {
+            var nearOrigin = new Vector3(1E-6, 1E-6, 1E-6);
+            Assert.Equal(nearOrigin, Vector3.Origin);
+
+            Assert.Equal(nearOrigin.GetHashCode(), Vector3.Origin.GetHashCode());
+            Assert.NotEqual(nearOrigin.GetHashCode(1E-10), Vector3.Origin.GetHashCode(1E-10));
+        }
+
+        [Fact]
         public void AreCoplanar()
         {
             var a = Vector3.Origin;


### PR DESCRIPTION
BACKGROUND:
- When working with some geometry I wanted to check if vectors, lines and triangles were contained in some hashsets quickly based on their geometric features.

DESCRIPTION:
- Add IEqualityComparer to line with corresponding tests.
- Add IEqualityComparaer to triangle with corresponding tests.
- Add line IsApproximatelyEqual and HashCode with optional tolerance.
- Add triangle IsApproximatelyEqual and HashCode with optional tolerance.
- Improve speed of Vector3 hashing, and allow specifying tolerance.
- Make Vector3Comparer public
- Add comment to split method on polyline
- Remove 0.9.3 from changelog, we're still working on 0.9.2

TESTING:
- How should a reviewer observe the behavior desired by this pull request?
  
FUTURE WORK:
- don't think so

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/637)
<!-- Reviewable:end -->
