### PR TITLE
inverse => inverted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - `ModelText`
 - `Solid.Intersects(Plane p, out List<Polygon> result)`
 - `Vector3.IsUnitized()`
-- `Transform.Inverse()`
+- `Transform.Inverted()`
 
 ### Changed
 

--- a/Elements/src/Geometry/Matrix.cs
+++ b/Elements/src/Geometry/Matrix.cs
@@ -437,7 +437,7 @@ namespace Elements.Geometry
         /// <summary>
         /// Compute the inverse of the matrix.
         /// </summary>
-        public Matrix Inverse()
+        public Matrix Inverted()
         {
             var det = Determinant();
             if (Math.Abs(det) < 0.000001)
@@ -465,6 +465,15 @@ namespace Elements.Geometry
             m.tz = -(tx * m.m13 + ty * m.m23 + tz * m.m33);
 
             return m;
+        }
+
+        /// <summary>
+        /// Compute the inverse of the matrix.
+        /// </summary>
+        [Obsolete("Use Matrix.Inverted() instead.")]
+        public Matrix Inverse()
+        {
+            return Inverted();
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Transform.cs
+++ b/Elements/src/Geometry/Transform.cs
@@ -304,15 +304,15 @@ namespace Elements.Geometry
         /// </summary>
         public void Invert()
         {
-            this.Matrix = this.Matrix.Inverse();
+            this.Matrix = this.Matrix.Inverted();
         }
 
         /// <summary>
         /// Return a new transform which is the inverse of this transform.
         /// </summary>
-        public Transform Inverse()
+        public Transform Inverted()
         {
-            return new Transform(this.Matrix.Inverse());
+            return new Transform(this.Matrix.Inverted());
         }
 
         /// <summary>

--- a/Elements/test/TransformTests.cs
+++ b/Elements/test/TransformTests.cs
@@ -92,12 +92,12 @@ namespace Elements.Tests
         }
 
         [Fact]
-        public void Transform_Inverse()
+        public void Transform_Inverted()
         {
             var polygon = Polygon.Rectangle(3, 5);
             var transform = new Transform((4, 3), 72);
             var pgonTransformed = polygon.TransformedPolygon(transform);
-            var pgonTransformedBack = pgonTransformed.TransformedPolygon(transform.Inverse());
+            var pgonTransformedBack = pgonTransformed.TransformedPolygon(transform.Inverted());
             for (int i = 0; i < pgonTransformedBack.Vertices.Count; i++)
             {
                 var vertex = pgonTransformedBack.Vertices[i];


### PR DESCRIPTION
BACKGROUND:
- Consensus was that "Inverted" was more consistent than "Inverse"
- We also wanted to rename Matrix.Inverse to Matrix.Inverted (by obsoleting .Inverse)
REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/648)
<!-- Reviewable:end -->
