### PR TITLE
Add Transform.Inverse()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@
 
 - `ModelArrows`
 - `ModelText`
+- `Transform.Inverse()`
+
 ### Changed
 
 ### Fixed
+
 - Deduplicate catalog names during code generation.
 
 ## 0.9.2
@@ -43,7 +46,6 @@
   - `Line.ExtendTo(Polygon)`
   - `Line.ExtendTo(Profile)`
 - Support for DXF from many basic elements.
-
 
 ### Changed
 

--- a/Elements/src/Geometry/Transform.cs
+++ b/Elements/src/Geometry/Transform.cs
@@ -308,6 +308,14 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Return a new transform which is the inverse of this transform.
+        /// </summary>
+        public Transform Inverse()
+        {
+            return new Transform(this.Matrix.Inverse());
+        }
+
+        /// <summary>
         /// Apply a translation to the transform.
         /// </summary>
         /// <param name="translation">The translation to apply.</param>

--- a/Elements/test/TransformTests.cs
+++ b/Elements/test/TransformTests.cs
@@ -65,7 +65,7 @@ namespace Elements.Tests
         {
             var o = new Vector3(1, 1, 0);
             var t = new Transform(o, Vector3.XAxis, Vector3.YAxis.Negate());
-            var p = new Plane( new Vector3(0.5, 0.5, 0.0), new Vector3(0, 0, 1) );
+            var p = new Plane(new Vector3(0.5, 0.5, 0.0), new Vector3(0, 0, 1));
             var pt = t.OfPlane(p);
             Assert.Equal(1.5, pt.Origin.X);
             Assert.Equal(1.0, pt.Origin.Y);
@@ -89,6 +89,20 @@ namespace Elements.Tests
             inverted.Invert();
 
             Assert.Equal(transform, inverted);
+        }
+
+        [Fact]
+        public void Transform_Inverse()
+        {
+            var polygon = Polygon.Rectangle(3, 5);
+            var transform = new Transform((4, 3), 72);
+            var pgonTransformed = polygon.TransformedPolygon(transform);
+            var pgonTransformedBack = pgonTransformed.TransformedPolygon(transform.Inverse());
+            for (int i = 0; i < pgonTransformedBack.Vertices.Count; i++)
+            {
+                var vertex = pgonTransformedBack.Vertices[i];
+                Assert.True(vertex.IsAlmostEqualTo(polygon.Vertices[i]));
+            }
         }
 
 


### PR DESCRIPTION
BACKGROUND:
- For a great many of our fluent-ish APIs, we supply both `.verb()` (e.g. `Move()`) methods to modify a thing in place, and `.participle-adjective()` (e.g. `Moved()`) to return a new version of the thing with a change applied. Transform had `.Invert()` but not `.Inverse()`.
DESCRIPTION:
- Adds `Transform.Inverse()`

TESTING:
- Added a `Transform_Inverse` test to `TransformTests`.

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/646)
<!-- Reviewable:end -->
