### PR TITLE
AdaptiveGrid.SubtractBox cover the corner case when result is between two tolerances

### DIFF
--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -205,8 +205,15 @@ namespace Elements.Spatial.AdaptiveGrid
                     var edgeLine = edge.GetGeometry();
                     List<Vector3> intersections;
                     edgeLine.Intersects(box, out intersections);
+                    // If no intersection found than outside point is exactly within tolerance.
+                    // But since Intersects works on 0 to 1 range internally, mismatch in interpretation
+                    // is possible. Cut the edge in this case.
+                    if (intersections.Count == 0 )
+                    {
+                        edgesToDelete.Add(edge);
+                    }
                     // Intersections are sorted from the start point.
-                    if (intersections.Count == 1)
+                    else if (intersections.Count == 1)
                     {
                         //Need to find which end is inside the box. 
                         //If none - we just touched the corner

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -208,7 +208,7 @@ namespace Elements.Spatial.AdaptiveGrid
                     // If no intersection found than outside point is exactly within tolerance.
                     // But since Intersects works on 0 to 1 range internally, mismatch in interpretation
                     // is possible. Cut the edge in this case.
-                    if (intersections.Count == 0 )
+                    if (intersections.Count == 0)
                     {
                         edgesToDelete.Add(edge);
                     }

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -98,5 +98,26 @@ namespace Elements.Tests
             Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(5, 5, 1), out _));
             Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(5, 4.9, 1), out _));
         }
+
+        [Fact]
+        public void AdaptiveGridSubtractBoxSmallDifference()
+        {
+            var adaptiveGrid = new AdaptiveGrid(new Transform());
+            var polygon = Polygon.Rectangle(new Vector3(-41, -51), new Vector3(-39, -49));
+
+            var points = new List<Vector3>();
+            points.Add(new Vector3(-40, -49.9, 1));
+            points.Add(new Vector3(-40, -49.80979, 1));
+
+            adaptiveGrid.AddFromExtrude(polygon, Vector3.ZAxis, 2, points);
+            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(-40, -49.9, 1), out _));
+            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(-40, -49.9, 2), out _));
+
+            var box = new BBox3(new Vector3(-40.2, -50.190211303259034, 0),
+                                new Vector3(-39.8, -49.809788696740966, 2));
+            adaptiveGrid.SubtractBox(box);
+            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(-40, -49.9, 1), out _));
+            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(-40, -49.9, 2), out _));
+        }
     }
 }


### PR DESCRIPTION

BACKGROUND:
- In Aliaxis workflow bug was discovered then routing algorithm could not correctly go down in the grid if points, algorithm should travel though is inside obstacle. It should have go though closest line but  instead it had broken  path, partially through obstacle. 

DESCRIPTION:
- This fixes bug when grid sometimes doesn't remove vertices inside obstacles

TESTING:
- Added AdaptiveGridSubtractBoxSmallDifference test to cover this exact case

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/672)
<!-- Reviewable:end -->
