### PR TITLE
Fix GLB Vertex normals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Deduplicate catalog names during code generation.
+- Fixed an issue where GLTFs would occasionally be generated with incorrect vertex normals.
 
 ## 0.9.2
 

--- a/Elements/src/Geometry/CsgExtensions.cs
+++ b/Elements/src/Geometry/CsgExtensions.cs
@@ -58,16 +58,16 @@ namespace Elements.Geometry
                 {
                     var vertexIndices = new ushort[p.Vertices.Count];
 
-                    var a = p.Vertices[0].Pos.ToElementsVector();
-                    var b = p.Vertices[1].Pos.ToElementsVector();
-                    var c = p.Vertices[2].Pos.ToElementsVector();
-                    basis = ComputeBasisAndNormalForTriangle(a, b, c, out Vector3 normal);
-
                     // Anything with 3 vertices is a triangle. Manually 
                     // tesselate triangles. For everything else, use 
                     // the tessellator.
-                    if (p.Vertices.Count > 2 && p.Vertices.Count <= 3)
+                    if (p.Vertices.Count == 3)
                     {
+                        var a = p.Vertices[0].Pos.ToElementsVector();
+                        var b = p.Vertices[1].Pos.ToElementsVector();
+                        var c = p.Vertices[2].Pos.ToElementsVector();
+                        basis = ComputeBasisAndNormalForTriangle(a, b, c, out Vector3 normal);
+
                         for (var i = 0; i < p.Vertices.Count; i++)
                         {
                             var v = p.Vertices[i];
@@ -107,6 +107,14 @@ namespace Elements.Geometry
                         {
                             continue;
                         }
+                        // We pick the first triangle from the tesselator,
+                        // instead of the first three vertices, which are not guaranteed to be
+                        // wound correctly.
+                        var a = tess.Vertices[tess.Elements[0]].ToElementsVector();
+                        var b = tess.Vertices[tess.Elements[1]].ToElementsVector();
+                        var c = tess.Vertices[tess.Elements[2]].ToElementsVector();
+
+                        basis = ComputeBasisAndNormalForTriangle(a, b, c, out Vector3 normal);
 
                         for (var i = 0; i < tess.Vertices.Length; i++)
                         {
@@ -387,6 +395,11 @@ namespace Elements.Geometry
         private static Csg.Vector3D ToCsgVector3(this ContourVertex v)
         {
             return new Csg.Vector3D(v.Position.X, v.Position.Y, v.Position.Z);
+        }
+
+        private static Vector3 ToElementsVector(this ContourVertex v)
+        {
+            return new Vector3(v.Position.X, v.Position.Y, v.Position.Z);
         }
 
         private static ContourVertex[] ToContourVertices(this List<Csg.Vertex> vertices)

--- a/Elements/src/Geometry/CsgExtensions.cs
+++ b/Elements/src/Geometry/CsgExtensions.cs
@@ -27,17 +27,27 @@ namespace Elements.Geometry
         /// </summary>
         internal static GraphicsBuffers Tessellate(this Csg.Solid csg)
         {
-            return Tesselate(new[] { csg });
+            return Tessellate(new[] { csg });
         }
 
         /// <summary>
         /// Triangulate a collection of CSGs and pack the triangulated data into
         /// buffers appropriate for use with gltf. 
         /// </summary>
-        internal static GraphicsBuffers Tesselate(this Csg.Solid[] csgs)
+        internal static GraphicsBuffers Tessellate(this Csg.Solid[] csgs)
         {
             var buffers = new GraphicsBuffers();
 
+            Tessellate(csgs, buffers);
+            return buffers;
+        }
+
+        /// <summary>
+        /// Triangulate a collection of CSGs and pack the triangulated data into
+        /// a supplied buffers object. 
+        /// </summary>
+        internal static void Tessellate(Csg.Solid[] csgs, IGraphicsBuffers buffers)
+        {
             ushort iCursor = 0;
 
             (Vector3 U, Vector3 V) basis;
@@ -59,7 +69,7 @@ namespace Elements.Geometry
                     var vertexIndices = new ushort[p.Vertices.Count];
 
                     // Anything with 3 vertices is a triangle. Manually 
-                    // tesselate triangles. For everything else, use 
+                    // tessellate triangles. For everything else, use 
                     // the tessellator.
                     if (p.Vertices.Count == 3)
                     {
@@ -146,7 +156,6 @@ namespace Elements.Geometry
                     }
                 }
             }
-            return buffers;
         }
 
         private static (Vector3 U, Vector3 V) ComputeBasisAndNormalForTriangle(Vector3 a, Vector3 b, Vector3 c, out Vector3 n)
@@ -304,7 +313,7 @@ namespace Elements.Geometry
 
             if (p.Vertices.Count == 3)
             {
-                // Don't tesselate unless we need to.
+                // Don't tessellate unless we need to.
 
                 var a = p.Vertices[0];
                 var b = p.Vertices[1];
@@ -321,7 +330,7 @@ namespace Elements.Geometry
             }
             else if (p.Vertices.Count == 4)
             {
-                // Don't tesselate unless we need to.
+                // Don't tessellate unless we need to.
 
                 var a = p.Vertices[0];
                 var b = p.Vertices[1];

--- a/Elements/src/Geometry/GraphicsBuffers.cs
+++ b/Elements/src/Geometry/GraphicsBuffers.cs
@@ -1,13 +1,36 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Elements.Geometry
 {
     /// <summary>
+    /// A generic container for graphics data. This is broken out primarily to facilitate
+    /// simpler testing of graphics buffers.
+    /// </summary>
+    internal interface IGraphicsBuffers
+    {
+        /// <summary>
+        /// Add a vertex to the graphics buffers.
+        /// </summary>
+        /// <param name="position">The position of the vertex.</param>
+        /// <param name="normal">The normal of the vertex.</param>
+        /// <param name="uv">The UV of the vertex.</param>
+        /// <param name="color">The vertex color.</param>
+        void AddVertex(Vector3 position, Vector3 normal, UV uv, Color? color = null);
+
+        /// <summary>
+        /// Add an index to the graphics buffers.
+        /// </summary>
+        /// <param name="index">The index to add.</param>
+        void AddIndex(ushort index);
+    }
+
+    /// <summary>
     /// A container for graphics data.
     /// The buffers used in this class align with webgl requirements.
     /// </summary>
-    public class GraphicsBuffers
+    public class GraphicsBuffers : IGraphicsBuffers
     {
         /// <summary>
         /// A collection of vertex positions stored as sequential bytes.

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -1247,10 +1247,10 @@ namespace Elements.Serialization.glTF
             if (geometricElement.Representation.SkipCSGUnion)
             {
                 // There's a special flag on Representation that allows you to
-                // skip CSG unions. In this case, we tesselate all solids
+                // skip CSG unions. In this case, we tessellate all solids
                 // individually, and do no booleaning. Voids are also ignored.
                 var solids = geometricElement.GetSolids();
-                buffers = solids.Tesselate();
+                buffers = solids.Tessellate();
             }
             else
             {

--- a/Elements/test/CsgTests.cs
+++ b/Elements/test/CsgTests.cs
@@ -5,6 +5,7 @@ using Elements.Geometry.Solids;
 using System;
 using Xunit;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace Elements.Tests
 {
@@ -78,7 +79,8 @@ namespace Elements.Tests
         public void TessellatorProducesCorrectVertexNormals()
         {
             Name = nameof(TessellatorProducesCorrectVertexNormals);
-            var shape = new Polygon((-1, 0.5), (0, 0.5), (0, 0), (1, 0), (1, 1), (0, 1));
+            var shape = new Polygon((4.96243, 50.58403), (5.78472, 50.58403), (5.78472, 65.83403), (-7.05727, 65.83403), (-7.05727, 50.57403), (4.96243, 50.57403));
+
             var geoElem = new GeometricElement(representation: new Extrude(shape, 1, Vector3.ZAxis, false));
             Model.AddElement(geoElem);
             var solid = geoElem.GetFinalCsgFromSolids();


### PR DESCRIPTION
BACKGROUND:
- Some shapes were showing up inexplicably dark in the viewport, despite having been consistently constructed. 
![image](https://user-images.githubusercontent.com/31935763/129985505-3ade6397-1695-4fef-85fc-ffa3d7b8232b.png)
- This was because certain meshes had incorrect vertex normals, as verified in a GLTF debugger:
![image](https://user-images.githubusercontent.com/31935763/129985891-8a2b6167-5211-4134-921e-8635e4848522.png) 
- This was due to an invalid assumption in the code: that a normal calculated from the first three vertices of a polygon would necessarily be the correct normal for that face. In fact, if the polygon face was non-convex, and the first three vertices fell within a concave portion, then the "triangle" we were using to calculate the normal would be wound clockwise relative to the polygon it came from. 
![image](https://user-images.githubusercontent.com/31935763/129985618-9d2a86c5-5a52-4b31-a510-1df076d9478f.png)

DESCRIPTION:
- Switches to using a tessellated triangle as the basis for the normal, which is guaranteed to lie within the CSG face polygon and be correctly wound.

TESTING:
- I verified that a glb generated after this fix has its normals correctly oriented, and all volumes are shaded consistently. 
![image](https://user-images.githubusercontent.com/31935763/129985977-14aff42c-f5dd-477b-aaa8-e8a6b8d19a14.png)
 
REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/652)
<!-- Reviewable:end -->
