### PR TITLE
Remove vertices near curve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `Elements.Search.DirectionComparer`
 - `Elements.Search.Network<T>`
 - `ModelExtensions.AllElementsOfType<T>(this Dictionary<string, Model> models, string modelName)`
+- `Polygon RemoveVerticesNearCurve(Curve curve, double tolerance)`
 
 ### Changed
 

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -1584,6 +1584,12 @@ namespace Elements.Geometry
             {
                 switch (curve)
                 {
+                    case Polygon polygon:
+                        if (v.DistanceTo(polygon, out _) > tolerance)
+                        {
+                            newVertices.Add(v);
+                        }
+                        break;
                     case Polyline polyline:
                         if (v.DistanceTo(polyline, out _) > tolerance)
                         {
@@ -1895,7 +1901,7 @@ namespace Elements.Geometry
         /// Construct a clipper path from a Polygon.
         /// </summary>
         /// <param name="p"></param>
-        /// <param name="tolerance">Optional tolerance value. If converting back to a polygon after the operation, be sure to use the same tolerance value.Optional tolerance value. If converting back to a polygon after the operation, be sure to use the same tolerance value.</param>
+        /// <param name="tolerance">Optional tolerance value. If converting back to a polygon after the operation, be sure to use the same tolerance value.</param>
         /// <returns></returns>
         internal static List<IntPoint> ToClipperPath(this Polygon p, double tolerance = Vector3.EPSILON)
         {

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -1573,6 +1573,37 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Trim vertices from a polygon that lie near a given curve.
+        /// </summary>
+        /// <param name="curve">The curve used to trim the polygon</param>
+        /// <param name="tolerance">Optional tolerance value.</param>
+        public Polygon RemoveVerticesNearCurve(Curve curve, double tolerance = Vector3.EPSILON)
+        {
+            var newVertices = new List<Vector3>(this.Vertices.Count);
+            foreach (var v in Vertices)
+            {
+                switch (curve)
+                {
+                    case Polyline polyline:
+                        if (v.DistanceTo(polyline, out _) > tolerance)
+                        {
+                            newVertices.Add(v);
+                        }
+                        break;
+                    case Line line:
+                        if (v.DistanceTo(line, out _) > tolerance)
+                        {
+                            newVertices.Add(v);
+                        }
+                        break;
+                    default:
+                        throw new ArgumentException("Unknown curve type for removing vertices.  Only Polygon, Polyline, and Line are supported.");
+                }
+            }
+            return new Polygon(newVertices);
+        }
+
+        /// <summary>
         /// Remove collinear points from this Polygon.
         /// </summary>
         /// <returns>New Polygon without collinear points.</returns>
@@ -1864,7 +1895,7 @@ namespace Elements.Geometry
         /// Construct a clipper path from a Polygon.
         /// </summary>
         /// <param name="p"></param>
-        /// <param name="tolerance">Optional tolerance value. If converting back to a polygon after the operation, be sure to use the same tolerance value.</param>
+        /// <param name="tolerance">Optional tolerance value. If converting back to a polygon after the operation, be sure to use the same tolerance value.Optional tolerance value. If converting back to a polygon after the operation, be sure to use the same tolerance value.</param>
         /// <returns></returns>
         internal static List<IntPoint> ToClipperPath(this Polygon p, double tolerance = Vector3.EPSILON)
         {

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -155,11 +155,11 @@ namespace Elements.Geometry
 
                     if (d1 > 0 && d2.ApproximatelyEquals(0, precision))
                     {
-                        // The first point is inside and 
+                        // The first point is inside and
                         // the second point is on the plane.
                         newVertices.Add(v1);
 
-                        // Insert what will become a duplicate 
+                        // Insert what will become a duplicate
                         // vertex.
                         newVertices.Add(v2);
                         continue;
@@ -217,9 +217,9 @@ namespace Elements.Geometry
 
                     for (var i = 0; i < intersections.Count - 1; i += 2)
                     {
-                        // Because we'll have duplicate vertices where an 
+                        // Because we'll have duplicate vertices where an
                         // intersection is on the plane, we need to choose
-                        // which one to use. This follows the rule of finding 
+                        // which one to use. This follows the rule of finding
                         // the one whose index is closer to the first index used.
                         var a = ClosestIndexOf(newVertices, intersections[i], i);
                         var b = ClosestIndexOf(newVertices, intersections[i + 1], a);
@@ -256,9 +256,9 @@ namespace Elements.Geometry
 
         /// <summary>
         /// Intersect this polygon with the provided polygon in 3d.
-        /// Unlike other methods that do 2d intersection, this method is able to 
+        /// Unlike other methods that do 2d intersection, this method is able to
         /// calculate intersections in 3d by doing planar intersections and
-        /// 3D containment checks. If you are looking for 2d intersection, use the 
+        /// 3D containment checks. If you are looking for 2d intersection, use the
         /// Polygon.Intersects(Plane plane, ...) method.
         /// </summary>
         /// <param name="polygon">The target polygon.</param>
@@ -267,7 +267,7 @@ namespace Elements.Geometry
         /// <param name="sort">Should the resulting intersections be sorted along
         /// the plane?</param>
         /// <returns>True if this polygon intersect the provided polygon, otherwise false.
-        /// The result collection may have duplicate vertices where intersection 
+        /// The result collection may have duplicate vertices where intersection
         /// with a vertex occurs as there is one intersection associated with each
         /// edge attached to the vertex.</returns>
         private bool Intersects3d(Polygon polygon, out List<Vector3> result, bool sort = true)
@@ -338,13 +338,13 @@ namespace Elements.Geometry
         /// Does this polygon intersect the provided plane?
         /// </summary>
         /// <param name="plane">The intersection plane.</param>
-        /// <param name="results">A collection of intersection results 
+        /// <param name="results">A collection of intersection results
         /// sorted along the plane.</param>
         /// <param name="distinct">Should the intersection results that
         /// are returned be distinct?</param>
         /// <param name="sort">Should the intersection results be sorted
         /// along the plane?</param>
-        /// <returns>True if the plane intersects the polygon, 
+        /// <returns>True if the plane intersects the polygon,
         /// otherwise false.</returns>
         public bool Intersects(Plane plane, out List<Vector3> results, bool distinct = true, bool sort = true)
         {
@@ -828,9 +828,9 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Trim the polygon with a collection of polygons that intersect it 
-        /// in 3d. Portions of the intersected polygon on the "outside" 
-        /// (normal-facing side) of the trimming polygons will remain. 
+        /// Trim the polygon with a collection of polygons that intersect it
+        /// in 3d. Portions of the intersected polygon on the "outside"
+        /// (normal-facing side) of the trimming polygons will remain.
         /// Portions inside the trimming polygons will be discarded.
         /// </summary>
         /// <param name="polygons">The trimming polygons.</param>
@@ -841,9 +841,9 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Trim the polygon with a collection of polygons that intersect it 
-        /// in 3d. Portions of the intersected polygon on the "outside" 
-        /// (normal-facing side) of the trimming polygons will remain. 
+        /// Trim the polygon with a collection of polygons that intersect it
+        /// in 3d. Portions of the intersected polygon on the "outside"
+        /// (normal-facing side) of the trimming polygons will remain.
         /// Portions inside the trimming polygons will be discarded.
         /// </summary>
         /// <param name="polygons">The trimming polygons.</param>
@@ -879,7 +879,7 @@ namespace Elements.Geometry
                     throw new Exception("The trim could not be completed. One of the trimming planes was coplanar with the polygon being trimmed.");
                 }
 
-                // Add a results collection for each polygon. 
+                // Add a results collection for each polygon.
                 // This may or may not have results in it after processing.
                 results[i] = new List<Vector3>();
 

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -1075,6 +1075,43 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
+        public void RemoveVerticesNearCurve()
+        {
+            this.Name = nameof(RemoveVerticesNearCurve);
+
+            var square = Polygon.Rectangle(1, 1);
+            var upperLeftLine = new Line(new Vector3(-1, 0), new Vector3(0, 1));
+            var remainderPoly1 = square.RemoveVerticesNearCurve(upperLeftLine);
+
+            Assert.Equal(new[] {
+                new Vector3(-0.5, -0.5),
+                new Vector3(0.5, -0.5),
+                new Vector3(0.5, 0.5)
+            }, remainderPoly1.Vertices);
+
+            var lowerRightLine = new Line(new Vector3(0, -1), new Vector3(1, 0));
+
+            var house = new Polygon(new[] {
+                new Vector3(0,0),
+                new Vector3(0,2),
+                new Vector3(2,2),
+                new Vector3(2,0),
+                new Vector3(1.5,0),
+                new Vector3(1.5,1),
+                new Vector3(0.5,1),
+                new Vector3(0.5,0)
+            });
+
+            var doorOutline = Polygon.Rectangle(new Vector3(0.5, 0), new Vector3(1.5, 1));
+
+
+            var houseOutline = house.RemoveVerticesNearCurve(doorOutline);
+
+            var expectedhouseOutline = Polygon.Rectangle(new Vector3(), new Vector3(2, 2));
+            Assert.True(expectedhouseOutline.IsAlmostEqualTo(houseOutline, ignoreWinding: true));
+        }
+
+        [Fact]
         public void SharedSegments_ConcentricCircles_NoResults()
         {
             var a = new Circle(new Vector3(), 1).ToPolygon();


### PR DESCRIPTION
BACKGROUND:
- We want to trim a door cutout from a wall perimeter leaving the "whole" wall perimeter behind.

DESCRIPTION:
- Add a method that will allow you to trim vertices from a polygon given an input curve, accepts lines, polylines and polygons.

TESTING:
- The tests work for trimming corners from a square and also trimming a door-like notch from a polygon.
  
FUTURE WORK:
- We may want to support other curve types in the future, it's easiest if they implement `DistanceTo()`

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/663)
<!-- Reviewable:end -->
