### PR TITLE
Add a convex hull frame in 3d method and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `AdaptiveGrid`
 - `Line.Intersects(BBox3 box, out List<Vector3> results, bool infinite = false)`
 - `Vector3.AreCoplanar(Vector3 a, Vector3 b, Vector3 c, Vector3 d)`
+- `ConvexHull.Frame3DPoints(IEnumerable<Vector3> points, Vector3 normalVectorOfFrame)`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - `AdaptiveGrid`
 - `Line.Intersects(BBox3 box, out List<Vector3> results, bool infinite = false)`
 - `Vector3.AreCoplanar(Vector3 a, Vector3 b, Vector3 c, Vector3 d)`
-- `ConvexHull.Frame3DPoints(IEnumerable<Vector3> points, Vector3 normalVectorOfFrame)`
+- `ConvexHull.FromPointsInPlane(IEnumerable<Vector3> points, Vector3 normalVectorOfFrame)`
 
 ### Changed
 

--- a/Elements/src/Geometry/ConvexHull.cs
+++ b/Elements/src/Geometry/ConvexHull.cs
@@ -74,18 +74,12 @@ namespace Elements.Geometry
             }
             else
             {
-                var transform = new Transform();
-                transform.Rotate(normalVectorOfFrame.Cross(Vector3.ZAxis).Unitized(), normalVectorOfFrame.AngleTo(Vector3.ZAxis));
-                var tPoints = points.Select(p => transform.OfPoint(p)).Select(p => new Vector3(p.X, p.Y));
-
+                var center3D = points.Average();
+                var toOrientation = new Transform(center3D, normalVectorOfFrame);
+                var fromOrientation = toOrientation.Inverted();
+                var tPoints = points.Select(p => fromOrientation.OfPoint(p)).Select(p => new Vector3(p.X, p.Y));
                 var twoDHull = FromPoints(tPoints);
-
-                var threeDHull = twoDHull.TransformedPolygon(transform.Inverted());
-                var center = points.Average();
-                var planPoint = center.Project(threeDHull.Plane());
-                var movement = center - planPoint;
-
-                return threeDHull.TransformedPolygon(new Transform().Moved(movement));
+                return twoDHull.TransformedPolygon(toOrientation);
             }
         }
 

--- a/Elements/src/Geometry/ConvexHull.cs
+++ b/Elements/src/Geometry/ConvexHull.cs
@@ -56,23 +56,23 @@ namespace Elements.Geometry
         /// Compute the 2D convex hull of a set of 3D points in a plane.
         /// </summary>
         /// <param name="points">A collection of points</param>
-        /// <param name="normalVectorOfFrame">The normal direction of the plane in which to compute the hull.</param>
+        /// <param name="planeNormal">The normal direction of the plane in which to compute the hull.</param>
         /// <returns>A polygon representing the convex hull, projected along the normal vector to the average depth of the provided points.</returns>
-        public static Polygon Frame3DPoints(IEnumerable<Vector3> points, Vector3 normalVectorOfFrame)
+        public static Polygon FromPointsInPlane(IEnumerable<Vector3> points, Vector3 planeNormal)
         {
-            if (normalVectorOfFrame.Length().ApproximatelyEquals(0))
+            if (planeNormal.Length().ApproximatelyEquals(0))
             {
                 throw new ArgumentException("The current normal vector cannot be of length 0");
             }
-            if (normalVectorOfFrame.Unitized() == Vector3.ZAxis
-                 || normalVectorOfFrame.Unitized().Negate() == Vector3.ZAxis)
+            if (planeNormal.Unitized() == Vector3.ZAxis
+                 || planeNormal.Unitized().Negate() == Vector3.ZAxis)
             {
                 return FromPoints(points);
             }
             else
             {
                 var center3D = points.Average();
-                var toOrientation = new Transform(center3D, normalVectorOfFrame);
+                var toOrientation = new Transform(center3D, planeNormal);
                 var fromOrientation = toOrientation.Inverted();
                 var tPoints = points.Select(p => fromOrientation.OfPoint(p)).Select(p => new Vector3(p.X, p.Y));
                 var twoDHull = FromPoints(tPoints);

--- a/Elements/src/Geometry/ConvexHull.cs
+++ b/Elements/src/Geometry/ConvexHull.cs
@@ -13,7 +13,7 @@ namespace Elements.Geometry
         /// Calculate a polygon from the 2d convex hull of a collection of points.
         /// Adapted from https://rosettacode.org/wiki/Convex_hull#C.23
         /// </summary>
-        /// <param name="points">a collection of points</param>
+        /// <param name="points">A collection of points</param>
         /// <returns>A polygon representing the convex hull of the provided points.</returns>
         public static Polygon FromPoints(IEnumerable<Vector3> points)
         {
@@ -21,7 +21,7 @@ namespace Elements.Geometry
             {
                 return null;
             }
-            var pointsSorted = points.OrderBy(p => p.X).ThenBy(p => p.Y).ToArray();
+            var pointsSorted = points.Select(p => new Vector3(p.X, p.Y)).OrderBy(p => p.X).ThenBy(p => p.Y).ToArray();
             List<Vector3> hullPoints = new List<Vector3>();
 
             Func<Vector3, Vector3, Vector3, bool> Ccw = (Vector3 a, Vector3 b, Vector3 c) => ((b.X - a.X) * (c.Y - a.Y)) > ((b.Y - a.Y) * (c.X - a.X));
@@ -53,13 +53,11 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Get the 2D polygon convex hull of the points, allowing the points
-        /// to be 3D and finding the polygon that frames those points when
-        /// looking in the direction of the provided normal vector.
+        /// Compute the 2D convex hull of a set of 3D points in a plane.
         /// </summary>
         /// <param name="points">A collection of points</param>
-        /// <param name="normalVectorOfFrame">The direction of the frames perspective.</param>
-        /// <returns>The polygonal frame that will encompass the points, roughly centered on the points themselves.</returns>
+        /// <param name="normalVectorOfFrame">The normal direction of the plane in which to compute the hull.</param>
+        /// <returns>A polygon representing the convex hull, projected along the normal vector to the average depth of the provided points.</returns>
         public static Polygon Frame3DPoints(IEnumerable<Vector3> points, Vector3 normalVectorOfFrame)
         {
             if (normalVectorOfFrame.Length().ApproximatelyEquals(0))
@@ -69,8 +67,7 @@ namespace Elements.Geometry
             if (normalVectorOfFrame.Unitized() == Vector3.ZAxis
                  || normalVectorOfFrame.Unitized().Negate() == Vector3.ZAxis)
             {
-                var tPoints = points.Select(p => new Vector3(p.X, p.Y));
-                return FromPoints(tPoints);
+                return FromPoints(points);
             }
             else
             {

--- a/Elements/src/Geometry/ConvexHull.cs
+++ b/Elements/src/Geometry/ConvexHull.cs
@@ -66,10 +66,14 @@ namespace Elements.Geometry
             {
                 throw new ArgumentException("The current normal vector cannot be of length 0");
             }
-            if (normalVectorOfFrame.Unitized() != Vector3.ZAxis
-                && normalVectorOfFrame.Unitized().Negate() != Vector3.ZAxis)
+            if (normalVectorOfFrame.Unitized() == Vector3.ZAxis
+                 || normalVectorOfFrame.Unitized().Negate() == Vector3.ZAxis)
             {
-
+                var tPoints = points.Select(p => new Vector3(p.X, p.Y));
+                return FromPoints(tPoints);
+            }
+            else
+            {
                 var transform = new Transform();
                 transform.Rotate(normalVectorOfFrame.Cross(Vector3.ZAxis).Unitized(), normalVectorOfFrame.AngleTo(Vector3.ZAxis));
                 var tPoints = points.Select(p => transform.OfPoint(p)).Select(p => new Vector3(p.X, p.Y));
@@ -83,18 +87,6 @@ namespace Elements.Geometry
 
                 return threeDHull.TransformedPolygon(new Transform().Moved(movement));
             }
-            else if (
-                 normalVectorOfFrame.Unitized() == Vector3.ZAxis
-                 || normalVectorOfFrame.Unitized().Negate() == Vector3.ZAxis)
-            {
-                var tPoints = points.Select(p => new Vector3(p.X, p.Y));
-                return FromPoints(tPoints);
-            }
-            else
-            {
-                return FromPoints(points);
-            }
-
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -967,7 +967,7 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="points">The Vector3 collection to average.</param>
         /// <returns>A Vector3 representing the average.</returns>
-        public static Vector3 Average(this IList<Vector3> points)
+        public static Vector3 Average(this IEnumerable<Vector3> points)
         {
             double x = 0.0, y = 0.0, z = 0.0;
             foreach (var p in points)
@@ -976,7 +976,8 @@ namespace Elements.Geometry
                 y += p.Y;
                 z += p.Z;
             }
-            return new Vector3(x / points.Count, y / points.Count, z / points.Count);
+            var count = points.Count();
+            return new Vector3(x / count, y / count, z / count);
         }
 
         /// <summary>

--- a/Elements/test/ConvexHullTests.cs
+++ b/Elements/test/ConvexHullTests.cs
@@ -39,20 +39,20 @@ namespace Elements.Tests
 
             var flatHull = ConvexHull.FromPoints(L.Vertices);
 
-            var jitteredHull = ConvexHull.Frame3DPoints(jitteredVertices, Vector3.ZAxis);
+            var jitteredHull = ConvexHull.FromPointsInPlane(jitteredVertices, Vector3.ZAxis);
             Assert.True(jitteredHull.IsAlmostEqualTo(flatHull), "Jittered flat hull doesn't match original hull.");
 
             // Simple transform allows simple polygon comparison for Assert.
             var simpleTransform = new Transform(Vector3.Origin, new Vector3(1, 0, 0).Unitized(), 0);
             var liftedPoints = jitteredVertices.Select(p => simpleTransform.OfPoint(p));
-            var liftedHull = ConvexHull.Frame3DPoints(liftedPoints, Vector3.XAxis);
+            var liftedHull = ConvexHull.FromPointsInPlane(liftedPoints, Vector3.XAxis);
             Assert.True(liftedHull.IsAlmostEqualTo(flatHull.TransformedPolygon(simpleTransform)), "The lifted hull doesn't match the transformed flat hull.");
 
             // Complex transform can be used for visual inspection of the resulting frame.
             var complexTransform = new Transform(Vector3.Origin, new Vector3(1, 2, 0).Unitized(), 0);
             var complexLiftedPoints = jitteredVertices.Select(p => complexTransform.OfPoint(p));
-            var complexLiftedHull = ConvexHull.Frame3DPoints(complexLiftedPoints, Vector3.XAxis);
-            var complexliftedHull2 = ConvexHull.Frame3DPoints(complexLiftedPoints, new Vector3(1, 1, 0)); ;
+            var complexLiftedHull = ConvexHull.FromPointsInPlane(complexLiftedPoints, Vector3.XAxis);
+            var complexliftedHull2 = ConvexHull.FromPointsInPlane(complexLiftedPoints, new Vector3(1, 1, 0)); ;
 
             this.Model.AddElement(L);
             this.Model.AddElement(new ModelCurve(flatHull, new Material("aqua", Colors.Aqua)));

--- a/Elements/test/ConvexHullTests.cs
+++ b/Elements/test/ConvexHullTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Elements.Analysis;
 using Elements.Geometry;
 using Xunit;
@@ -24,6 +25,46 @@ namespace Elements.Tests
             };
             var hull = ConvexHull.FromPoints(points);
             Assert.Equal(4, hull.Segments().Length);
+        }
+
+        [Fact]
+        public void ConvexHullFrom3DCloudAndNormal()
+        {
+            Name = nameof(ConvexHullFrom3DCloudAndNormal);
+            var L = Polygon.L(2, 4, 1).TransformedPolygon(new Transform().Moved(3, 4));
+            var jitteredVertices = L.Vertices.ToList();
+
+            jitteredVertices[0] = new Transform().Moved(0, 0, 0.1).OfPoint(jitteredVertices[0]);
+            jitteredVertices[1] = new Transform().Moved(0, 0, -0.1).OfPoint(jitteredVertices[1]);
+
+            var flatHull = ConvexHull.FromPoints(L.Vertices);
+
+            var jitteredHull = ConvexHull.Frame3DPoints(jitteredVertices, Vector3.ZAxis);
+            Assert.True(jitteredHull.IsAlmostEqualTo(flatHull), "Jittered flat hull doesn't match original hull.");
+
+            // Simple transform allows simple polygon comparison for Assert.
+            var simpleTransform = new Transform(Vector3.Origin, new Vector3(1, 0, 0).Unitized(), 0);
+            var liftedPoints = jitteredVertices.Select(p => simpleTransform.OfPoint(p));
+            var liftedHull = ConvexHull.Frame3DPoints(liftedPoints, Vector3.XAxis);
+            Assert.True(liftedHull.IsAlmostEqualTo(flatHull.TransformedPolygon(simpleTransform)), "The lifted hull doesn't match the transformed flat hull.");
+
+            // Complex transform can be used for visual inspection of the resulting frame.
+            var complexTransform = new Transform(Vector3.Origin, new Vector3(1, 2, 0).Unitized(), 0);
+            var complexLiftedPoints = jitteredVertices.Select(p => complexTransform.OfPoint(p));
+            var complexLiftedHull = ConvexHull.Frame3DPoints(complexLiftedPoints, Vector3.XAxis);
+            var complexliftedHull2 = ConvexHull.Frame3DPoints(complexLiftedPoints, new Vector3(1, 1, 0)); ;
+
+            this.Model.AddElement(L);
+            this.Model.AddElement(new ModelCurve(flatHull, new Material("aqua", Colors.Aqua)));
+            this.Model.AddElement(new ModelCurve(jitteredHull, new Material("cobalt", Colors.Cobalt)));
+            this.Model.AddElements(CylinderAtPoints(complexLiftedPoints));
+            this.Model.AddElement(new ModelCurve(complexLiftedHull, new Material("cobalt", Colors.Cobalt)));
+            this.Model.AddElement(new ModelCurve(complexliftedHull2, new Material("crimson", Colors.Crimson)));
+        }
+
+        private static IEnumerable<Mass> CylinderAtPoints(IEnumerable<Vector3> liftedPoints)
+        {
+            return liftedPoints.Select(p => new Mass(new Circle(p, 0.02).ToPolygon(), 0.02) { Transform = new Transform(0, 0, p.Z), Material = BuiltInMaterials.XAxis });
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- I have a collection of points in 3D and I want their bounding frame in 3D along a given perspective line.

DESCRIPTION:
- Add the Frame3DPoints to ConvexHull static classes.
- tweak `Average` Vector3 extension to operation on IEnumerable.

TESTING:
- run the test to view the resulting glb.  (viewing in our viewer lets you use ortho mode which can be nice)
![image](https://user-images.githubusercontent.com/5872187/131920542-b0ba7323-641c-4638-b66e-8ccf39c38971.png)
![image](https://user-images.githubusercontent.com/5872187/131920568-82983682-571b-4b9d-b2f0-9bb9bb46a020.png)

  
FUTURE WORK:
- There is probably a more performant way to do this, but we can optimize later if necessary.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/660)
<!-- Reviewable:end -->
