### PR TITLE
GlTF export performance improvements

### DIFF
--- a/Elements.Benchmarks/Elements.Benchmarks.csproj
+++ b/Elements.Benchmarks/Elements.Benchmarks.csproj
@@ -10,6 +10,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="Csg">
+      <HintPath>../Elements/lib/Csg.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
   </ItemGroup>
 

--- a/Elements.Benchmarks/Program.cs
+++ b/Elements.Benchmarks/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
@@ -10,22 +9,23 @@ using Elements.Serialization.glTF;
 
 namespace Elements.Benchmarks
 {
+    [MemoryDiagnoser]
     [SimpleJob(launchCount: 1, warmupCount: 1, targetCount: 3)]
-    public class Csg
+    public class CsgBenchmarks
     {
         private WideFlangeProfileFactory _profileFactory = new WideFlangeProfileFactory();
+        private Beam _beam;
+        private Csg.Solid _csg;
 
-        [Params(1, 10, 20)]
-        public int Samples { get; set; }
+        [Params(1, 10, 20, 50)]
+        public int NumberOfHoles { get; set; }
 
-        [Benchmark(Description = "Compute csg of beam.")]
-        public void CSG()
+        public CsgBenchmarks()
         {
-            var profile = _profileFactory.GetProfileByType(WideFlangeProfileType.W10x100);
-
             var line = new Line(new Vector3(0, 0, 0), new Vector3(10, 0, 5));
-            var beam = new Beam(line, profile, BuiltInMaterials.Steel);
-            for (var i = 0.0; i <= 1.0; i += 1.0 / (double)Samples)
+            var profile = Polygon.Rectangle(Units.InchesToMeters(10), Units.InchesToMeters(20));
+            _beam = new Beam(line, profile, BuiltInMaterials.Steel);
+            for (var i = 0.0; i <= 1.0; i += 1.0 / (double)NumberOfHoles)
             {
                 var t = line.TransformAt(i);
                 var lt = new Transform(t.Origin, t.ZAxis, t.XAxis.Negate());
@@ -34,11 +34,15 @@ namespace Elements.Benchmarks
                 {
                     LocalTransform = lt
                 };
-                beam.Representation.SolidOperations.Add(hole);
+                _beam.Representation.SolidOperations.Add(hole);
             }
-            var model = new Model();
-            model.AddElement(beam);
-            GltfExtensions.InitializeGlTF(model, out var buffers, false);
+            _csg = _beam.GetFinalCsgFromSolids();
+        }
+
+        [Benchmark(Description = "Tesselate CSG.")]
+        public void CsgToGraphicsBuffers()
+        {
+            _csg.Tessellate();
         }
     }
 
@@ -46,22 +50,21 @@ namespace Elements.Benchmarks
     [SimpleJob(launchCount: 1, warmupCount: 3, targetCount: 10)]
     public class HSS
     {
-        [Benchmark(Description = "Create all HSS beams.")]
-        public void CreateAllHSSBeams()
+        Model _model;
+
+        public HSS()
         {
             var x = 0.0;
             var z = 0.0;
             var hssFactory = new HSSPipeProfileFactory();
             var profiles = hssFactory.AllProfiles().ToList();
-            var model = new Model();
+            _model = new Model();
             foreach (var profile in profiles)
             {
                 var color = new Color((float)(x / 20.0), (float)(z / profiles.Count), 0.0f, 1.0f);
                 var line = new Line(new Vector3(x, 0, z), new Vector3(x, 3, z));
-                var m = new Material(Guid.NewGuid().ToString(), color, 0.1f, 0.4f);
-                model.AddElement(m, false);
-                var beam = new Beam(line, profile, m);
-                model.AddElement(beam, false);
+                var beam = new Beam(line, profile);
+                _model.AddElement(beam);
                 x += 2.0;
                 if (x > 20.0)
                 {
@@ -69,7 +72,18 @@ namespace Elements.Benchmarks
                     x = 0.0;
                 }
             }
-            model.ToGlTF();
+        }
+
+        [Benchmark(Description = "Draw all beams without merge.")]
+        public void DrawAllBeamsWithoutMerge()
+        {
+            _model.ToGlTF(false, false);
+        }
+
+        [Benchmark(Description = "Draw all beams with merge.")]
+        public void DrawAllBeamsWithMerge()
+        {
+            _model.ToGlTF(false, true);
         }
     }
 
@@ -77,7 +91,8 @@ namespace Elements.Benchmarks
     {
         public static void Main(string[] args)
         {
-            var summary = BenchmarkRunner.Run<HSS>();
+            BenchmarkRunner.Run<HSS>();
+            BenchmarkRunner.Run<CsgBenchmarks>();
         }
     }
 }

--- a/Elements/src/Geometry/CsgExtensions.cs
+++ b/Elements/src/Geometry/CsgExtensions.cs
@@ -71,15 +71,11 @@ namespace Elements.Geometry
                             var v = p.Vertices[i];
                             var uu = basis.U.Dot(v.Pos.X, v.Pos.Y, v.Pos.Z);
                             var vv = basis.V.Dot(v.Pos.X, v.Pos.Y, v.Pos.Z);
-                            vertexIndices[i] = (ushort)GetOrCreateVertex(v.Pos.X,
-                                                                         v.Pos.Y,
-                                                                         v.Pos.Z,
-                                                                         n.X,
-                                                                         n.Y,
-                                                                         n.Z,
-                                                                         uu,
-                                                                         vv,
-                                                                         allVertices, mergeVertices);
+                            vertexIndices[i] = (ushort)GetOrCreateVertex((v.Pos.X, v.Pos.Y, v.Pos.Z),
+                                                                         (n.X, n.Y, n.Z),
+                                                                         (uu, vv),
+                                                                         allVertices,
+                                                                         mergeVertices);
                         }
 
                         // First triangle
@@ -114,15 +110,11 @@ namespace Elements.Geometry
                             var uu = basis.U.Dot(v.Position.X, v.Position.Y, v.Position.Z);
                             var vv = basis.V.Dot(v.Position.X, v.Position.Y, v.Position.Z);
 
-                            vertexIndices[i] = (ushort)GetOrCreateVertex(v.Position.X,
-                                                                         v.Position.Y,
-                                                                         v.Position.Z,
-                                                                         n.X,
-                                                                         n.Y,
-                                                                         n.Z,
-                                                                         uu,
-                                                                         vv,
-                                                                         allVertices, mergeVertices);
+                            vertexIndices[i] = (ushort)GetOrCreateVertex((v.Position.X, v.Position.Y, v.Position.Z),
+                                                                         (n.X, n.Y, n.Z),
+                                                                         (uu, vv),
+                                                                         allVertices,
+                                                                         mergeVertices);
 
                         }
 
@@ -149,17 +141,17 @@ namespace Elements.Geometry
             return basis;
         }
 
-        private static int GetOrCreateVertex(double x, double y, double z, double nx, double ny, double nz, double u, double v,
-                                                 List<(Vector3 position, Vector3 normal, UV uv)> pts, bool mergeVertices)
+        private static int GetOrCreateVertex((double x, double y, double z) position,
+                                             (double nx, double ny, double nz) normal,
+                                             (double u, double v) uv,
+                                             List<(Vector3 position, Vector3 normal, UV uv)> pts,
+                                             bool mergeVertices)
         {
-            var n = new Vector3(nx, ny, nz);
-            var pt = new Vector3(x, y, z);
-
             if (mergeVertices)
             {
                 var index = pts.FindIndex(p =>
                 {
-                    return p.position.IsAlmostEqualTo(pt) && p.normal.AngleTo(n) < 45.0;
+                    return p.position.IsAlmostEqualTo(position) && p.normal.AngleTo(normal) < 45.0;
                 });
                 if (index != -1)
                 {
@@ -167,7 +159,7 @@ namespace Elements.Geometry
                 }
             }
 
-            pts.Add((pt, n, new UV(u, v)));
+            pts.Add((position, normal, uv));
             return pts.Count - 1;
         }
 

--- a/Elements/src/Geometry/CsgExtensions.cs
+++ b/Elements/src/Geometry/CsgExtensions.cs
@@ -142,16 +142,19 @@ namespace Elements.Geometry
         }
 
         private static int GetOrCreateVertex((double x, double y, double z) position,
-                                             (double nx, double ny, double nz) normal,
+                                             (double x, double y, double z) normal,
                                              (double u, double v) uv,
                                              List<(Vector3 position, Vector3 normal, UV uv)> pts,
                                              bool mergeVertices)
         {
+            var pt = new Vector3(position.x, position.y, position.z);
+            var n = new Vector3(normal.x, normal.y, normal.z);
+
             if (mergeVertices)
             {
                 var index = pts.FindIndex(p =>
                 {
-                    return p.position.IsAlmostEqualTo(position) && p.normal.AngleTo(normal) < 45.0;
+                    return p.position.IsAlmostEqualTo(pt) && p.normal.AngleTo(n) < 45.0;
                 });
                 if (index != -1)
                 {
@@ -159,7 +162,7 @@ namespace Elements.Geometry
                 }
             }
 
-            pts.Add((position, normal, uv));
+            pts.Add((pt, n, uv));
             return pts.Count - 1;
         }
 

--- a/Elements/src/Geometry/CsgExtensions.cs
+++ b/Elements/src/Geometry/CsgExtensions.cs
@@ -52,16 +52,6 @@ namespace Elements.Geometry
 
             (Vector3 U, Vector3 V) basis;
 
-            const float SEARCH_RADIUS = 0.001f;
-
-            // Setup the octree to fit around the csg.
-            // This requires one expensive initialization.
-            var verts = csgs.SelectMany(csg => csg.Polygons.SelectMany(p => p.Vertices).Select(v => v.Pos.ToElementsVector())).ToArray();
-            var bounds = new BBox3(verts);
-            var center = bounds.Center();
-            var origin = new Point((float)center.X, (float)center.Y, (float)center.Z);
-            var size = (float)bounds.Max.DistanceTo(bounds.Min);
-            var octree = new PointOctree<(Vector3 position, Vector3 normal, ushort index)>(size, origin, SEARCH_RADIUS);
             foreach (var csg in csgs)
             {
                 foreach (var p in csg.Polygons)
@@ -81,23 +71,12 @@ namespace Elements.Geometry
                         for (var i = 0; i < p.Vertices.Count; i++)
                         {
                             var v = p.Vertices[i];
-
-                            var op = new Point((float)v.Pos.X, (float)v.Pos.Y, (float)v.Pos.Z);
-                            var ep = v.Pos.ToElementsVector();
-                            if (TryGetExistingVertex(op, ep, octree, normal, SEARCH_RADIUS, out ushort vertexIndex))
-                            {
-                                vertexIndices[i] = vertexIndex;
-                                continue;
-                            }
-
                             vertexIndices[i] = iCursor;
                             iCursor++;
 
-                            var uu = basis.U.Dot(ep);
-                            var vv = basis.V.Dot(ep);
-                            buffers.AddVertex(ep, normal, new UV(uu, vv));
-
-                            octree.Add((ep, normal, vertexIndices[i]), op);
+                            var uu = basis.U.Dot(v.Pos.X, v.Pos.Y, v.Pos.Z);
+                            var vv = basis.V.Dot(v.Pos.X, v.Pos.Y, v.Pos.Z);
+                            buffers.AddVertex(v.Pos.X, v.Pos.Y, v.Pos.Z, normal.X, normal.Y, normal.Z, uu, vv);
                         }
 
                         // First triangle
@@ -129,23 +108,12 @@ namespace Elements.Geometry
                         for (var i = 0; i < tess.Vertices.Length; i++)
                         {
                             var v = tess.Vertices[i];
-                            var op = new Point((float)v.Position.X, (float)v.Position.Y, (float)v.Position.Z);
-                            var ep = v.Position.ToVector3();
-
-                            if (TryGetExistingVertex(op, ep, octree, normal, SEARCH_RADIUS, out ushort vertexIndex))
-                            {
-                                vertexIndices[i] = vertexIndex;
-                                continue;
-                            }
-
                             vertexIndices[i] = iCursor;
                             iCursor++;
 
-                            var uu = basis.U.Dot(ep);
-                            var vv = basis.V.Dot(ep);
-                            buffers.AddVertex(ep, normal, new UV(uu, vv));
-
-                            octree.Add((ep, normal, vertexIndices[i]), op);
+                            var uu = basis.U.Dot(v.Position.X, v.Position.Y, v.Position.Z);
+                            var vv = basis.V.Dot(v.Position.X, v.Position.Y, v.Position.Z);
+                            buffers.AddVertex(v.Position.X, v.Position.Y, v.Position.Z, normal.X, normal.Y, normal.Z, uu, vv);
                         }
 
                         for (var k = 0; k < tess.Elements.Length; k++)

--- a/Elements/src/Geometry/GraphicsBuffers.cs
+++ b/Elements/src/Geometry/GraphicsBuffers.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Elements.Geometry
 {
@@ -18,6 +17,20 @@ namespace Elements.Geometry
         /// <param name="uv">The UV of the vertex.</param>
         /// <param name="color">The vertex color.</param>
         void AddVertex(Vector3 position, Vector3 normal, UV uv, Color? color = null);
+
+        /// <summary>
+        /// Add a vertex to the graphics buffers.
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <param name="z"></param>
+        /// <param name="nx"></param>
+        /// <param name="ny"></param>
+        /// <param name="nz"></param>
+        /// <param name="u"></param>
+        /// <param name="v"></param>
+        /// <param name="color"></param>
+        void AddVertex(double x, double y, double z, double nx, double ny, double nz, double u, double v, Color? color = null);
 
         /// <summary>
         /// Add an index to the graphics buffers.
@@ -141,35 +154,52 @@ namespace Elements.Geometry
         /// <param name="color">The vertex color.</param>
         public void AddVertex(Vector3 position, Vector3 normal, UV uv, Color? color = null)
         {
-            this.Vertices.AddRange(BitConverter.GetBytes((float)position.X));
-            this.Vertices.AddRange(BitConverter.GetBytes((float)position.Y));
-            this.Vertices.AddRange(BitConverter.GetBytes((float)position.Z));
+            this.AddVertex(position.X, position.Y, position.Z, normal.X, normal.Y, normal.Z, uv.U, uv.V, color);
+        }
 
-            this.Normals.AddRange(BitConverter.GetBytes((float)normal.X));
-            this.Normals.AddRange(BitConverter.GetBytes((float)normal.Y));
-            this.Normals.AddRange(BitConverter.GetBytes((float)normal.Z));
+        /// <summary>
+        /// Add a vertex to the graphics buffers.
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <param name="z"></param>
+        /// <param name="nx"></param>
+        /// <param name="ny"></param>
+        /// <param name="nz"></param>
+        /// <param name="u"></param>
+        /// <param name="v"></param>
+        /// <param name="color"></param>
+        public void AddVertex(double x, double y, double z, double nx, double ny, double nz, double u, double v, Color? color)
+        {
+            this.Vertices.AddRange(BitConverter.GetBytes((float)x));
+            this.Vertices.AddRange(BitConverter.GetBytes((float)y));
+            this.Vertices.AddRange(BitConverter.GetBytes((float)z));
 
-            this.UVs.AddRange(BitConverter.GetBytes((float)uv.U));
-            this.UVs.AddRange(BitConverter.GetBytes((float)uv.V));
+            this.Normals.AddRange(BitConverter.GetBytes((float)nx));
+            this.Normals.AddRange(BitConverter.GetBytes((float)ny));
+            this.Normals.AddRange(BitConverter.GetBytes((float)nz));
 
-            this.VMax[0] = Math.Max(this.VMax[0], position.X);
-            this.VMax[1] = Math.Max(this.VMax[1], position.Y);
-            this.VMax[2] = Math.Max(this.VMax[2], position.Z);
-            this.VMin[0] = Math.Min(this.VMin[0], position.X);
-            this.VMin[1] = Math.Min(this.VMin[1], position.Y);
-            this.VMin[2] = Math.Min(this.VMin[2], position.Z);
+            this.UVs.AddRange(BitConverter.GetBytes((float)u));
+            this.UVs.AddRange(BitConverter.GetBytes((float)v));
 
-            this.NMax[0] = Math.Max(this.NMax[0], normal.X);
-            this.NMax[1] = Math.Max(this.NMax[1], normal.Y);
-            this.NMax[2] = Math.Max(this.NMax[2], normal.Z);
-            this.NMin[0] = Math.Min(this.NMin[0], normal.X);
-            this.NMin[1] = Math.Min(this.NMin[1], normal.Y);
-            this.NMin[2] = Math.Min(this.NMin[2], normal.Z);
+            this.VMax[0] = Math.Max(this.VMax[0], x);
+            this.VMax[1] = Math.Max(this.VMax[1], y);
+            this.VMax[2] = Math.Max(this.VMax[2], z);
+            this.VMin[0] = Math.Min(this.VMin[0], x);
+            this.VMin[1] = Math.Min(this.VMin[1], y);
+            this.VMin[2] = Math.Min(this.VMin[2], z);
 
-            this.UVMax[0] = Math.Max(this.UVMax[0], uv.U);
-            this.UVMax[1] = Math.Max(this.UVMax[1], uv.V);
-            this.UVMin[0] = Math.Min(this.UVMin[0], uv.U);
-            this.UVMin[1] = Math.Min(this.UVMin[1], uv.V);
+            this.NMax[0] = Math.Max(this.NMax[0], nx);
+            this.NMax[1] = Math.Max(this.NMax[1], ny);
+            this.NMax[2] = Math.Max(this.NMax[2], nz);
+            this.NMin[0] = Math.Min(this.NMin[0], nx);
+            this.NMin[1] = Math.Min(this.NMin[1], ny);
+            this.NMin[2] = Math.Min(this.NMin[2], nz);
+
+            this.UVMax[0] = Math.Max(this.UVMax[0], u);
+            this.UVMax[1] = Math.Max(this.UVMax[1], v);
+            this.UVMin[0] = Math.Min(this.UVMin[0], u);
+            this.UVMin[1] = Math.Min(this.UVMin[1], v);
 
             if (color.HasValue && color.Value != default(Color))
             {
@@ -196,5 +226,6 @@ namespace Elements.Geometry
             this.IMax = Math.Max(this.IMax, index);
             this.IMin = Math.Min(this.IMin, index);
         }
+
     }
 }

--- a/Elements/src/Geometry/Solids/Solid.cs
+++ b/Elements/src/Geometry/Solids/Solid.cs
@@ -770,6 +770,13 @@ namespace Elements.Geometry.Solids
             return loop;
         }
 
+        // TODO: This method should not be required if we have adequate lookup
+        // operations based on vertex locations and incident edges. This is 
+        // currently used in the case where we want to add a face from a polygon
+        // but in most cases where we want to do that we already know something
+        // about the shape of the existing solid and should be able to lookup 
+        // existing vertices without doing an O(n) search. Implement a better
+        // search strategy!
         private void FindOrCreateVertex(Vector3 pt, int i, Transform transform, bool mergeVerticesAndEdges, Vertex[] verts)
         {
             if (transform != null)

--- a/Elements/src/Geometry/Solids/Solid.cs
+++ b/Elements/src/Geometry/Solids/Solid.cs
@@ -62,12 +62,12 @@ namespace Elements.Geometry.Solids
             if (voids != null && voids.Count > 0)
             {
                 solid.AddFace(perimeter, voids);
-                solid.AddFace(perimeter.Reversed(), voids.Select(h => h.Reversed()).ToArray(), true);
+                solid.AddFace(perimeter, voids, true, reverse: true);
             }
             else
             {
                 solid.AddFace(perimeter);
-                solid.AddFace(perimeter.Reversed(), null, true);
+                solid.AddFace(perimeter, null, true, reverse: true);
             }
 
             return solid;
@@ -141,13 +141,13 @@ namespace Elements.Geometry.Solids
             }
             else if (curve is Bezier)
             {
-                var startCap = solid.AddFace((Polygon)perimeter.Transformed(transforms[0]));
+                var startCap = solid.AddFace(perimeter, transform: transforms[0]);
                 for (var i = 0; i < transforms.Length - 1; i++)
                 {
                     var next = transforms[i + 1];
                     solid.SweepPolygonBetweenPlanes(perimeter, transforms[i], next);
                 }
-                var endCap = solid.AddFace(((Polygon)perimeter.Transformed(transforms[transforms.Length - 1])).Reversed());
+                var endCap = solid.AddFace(perimeter, transform: transforms[transforms.Length - 1], reverse: true);
             }
             else
             {
@@ -157,12 +157,12 @@ namespace Elements.Geometry.Solids
 
                 if (holes != null)
                 {
-                    cap = solid.AddFace((Polygon)perimeter.Transformed(transforms[0]), transforms[0].OfPolygons(holes));
+                    cap = solid.AddFace(perimeter, holes, transform: transforms[0]);
                     openEdges = new Edge[1 + holes.Count][];
                 }
                 else
                 {
-                    cap = solid.AddFace((Polygon)perimeter.Transformed(transforms[0]));
+                    cap = solid.AddFace(perimeter, transform: transforms[0]);
                     openEdges = new Edge[1][];
                 }
 
@@ -223,22 +223,22 @@ namespace Elements.Geometry.Solids
                 var t = new Transform(direction.Negate() * (distance / 2), rotation);
                 if (holes != null)
                 {
-                    fStart = solid.AddFace((Polygon)perimeter.Reversed().Transformed(t), t.OfPolygons(holes.Reversed()));
+                    fStart = solid.AddFace(perimeter, holes, transform: t, reverse: true);
                 }
                 else
                 {
-                    fStart = solid.AddFace((Polygon)perimeter.Reversed().Transformed(t));
+                    fStart = solid.AddFace(perimeter, transform: t, reverse: true);
                 }
             }
             else
             {
                 if (holes != null)
                 {
-                    fStart = solid.AddFace(perimeter.Reversed(), holes.Reversed());
+                    fStart = solid.AddFace(perimeter, holes, reverse: true);
                 }
                 else
                 {
-                    fStart = solid.AddFace(perimeter.Reversed());
+                    fStart = solid.AddFace(perimeter, reverse: true);
                 }
             }
 
@@ -280,10 +280,16 @@ namespace Elements.Geometry.Solids
         /// <param name="outer">A polygon representing the perimeter of the face.</param>
         /// <param name="inner">An array of polygons representing the holes in the face.</param>
         /// <param name="mergeVerticesAndEdges">Should existing vertices / edges in the solid be used for the added face?</param>
+        /// <param name="transform">An optional transform which is applied to the polygon.</param>
+        /// <param name="reverse">Should the loop be reversed?</param>
         /// <returns>The newly added face.</returns>
-        public Face AddFace(Polygon outer, IList<Polygon> inner = null, bool mergeVerticesAndEdges = false)
+        public Face AddFace(Polygon outer,
+                            IList<Polygon> inner = null,
+                            bool mergeVerticesAndEdges = false,
+                            Transform transform = null,
+                            bool reverse = false)
         {
-            var outerLoop = LoopFromPolygon(outer, mergeVerticesAndEdges);
+            var outerLoop = LoopFromPolygon(outer, mergeVerticesAndEdges, transform, reverse);
             Loop[] innerLoops = null;
 
             if (inner != null)
@@ -291,7 +297,7 @@ namespace Elements.Geometry.Solids
                 innerLoops = new Loop[inner.Count];
                 for (var i = 0; i < inner.Count; i++)
                 {
-                    innerLoops[i] = LoopFromPolygon(inner[i], mergeVerticesAndEdges);
+                    innerLoops[i] = LoopFromPolygon(inner[i], mergeVerticesAndEdges, transform, reverse);
                 }
             }
 
@@ -728,22 +734,31 @@ namespace Elements.Geometry.Solids
             AddFace(loop, inner);
         }
 
-        protected Loop LoopFromPolygon(Polygon p, bool mergeVerticesAndEdges = false)
+        protected Loop LoopFromPolygon(Polygon p,
+                                       bool mergeVerticesAndEdges = false,
+                                       Transform transform = null,
+                                       bool reverse = false)
         {
             var loop = new Loop();
             var verts = new Vertex[p.Vertices.Count];
-            for (var i = 0; i < p.Vertices.Count; i++)
+
+            if (reverse)
             {
-                if (mergeVerticesAndEdges)
+                for (var i = p.Vertices.Count - 1; i >= 0; i--)
                 {
-                    var existingVertex = Vertices.Select(v => v.Value).FirstOrDefault(v => v.Point.IsAlmostEqualTo(p.Vertices[i]));
-                    verts[i] = existingVertex ?? AddVertex(p.Vertices[i]);
-                }
-                else
-                {
-                    verts[i] = AddVertex(p.Vertices[i]);
+                    var pt = p.Vertices[i];
+                    FindOrCreateVertex(pt, p.Vertices.Count - 1 - i, transform, mergeVerticesAndEdges, verts);
                 }
             }
+            else
+            {
+                for (var i = 0; i < p.Vertices.Count; i++)
+                {
+                    var pt = p.Vertices[i];
+                    FindOrCreateVertex(pt, i, transform, mergeVerticesAndEdges, verts);
+                }
+            }
+
             for (var i = 0; i < p.Vertices.Count; i++)
             {
                 var v1 = verts[i];
@@ -751,7 +766,26 @@ namespace Elements.Geometry.Solids
                 var edge = AddEdge(v1, v2, mergeVerticesAndEdges, out var edgeType);
                 loop.AddEdgeToEnd(edgeType == "left" ? edge.Left : edge.Right);
             }
+
             return loop;
+        }
+
+        private void FindOrCreateVertex(Vector3 pt, int i, Transform transform, bool mergeVerticesAndEdges, Vertex[] verts)
+        {
+            if (transform != null)
+            {
+                pt = transform.OfPoint(pt);
+            }
+
+            if (mergeVerticesAndEdges)
+            {
+                var existingVertex = Vertices.Select(v => v.Value).FirstOrDefault(v => v.Point.IsAlmostEqualTo(pt));
+                verts[i] = existingVertex ?? AddVertex(pt);
+            }
+            else
+            {
+                verts[i] = AddVertex(pt);
+            }
         }
 
         internal Face AddFace(long id, Loop outer, Loop[] inner = null)
@@ -861,7 +895,7 @@ namespace Elements.Geometry.Solids
             // do not introduce shear into the transform.
             var v = (start.Origin - end.Origin).Unitized();
             var midTrans = new Transform(end.Origin.Average(start.Origin), start.YAxis.Cross(v), v);
-            var mid = (Polygon)p.Transformed(midTrans);
+            var mid = p.TransformedPolygon(midTrans);
             var startP = mid.ProjectAlong(v, start.XY());
             var endP = mid.ProjectAlong(v, end.XY());
 

--- a/Elements/src/Geometry/UV.cs
+++ b/Elements/src/Geometry/UV.cs
@@ -54,5 +54,14 @@ namespace Elements.Geometry
         {
             return $"U:{this.U}, V:{this.V}";
         }
+
+        /// <summary>
+        /// Automatically convert a tuple of two doubles into a UV.
+        /// </summary>
+        /// <param name="uv">An (u,v) tuple of doubles.</param>
+        public static implicit operator UV((double u, double v) uv)
+        {
+            return new UV(uv.u, uv.v);
+        }
     }
 }

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -163,13 +163,42 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Compute the cross product of this vector and a vector composed
+        /// of the provided components.
+        /// </summary>
+        /// <param name="x">X</param>
+        /// <param name="y">Y</param>
+        /// <param name="z">Z</param>
+        public Vector3 Cross(double x, double y, double z)
+        {
+            var xx = Y * z - Z * y;
+            var yy = Z * x - X * z;
+            var zz = X * y - Y * x;
+
+            return new Vector3(xx, yy, zz);
+        }
+
+        /// <summary>
         /// Compute the dot product of this vector and v.
         /// </summary>
         /// <param name="v">The vector with which to compute the dot product.</param>
-        /// <returns>The dot product.</returns>
+        /// <returns>A value between 1 and -1.</returns>
         public double Dot(Vector3 v)
         {
             return v.X * this.X + v.Y * this.Y + v.Z * this.Z;
+        }
+
+        /// <summary>
+        /// Compute the dot product of this vector and a vector composed
+        /// of the provided components.
+        /// </summary>
+        /// <param name="x">X</param>
+        /// <param name="y">Y</param>
+        /// <param name="z">Z</param>
+        /// <returns>A value between 1 and -1.</returns>
+        public double Dot(double x, double y, double z)
+        {
+            return x * this.X + y * this.Y + z * this.Z;
         }
 
         /// <summary>

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -422,9 +422,6 @@ namespace Elements.Serialization.glTF
                                             int? parent_index,
                                             List<glTFLoader.Schema.Mesh> meshes)
         {
-            var sw = new Stopwatch();
-            sw.Start();
-
             var m = new glTFLoader.Schema.Mesh();
             m.Name = name;
 
@@ -513,9 +510,6 @@ namespace Elements.Serialization.glTF
 
             // Add mesh to gltf
             meshes.Add(m);
-
-            sw.Stop();
-            Console.WriteLine($"{sw.Elapsed} for writing mesh to gltf.");
 
             return meshes.Count - 1;
         }
@@ -736,11 +730,7 @@ namespace Elements.Serialization.glTF
         {
             var schemaBuffer = new glTFLoader.Schema.Buffer();
             var schemaBuffers = new List<glTFLoader.Schema.Buffer> { schemaBuffer };
-            // var floatSize = sizeof(float);
-            // Console.WriteLine(floatSize);
-            // int size = (2 * floatSize + 3 * floatSize + 3 * floatSize + 4 * floatSize) * ushort.MaxValue * 1000;
-            // Console.WriteLine(size);
-            var buffer = new List<byte>(ushort.MaxValue);
+            var buffer = new List<byte>();
             allBuffers = new List<byte[]> { Array.Empty<byte>() };
 
             var gltf = new Gltf();
@@ -1254,9 +1244,6 @@ namespace Elements.Serialization.glTF
                                       List<Vector3> lines,
                                       Transform t = null)
         {
-            var sw = new Stopwatch();
-            sw.Start();
-
             GraphicsBuffers buffers = null;
             if (geometricElement.Representation.SkipCSGUnion)
             {
@@ -1276,9 +1263,6 @@ namespace Elements.Serialization.glTF
             {
                 return -1;
             }
-
-            sw.Stop();
-            Console.WriteLine($"{sw.Elapsed} for generating element geometry for gltf.");
 
             return gltf.AddTriangleMesh(id + "_mesh",
                                         buffer,

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -12,11 +12,9 @@ using Elements.Geometry.Interfaces;
 using SixLabors.ImageSharp.Processing;
 using Elements.Collections.Generics;
 using System.Net;
-using Elements.Interfaces;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp;
 using Image = glTFLoader.Schema.Image;
-using System.Diagnostics;
 
 [assembly: InternalsVisibleTo("Hypar.Elements.Tests")]
 [assembly: InternalsVisibleTo("Elements.Benchmarks")]
@@ -81,10 +79,12 @@ namespace Elements.Serialization.glTF
         /// Serialize the model to a byte array.
         /// </summary>
         /// <param name="model">The model to serialize.</param>
+        /// <param name="drawEdges">Should edges of the model be drawn?</param>
+        /// <param name="mergeVertices">Should vertices be merged in the resulting output?</param>
         /// <returns>A byte array representing the model.</returns>
-        public static byte[] ToGlTF(this Model model)
+        public static byte[] ToGlTF(this Model model, bool drawEdges = false, bool mergeVertices = false)
         {
-            var gltf = InitializeGlTF(model, out var buffers, false);
+            var gltf = InitializeGlTF(model, out var buffers, drawEdges, mergeVertices);
             if (gltf == null)
             {
                 return null;
@@ -106,10 +106,10 @@ namespace Elements.Serialization.glTF
         /// Serialize the model to a base64 encoded string.
         /// </summary>
         /// <returns>A Base64 string representing the model.</returns>
-        public static string ToBase64String(this Model model, bool drawEdges = false)
+        public static string ToBase64String(this Model model, bool drawEdges = false, bool mergeVertices = false)
         {
             var tmp = Path.GetTempFileName();
-            var gltf = InitializeGlTF(model, out var buffers, drawEdges);
+            var gltf = InitializeGlTF(model, out var buffers, drawEdges, mergeVertices);
             if (gltf == null)
             {
                 return "";
@@ -697,9 +697,9 @@ namespace Elements.Serialization.glTF
         }
 
         /// <returns>Whether a Glb was successfully saved. False indicates that there was no geometry to save.</returns>
-        private static bool SaveGlb(Model model, string path, bool drawEdges = false)
+        private static bool SaveGlb(Model model, string path, bool drawEdges = false, bool mergeVertices = false)
         {
-            var gltf = InitializeGlTF(model, out var buffers, drawEdges);
+            var gltf = InitializeGlTF(model, out var buffers, drawEdges, mergeVertices);
             if (gltf == null)
             {
                 return false;
@@ -712,9 +712,9 @@ namespace Elements.Serialization.glTF
         }
 
         /// <returns>Whether a Glb was successfully saved. False indicates that there was no geometry to save.</returns>
-        private static bool SaveGltf(Model model, string path, bool drawEdges = false)
+        private static bool SaveGltf(Model model, string path, bool drawEdges = false, bool mergeVertices = false)
         {
-            var gltf = InitializeGlTF(model, out List<byte[]> buffers, drawEdges);
+            var gltf = InitializeGlTF(model, out List<byte[]> buffers, drawEdges, mergeVertices);
             if (gltf == null)
             {
                 return false;
@@ -726,7 +726,10 @@ namespace Elements.Serialization.glTF
             return true;
         }
 
-        internal static Gltf InitializeGlTF(Model model, out List<byte[]> allBuffers, bool drawEdges = false)
+        internal static Gltf InitializeGlTF(Model model,
+                                            out List<byte[]> allBuffers,
+                                            bool drawEdges = false,
+                                            bool mergeVertices = false)
         {
             var schemaBuffer = new glTFLoader.Schema.Buffer();
             var schemaBuffers = new List<glTFLoader.Schema.Buffer> { schemaBuffer };
@@ -834,7 +837,8 @@ namespace Elements.Serialization.glTF
                                         nodeElementMap,
                                         meshTransformMap,
                                         currLines,
-                                        drawEdges);
+                                        drawEdges,
+                                        mergeVertices);
             }
             if (allBuffers.Sum(b => b.Count()) + buffer.Count == 0 && lights.Count == 0)
             {
@@ -911,7 +915,8 @@ namespace Elements.Serialization.glTF
                                                     Dictionary<Guid, ProtoNode> nodeElementMap,
                                                     Dictionary<Guid, Transform> meshTransformMap,
                                                     List<Vector3> lines,
-                                                    bool drawEdges)
+                                                    bool drawEdges,
+                                                    bool mergeVertices = false)
         {
             var materialName = BuiltInMaterials.Default.Name;
             int meshId = -1;
@@ -965,19 +970,20 @@ namespace Elements.Serialization.glTF
                     else
                     {
                         meshId = ProcessGeometricRepresentation(e,
-                                                        ref gltf,
-                                                        ref materialIndexMap,
-                                                        ref buffer,
-                                                        bufferViews,
-                                                        accessors,
-                                                        meshes,
-                                                        nodes,
-                                                        meshElementMap,
-                                                        lines,
-                                                        drawEdges,
-                                                        materialName,
-                                                        ref meshId,
-                                                        content);
+                                                                ref gltf,
+                                                                ref materialIndexMap,
+                                                                ref buffer,
+                                                                bufferViews,
+                                                                accessors,
+                                                                meshes,
+                                                                nodes,
+                                                                meshElementMap,
+                                                                lines,
+                                                                drawEdges,
+                                                                materialName,
+                                                                ref meshId,
+                                                                content,
+                                                                mergeVertices);
                         if (!meshElementMap.ContainsKey(e.Id))
                         {
                             meshElementMap.Add(e.Id, new List<int> { meshId });
@@ -990,19 +996,20 @@ namespace Elements.Serialization.glTF
                     materialName = geometricElement.Material.Name;
 
                     meshId = ProcessGeometricRepresentation(e,
-                                                   ref gltf,
-                                                   ref materialIndexMap,
-                                                   ref buffer,
-                                                   bufferViews,
-                                                   accessors,
-                                                   meshes,
-                                                   nodes,
-                                                   meshElementMap,
-                                                   lines,
-                                                   drawEdges,
-                                                   materialName,
-                                                   ref meshId,
-                                                   geometricElement);
+                                                            ref gltf,
+                                                            ref materialIndexMap,
+                                                            ref buffer,
+                                                            bufferViews,
+                                                            accessors,
+                                                            meshes,
+                                                            nodes,
+                                                            meshElementMap,
+                                                            lines,
+                                                            drawEdges,
+                                                            materialName,
+                                                            ref meshId,
+                                                            geometricElement,
+                                                            mergeVertices);
                     if (meshId > -1 && !meshElementMap.ContainsKey(e.Id))
                     {
                         meshElementMap.Add(e.Id, new List<int> { meshId });
@@ -1189,7 +1196,8 @@ namespace Elements.Serialization.glTF
                                                            bool drawEdges,
                                                            string materialName,
                                                            ref int meshId,
-                                                           GeometricElement geometricElement)
+                                                           GeometricElement geometricElement,
+                                                           bool mergeVertices = false)
         {
             geometricElement.UpdateRepresentations();
 
@@ -1214,7 +1222,8 @@ namespace Elements.Serialization.glTF
                                     accessors,
                                     meshes,
                                     lines,
-                                    geometricElement.Transform);
+                                    geometricElement.Transform,
+                                    mergeVertices);
 
                 // If the id == -1, the mesh is malformed.
                 // It may have no geometry.
@@ -1242,7 +1251,8 @@ namespace Elements.Serialization.glTF
                                       List<Accessor> accessors,
                                       List<glTFLoader.Schema.Mesh> meshes,
                                       List<Vector3> lines,
-                                      Transform t = null)
+                                      Transform t = null,
+                                      bool mergeVertices = false)
         {
             GraphicsBuffers buffers = null;
             if (geometricElement.Representation.SkipCSGUnion)
@@ -1251,12 +1261,12 @@ namespace Elements.Serialization.glTF
                 // skip CSG unions. In this case, we tessellate all solids
                 // individually, and do no booleaning. Voids are also ignored.
                 var solids = geometricElement.GetSolids();
-                buffers = solids.Tessellate();
+                buffers = solids.Tessellate(mergeVertices);
             }
             else
             {
                 var csg = geometricElement.GetFinalCsgFromSolids();
-                buffers = csg.Tessellate();
+                buffers = csg.Tessellate(mergeVertices);
             }
 
             if (buffers.Vertices.Count == 0)

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -736,7 +736,11 @@ namespace Elements.Serialization.glTF
         {
             var schemaBuffer = new glTFLoader.Schema.Buffer();
             var schemaBuffers = new List<glTFLoader.Schema.Buffer> { schemaBuffer };
-            var buffer = new List<byte>();
+            // var floatSize = sizeof(float);
+            // Console.WriteLine(floatSize);
+            // int size = (2 * floatSize + 3 * floatSize + 3 * floatSize + 4 * floatSize) * ushort.MaxValue * 1000;
+            // Console.WriteLine(size);
+            var buffer = new List<byte>(ushort.MaxValue);
             allBuffers = new List<byte[]> { Array.Empty<byte>() };
 
             var gltf = new Gltf();

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -16,6 +16,7 @@ using Elements.Interfaces;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp;
 using Image = glTFLoader.Schema.Image;
+using System.Diagnostics;
 
 [assembly: InternalsVisibleTo("Hypar.Elements.Tests")]
 [assembly: InternalsVisibleTo("Elements.Benchmarks")]
@@ -421,6 +422,9 @@ namespace Elements.Serialization.glTF
                                             int? parent_index,
                                             List<glTFLoader.Schema.Mesh> meshes)
         {
+            var sw = new Stopwatch();
+            sw.Start();
+
             var m = new glTFLoader.Schema.Mesh();
             m.Name = name;
 
@@ -509,6 +513,9 @@ namespace Elements.Serialization.glTF
 
             // Add mesh to gltf
             meshes.Add(m);
+
+            sw.Stop();
+            Console.WriteLine($"{sw.Elapsed} for writing mesh to gltf.");
 
             return meshes.Count - 1;
         }
@@ -1243,6 +1250,9 @@ namespace Elements.Serialization.glTF
                                       List<Vector3> lines,
                                       Transform t = null)
         {
+            var sw = new Stopwatch();
+            sw.Start();
+
             GraphicsBuffers buffers = null;
             if (geometricElement.Representation.SkipCSGUnion)
             {
@@ -1262,6 +1272,9 @@ namespace Elements.Serialization.glTF
             {
                 return -1;
             }
+
+            sw.Stop();
+            Console.WriteLine($"{sw.Elapsed} for generating element geometry for gltf.");
 
             return gltf.AddTriangleMesh(id + "_mesh",
                                         buffer,

--- a/Elements/test/CsgTests.cs
+++ b/Elements/test/CsgTests.cs
@@ -119,6 +119,11 @@ namespace Elements.Tests
             {
                 Vertices.Add((position, normal));
             }
+
+            public void AddVertex(double x, double y, double z, double nx, double ny, double nz, double u, double v, Color? color = null)
+            {
+                Vertices.Add((new Vector3(x, y, z), new Vector3(nx, ny, nz)));
+            }
         }
     }
 }


### PR DESCRIPTION
During discussions of compiling Elements to wasm, we began to investigate sources of slowness in the gltf conversion path. There were a number of opportunities for small improvements, like reducing allocation of new polygons, and removing unnecessary creation of `Vector3` when converting from another vector type. 

- Removes the use of octree for merge vertex lookup during CSG output to graphic buffers.
- Removes use of `polygon.Transformed()` and `polygon.Reversed()` in `Solid`. Those methods both allocate new polygons which is not required as the transforms and winding can be handled while building face loops.
- Adds a couple of method to `Vector3` to allow dot and cross products to be calculated using components of an incoming vector.

Writing all HSS members to gltf before:

|                          Method |     Mean |   Error |  StdDev |      Gen 0 |     Gen 1 | Gen 2 | Allocated |
|-------------------------------- |---------:|--------:|--------:|-----------:|----------:|------:|----------:|
| 'Draw all beams without merge.' | 235.7 ms | 4.99 ms | 2.97 ms | 29000.0000 | 1000.0000 |     - |  95.18 MB |
|    'Draw all beams with merge.' | 232.3 ms | 2.69 ms | 1.60 ms | 30000.0000 | 3000.0000 |     - |  95.18 MB |

After:
|                          Method |      Mean |     Error |    StdDev |      Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|-------------------------------- |----------:|----------:|----------:|-----------:|----------:|----------:|----------:|
| 'Draw all beams without merge.' | 119.72 ms | 29.135 ms | 19.271 ms | 25000.0000 | 2000.0000 | 1000.0000 |  83.01 MB |
|    'Draw all beams with merge.' |  95.55 ms |  8.368 ms |  5.535 ms | 25000.0000 | 2000.0000 | 1000.0000 |  83.01 MB |

Observations:
- The "before" benchmarks are run against master and don't have the API which allows to merge vertices, so both numbers are similar.
- The "after" benchmarks are run with and without the new API to merge vertices, which shows a nearly 20ms speed up even with the merge. My assumption here is that the reduced number of vertices after merge helps to accelerate everything downstream.
 
Creating a beam with a varying number of holes before:
|           Method | NumberOfHoles |     Mean |    Error |   StdDev |   Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |-------------- |---------:|---------:|---------:|--------:|------:|------:|----------:|
| 'Tesselate CSG.' |             1 | 756.0 us | 459.1 us | 25.17 us | 81.0547 |     - |     - | 250.77 KB |
| 'Tesselate CSG.' |            10 | 811.7 us | 472.5 us | 25.90 us | 81.0547 |     - |     - | 250.77 KB |
| 'Tesselate CSG.' |            20 | 774.2 us | 168.2 us |  9.22 us | 81.0547 |     - |     - | 250.77 KB |
| 'Tesselate CSG.' |            50 | 769.9 us | 399.9 us | 21.92 us | 81.0547 |     - |     - | 250.77 KB |

After:
|           Method | NumberOfHoles |     Mean |     Error |  StdDev |   Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |-------------- |---------:|----------:|--------:|--------:|------:|------:|----------:|
| 'Tesselate CSG.' |             1 | 143.7 us |  59.86 us | 3.28 us | 55.1758 |     - |     - | 169.75 KB |
| 'Tesselate CSG.' |            10 | 149.3 us | 169.65 us | 9.30 us | 55.1758 |     - |     - | 169.75 KB |
| 'Tesselate CSG.' |            20 | 158.4 us |  38.93 us | 2.13 us | 55.1758 |     - |     - | 169.75 KB |
| 'Tesselate CSG.' |            50 | 137.9 us | 106.55 us | 5.84 us | 55.1758 |     - |     - | 169.75 KB |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/656)
<!-- Reviewable:end -->
