### PR TITLE
version retrieval accoring to semver (ignoreing v*)

### DIFF
--- a/.github/workflows/build-and-publish-alpha.yml
+++ b/.github/workflows/build-and-publish-alpha.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get previous tag.
         id: version
         run: |
-          lastTag=`git tag -l --sort=-creatordate --format='%(refname:short)' | head -n 1`
+          lastTag=`git tag -l '[!v]*' --sort=-version:refname' | head -n 1`
           echo "::set-output name=tag::$lastTag"
       - name: Bump if alpha.
         id: bump-with-alpha


### PR DESCRIPTION
I've found a more reliable way of retrieving the latest version tag as long as we keep doing semver.  Had to exclude 'v' prefix since we don't use that lately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/653)
<!-- Reviewable:end -->
