### PR TITLE
Accelerate Polygon.Contains(Vector3) by iterating directly over vertices

### DIFF
--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -776,55 +776,5 @@ namespace Elements.Geometry
         {
             return new[] { this.Start, this.End };
         }
-
-        #region WindingNumberCalcs
-        internal Position RelativePositionOf(Vector3 location)
-        {
-            double positionCalculation =
-                (End.Y - Start.Y) * (location.X - Start.X) -
-                (location.Y - Start.Y) * (End.X - Start.X);
-
-            if (positionCalculation > 0)
-            {
-                return Position.Left;
-            }
-
-            if (positionCalculation < 0)
-            {
-                return Position.Right;
-            }
-
-            return Position.Center;
-        }
-
-        internal bool AscendingRelativeTo(Vector3 location)
-        {
-            return Start.X <= location.X;
-        }
-
-        internal bool LocationInRange(Vector3 location, Orientation orientation)
-        {
-            if (orientation == Orientation.Ascending)
-            {
-                return End.X > location.X;
-            }
-
-            return End.X <= location.X;
-        }
-
-        internal enum Position
-        {
-            Left,
-            Right,
-            Center
-        }
-
-        internal enum Orientation
-        {
-            Ascending,
-            Descending
-        }
-        #endregion
-
     }
 }

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -96,7 +96,7 @@ namespace Elements.Geometry
         /// <returns>Returns true if the supplied Vector3 is within this polygon.</returns>
         public bool Contains(Vector3 vector, out Containment containment)
         {
-            return Contains3D(Segments(), vector, out containment);
+            return Contains3D(Edges(), vector, out containment);
         }
 
         /// <summary>
@@ -379,18 +379,18 @@ namespace Elements.Geometry
         }
 
         // Projects non-flat containment request into XY plane and returns the answer for this projection
-        internal static bool Contains3D(IEnumerable<Line> segments, Vector3 location, out Containment containment)
+        internal static bool Contains3D(IEnumerable<(Vector3 from, Vector3 to)> edges, Vector3 location, out Containment containment)
         {
-            var vertices = segments.Select(segment => segment.Start).ToList();
+            var vertices = edges.Select(edge => edge.from).ToList();
             var is3D = vertices.Any(vertex => vertex.Z != 0);
             if (!is3D)
             {
-                return Contains(segments, location, out containment);
+                return Contains(edges, location, out containment);
             }
             var transformTo3D = vertices.ToTransform();
             var transformToGround = new Transform(transformTo3D);
             transformToGround.Invert();
-            var groundSegments = segments.Select(segment => segment.TransformedLine(transformToGround));
+            var groundSegments = edges.Select(edge => (transformToGround.OfPoint(edge.from), transformToGround.OfPoint(edge.to)));
             var groundLocation = transformToGround.OfPoint(location);
             return Contains(groundSegments, groundLocation, out containment);
         }
@@ -444,20 +444,20 @@ namespace Elements.Geometry
         }
 
         // Adapted from https://stackoverflow.com/questions/46144205/point-in-polygon-using-winding-number/46144206
-        internal static bool Contains(IEnumerable<Line> segments, Vector3 location, out Containment containment)
+        internal static bool Contains(IEnumerable<(Vector3 from, Vector3 to)> edges, Vector3 location, out Containment containment)
         {
             int windingNumber = 0;
 
-            foreach (var edge in segments)
+            foreach (var edge in edges)
             {
                 // check for coincidence with edge vertices
-                var toStart = location - edge.Start;
+                var toStart = location - edge.from;
                 if (toStart.IsZero())
                 {
                     containment = Containment.CoincidesAtVertex;
                     return true;
                 }
-                var toEnd = location - edge.End;
+                var toEnd = location - edge.to;
                 if (toEnd.IsZero())
                 {
                     containment = Containment.CoincidesAtVertex;
@@ -465,7 +465,7 @@ namespace Elements.Geometry
                 }
                 //along segment - check if perpendicular distance to segment is below tolerance and that point is between ends
                 var a = toStart.Length();
-                var b = toStart.Dot((edge.End - edge.Start).Unitized());
+                var b = toStart.Dot((edge.to - edge.from).Unitized());
                 if (a * a - b * b < Vector3.EPSILON * Vector3.EPSILON && toStart.Dot(toEnd) < 0)
                 {
                     containment = Containment.CoincidesAtEdge;
@@ -473,15 +473,15 @@ namespace Elements.Geometry
                 }
 
 
-                if (edge.AscendingRelativeTo(location) &&
-                    edge.LocationInRange(location, Line.Orientation.Ascending))
+                if (AscendingRelativeTo(location, edge) &&
+                    LocationInRange(location, Orientation.Ascending, edge))
                 {
-                    windingNumber += Wind(location, edge, Line.Position.Left);
+                    windingNumber += Wind(location, edge, Position.Left);
                 }
-                if (!edge.AscendingRelativeTo(location) &&
-                    edge.LocationInRange(location, Line.Orientation.Descending))
+                if (!AscendingRelativeTo(location, edge) &&
+                    LocationInRange(location, Orientation.Descending, edge))
                 {
-                    windingNumber -= Wind(location, edge, Line.Position.Right);
+                    windingNumber -= Wind(location, edge, Position.Right);
                 }
             }
 
@@ -490,10 +490,59 @@ namespace Elements.Geometry
             return result;
         }
 
-        private static int Wind(Vector3 location, Line edge, Line.Position position)
+        #region WindingNumberCalcs
+        private static int Wind(Vector3 location, (Vector3 from, Vector3 to) edge, Position position)
         {
-            return edge.RelativePositionOf(location) != position ? 0 : 1;
+            return RelativePositionOnEdge(location, edge) != position ? 0 : 1;
         }
+
+        private static Position RelativePositionOnEdge(Vector3 location, (Vector3 from, Vector3 to) edge)
+        {
+            double positionCalculation =
+                (edge.to.Y - edge.from.Y) * (location.X - edge.from.X) -
+                (location.Y - edge.from.Y) * (edge.to.X - edge.from.X);
+
+            if (positionCalculation > 0)
+            {
+                return Position.Left;
+            }
+
+            if (positionCalculation < 0)
+            {
+                return Position.Right;
+            }
+
+            return Position.Center;
+        }
+
+        private static bool AscendingRelativeTo(Vector3 location, (Vector3 from, Vector3 to) edge)
+        {
+            return edge.from.X <= location.X;
+        }
+
+        private static bool LocationInRange(Vector3 location, Orientation orientation, (Vector3 from, Vector3 to) edge)
+        {
+            if (orientation == Orientation.Ascending)
+            {
+                return edge.to.X > location.X;
+            }
+
+            return edge.to.X <= location.X;
+        }
+
+        private enum Position
+        {
+            Left,
+            Right,
+            Center
+        }
+
+        private enum Orientation
+        {
+            Ascending,
+            Descending
+        }
+        #endregion
 
 
         /// <summary>
@@ -1678,6 +1727,17 @@ namespace Elements.Geometry
             }
             segmentIndex = this.Vertices.Count - 1;
             return this.End;
+        }
+
+        // TODO: Investigate converting Polyline to IEnumerable<(Vector3, Vector3)>
+        internal IEnumerable<(Vector3 from, Vector3 to)> Edges()
+        {
+            for (var i = 0; i < this.Vertices.Count; i++)
+            {
+                var from = this.Vertices[i];
+                var to = i == this.Vertices.Count - 1 ? this.Vertices[0] : this.Vertices[i + 1];
+                yield return (from, to);
+            }
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Profile.cs
+++ b/Elements/src/Geometry/Profile.cs
@@ -317,12 +317,12 @@ namespace Elements.Geometry
         /// <returns>True if the point is within the profile.</returns>
         public bool Contains(Vector3 point, out Containment containment)
         {
-            IEnumerable<Line> allLines = Perimeter.Segments();
+            IEnumerable<(Vector3 from, Vector3 to)> allEdges = Perimeter.Edges();
             if (Voids != null)
             {
-                allLines = allLines.Union(Voids.SelectMany(v => v.Segments()));
+                allEdges = allEdges.Union(Voids.SelectMany(v => v.Edges()));
             }
-            return Polygon.Contains(allLines, point, out containment);
+            return Polygon.Contains(allEdges, point, out containment);
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Ray.cs
+++ b/Elements/src/Geometry/Ray.cs
@@ -165,12 +165,12 @@ namespace Elements.Geometry
                 var transformFromPolygon = new Transform(transformToPolygon);
                 transformFromPolygon.Invert();
                 var transformedIntersection = transformFromPolygon.OfPoint(intersection);
-                IEnumerable<Line> curveList = boundaryPolygon.Segments();
+                IEnumerable<(Vector3 from, Vector3 to)> curveList = boundaryPolygon.Edges();
                 if (voids != null)
                 {
-                    curveList = curveList.Union(voids.SelectMany(v => v.Segments()));
+                    curveList = curveList.Union(voids.SelectMany(v => v.Edges()));
                 }
-                curveList = curveList.Select(l => l.TransformedLine(transformFromPolygon));
+                curveList = curveList.Select(l => (transformFromPolygon.OfPoint(l.from), transformFromPolygon.OfPoint(l.to)));
 
                 if (Polygon.Contains(curveList, transformedIntersection, out _))
                 {
@@ -197,8 +197,8 @@ namespace Elements.Geometry
                 var transformFromPolygon = new Transform(transformToPolygon);
                 transformFromPolygon.Invert();
                 var transformedIntersection = transformFromPolygon.OfPoint(intersection);
-                IEnumerable<Line> curveList = polygon.Segments();
-                curveList = curveList.Select(l => l.TransformedLine(transformFromPolygon));
+                IEnumerable<(Vector3 from, Vector3 to)> curveList = polygon.Edges();
+                curveList = curveList.Select(l => (transformFromPolygon.OfPoint(l.from), transformFromPolygon.OfPoint(l.to)));
 
                 if (Polygon.Contains(curveList, transformedIntersection, out _))
                 {


### PR DESCRIPTION
BACKGROUND:
A function is using Polygon.Contains in a tight loop across many vertices. The Segments() call in Contains represents a significant portion of total runtime (~40%). 

DESCRIPTION:
This updates Contains to use the new Edges() method from Ian's draft PR #638. This has roughly the same performance as moving the Segments() call outside the inner loop.

TESTING:
This method has existing unit test coverage, which still pass. I also linked these changes into the function we've been optimizing and found 30-50% improvement to relevant code.

FUTURE WORK:
- More code can be updated to use Edges, some of which is already updated in Ian's #638.

REQUIRED:
- [N/A] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/642)
<!-- Reviewable:end -->
