### PR TITLE
Add tolerance to Vector3.Unitized

### DIFF
--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -129,10 +129,11 @@ namespace Elements.Geometry
         /// <summary>
         /// Return a new vector which is the unitized version of this vector.
         /// </summary>
-        public Vector3 Unitized()
+        /// <param name="tolerance">The amount of tolerance in the zero length comparison.</param>
+        public Vector3 Unitized(double tolerance = Vector3.EPSILON)
         {
             var length = Length();
-            if (length == 0)
+            if (length.ApproximatelyEquals(0, tolerance))
             {
                 return this;
             }
@@ -1039,7 +1040,7 @@ namespace Elements.Geometry
                 normal.Y += (p0.Z - p1.Z) * (p0.X + p1.X);
                 normal.Z += (p0.X - p1.X) * (p0.Y + p1.Y);
             }
-            return normal.Unitized();
+            return normal.Unitized(0);
         }
     }
 

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -401,6 +401,25 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void CollinearWithCoincidentPoints()
+        {
+            Vector3 p0 = new Vector3(13.770340049720485, 2.8262770874797756);
+            Vector3 p1 = new Vector3(14.68227083781888, -2.387949898514293);
+            Vector3 p2 = new Vector3(14.682270837818884, -2.3879498985142926);
+            Vector3 p3 = new Vector3(11.069392253545676, 18.26972418936262);
+
+            Vector3 p4 = new Vector3(0, 0);
+            Vector3 p5 = new Vector3(1, 0);
+            Vector3 p6 = new Vector3(1, 0.000000000001);
+            Vector3 p7 = new Vector3(2, 0);
+
+            Assert.True(p1.IsAlmostEqualTo(p2));
+            Assert.True(new[] { p0, p1, p2, p3 }.AreCollinear());
+            Assert.True(p5.IsAlmostEqualTo(p6));
+            Assert.True(new[] { p4, p5, p6, p7 }.AreCollinear());
+        }
+
+        [Fact]
         public void TupleSyntax()
         {
             // Integer Tuples + params constructor


### PR DESCRIPTION
BACKGROUND:
- `Vector3Extensions.AreCollinear` didn't work for coincident points. 
- A vector with almost zero values will still be unitized

DESCRIPTION:
- Add tolerance to Vector3.Unitized

TESTING:
- Added a new test, which used to fail, and now succeeds

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/650)
<!-- Reviewable:end -->
