### PR TITLE
use tryGetValue becuase it exists in older version of Newtonsoft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `ModelArrows`
 - `ModelText`
 ### Changed
+- Use `TryGetValue` on JObject during model serialization istead of `Contains`
 
 ### Fixed
 - Deduplicate catalog names during code generation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - `ModelArrows`
 - `ModelText`
 ### Changed
-- Use `TryGetValue` on JObject during model serialization istead of `Contains`
 
 ### Fixed
 - Deduplicate catalog names during code generation.

--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -147,7 +147,7 @@ namespace Elements.Serialization.JSON
                 else
                 {
                     var jObject = Newtonsoft.Json.Linq.JObject.FromObject(value, serializer);
-                    if (jObject.ContainsKey(_discriminator))
+                    if (jObject.TryGetValue(_discriminator, out _))
                     {
                         jObject[_discriminator] = value.GetType().FullName;
                     }


### PR DESCRIPTION
BACKGROUND:
- while working in Revit we ran into an issue where Newtonsoft 9.* is loaded, and it does not have a method we use during model serialization.

DESCRIPTION:
- Switch to using `TryGetValue` which should do basically the same thing, but appears to be available in older version, and thus works in Revit 2020.

TESTING:
- behavior is unchanged.
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/644)
<!-- Reviewable:end -->
