### PR TITLE
Wall from profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - `Identity.AddOverrideIdentity(this Element element, dynamic overrideObject)`
 
 ### Changed
+- Wall doesn't have Height or Profile any more
+- WallByProfile deprecates `Profile` and has methods/constructors to use Perimeter and Openings only.
+
 
 ### Fixed
 

--- a/Elements.Serialization.IFC/src/Serialization/IFC/IFCExtensions.cs
+++ b/Elements.Serialization.IFC/src/Serialization/IFC/IFCExtensions.cs
@@ -235,6 +235,7 @@ namespace Elements.Serialization.IFC
                 var newOpening = new Opening(profile,
                                              (IfcLengthMeasure)s.Depth,
                                              (IfcLengthMeasure)s.Depth,
+                                             default(Vector3),
                                              solidTransform,
                                              null,
                                              false,
@@ -320,13 +321,13 @@ namespace Elements.Serialization.IFC
         // private static IfcOpeningElement ToIfcOpeningElement(this Opening opening, IfcRepresentationContext context, Document doc, IfcObjectPlacement parent)
         // {
         //     // var sweptArea = opening.Profile.Perimeter.ToIfcArbitraryClosedProfileDef(doc);
-        //     // We use the Z extrude direction because the direction is 
+        //     // We use the Z extrude direction because the direction is
         //     // relative to the local placement, which is a transform at the
         //     // beam's end with the Z axis pointing along the direction.
 
         //     // var extrudeDirection = opening.ExtrudeDirection.ToIfcDirection();
         //     // var position = new Transform().ToIfcAxis2Placement3D(doc);
-        //     // var solid = new IfcExtrudedAreaSolid(sweptArea, position, 
+        //     // var solid = new IfcExtrudedAreaSolid(sweptArea, position,
         //     //     extrudeDirection, new IfcPositiveLengthMeasure(opening.ExtrudeDepth));
 
         //     var extrude= (Extrude)opening.Geometry.SolidOperations[0];

--- a/Elements.Serialization.IFC/src/Serialization/IFC/IFCExtensions.cs
+++ b/Elements.Serialization.IFC/src/Serialization/IFC/IFCExtensions.cs
@@ -233,9 +233,9 @@ namespace Elements.Serialization.IFC
                 var profile = (Polygon)s.SweptArea.ToCurve();
 
                 var newOpening = new Opening(profile,
-                                             (IfcLengthMeasure)s.Depth,
-                                             (IfcLengthMeasure)s.Depth,
                                              default(Vector3),
+                                             (IfcLengthMeasure)s.Depth,
+                                             (IfcLengthMeasure)s.Depth,
                                              solidTransform,
                                              null,
                                              false,

--- a/Elements.Serialization.IFC/test/IFCTests.cs
+++ b/Elements.Serialization.IFC/test/IFCTests.cs
@@ -107,7 +107,7 @@ namespace Elements.IFC.Tests
                 this.output.WriteLine(e);
             }
 
-            Assert.Equal(7, newModel.Elements.Values.Count);
+            Assert.Equal(model.Elements.Values.Count, newModel.Elements.Values.Count);
             newModel.ToGlTF(ConstructGlbPath("IfcFloor2"));
         }
 

--- a/Elements/src/Floor.cs
+++ b/Elements/src/Floor.cs
@@ -107,6 +107,7 @@ namespace Elements
         public override void UpdateRepresentations()
         {
             this.Representation.SolidOperations.Clear();
+            this.Openings.ForEach(o => o.UpdateRepresentations());
             this.Representation.SolidOperations.Add(new Extrude(this.Profile, this.Thickness, Vector3.ZAxis, false));
         }
 

--- a/Elements/src/Floor.cs
+++ b/Elements/src/Floor.cs
@@ -122,7 +122,7 @@ namespace Elements
         /// <param name="depthBack">The depth of the opening along the opening's -Z axis.</param>
         public Opening AddOpening(double width, double height, double x, double y, double depthFront = 1, double depthBack = 1)
         {
-            var o = new Opening(Polygon.Rectangle(width, height), depthFront, depthBack, transform: new Transform(x, y, 0));
+            var o = new Opening(Polygon.Rectangle(width, height), depthFront, depthBack, new Transform(x, y, 0));
             this.Openings.Add(o);
             return o;
         }
@@ -137,7 +137,7 @@ namespace Elements
         /// <param name="depthBack">The depth of the opening along the opening's -Z axis.</param>
         public Opening AddOpening(Polygon perimeter, double x, double y, double depthFront = 1, double depthBack = 1)
         {
-            var o = new Opening(perimeter, depthFront, depthBack, transform: new Transform(x, y, 0));
+            var o = new Opening(perimeter, depthFront, depthBack, new Transform(x, y, 0));
             this.Openings.Add(o);
             return o;
         }

--- a/Elements/src/Floor.cs
+++ b/Elements/src/Floor.cs
@@ -121,7 +121,7 @@ namespace Elements
         /// <param name="depthBack">The depth of the opening along the opening's -Z axis.</param>
         public Opening AddOpening(double width, double height, double x, double y, double depthFront = 1, double depthBack = 1)
         {
-            var o = new Opening(Polygon.Rectangle(width, height), depthFront, depthBack, new Transform(x, y, 0));
+            var o = new Opening(Polygon.Rectangle(width, height), depthFront, depthBack, transform: new Transform(x, y, 0));
             this.Openings.Add(o);
             return o;
         }
@@ -136,7 +136,7 @@ namespace Elements
         /// <param name="depthBack">The depth of the opening along the opening's -Z axis.</param>
         public Opening AddOpening(Polygon perimeter, double x, double y, double depthFront = 1, double depthBack = 1)
         {
-            var o = new Opening(perimeter, depthFront, depthBack, new Transform(x, y, 0));
+            var o = new Opening(perimeter, depthFront, depthBack, transform: new Transform(x, y, 0));
             this.Openings.Add(o);
             return o;
         }

--- a/Elements/src/GeometricElement.cs
+++ b/Elements/src/GeometricElement.cs
@@ -131,8 +131,8 @@ namespace Elements
                                                       .Where(op => op.IsVoid == true)
                                                       .Select(op => op._solid.ToCsg().Transform(o.Transform.ToMatrix4x4())))).ToArray();
             }
-            // Don't try CSG booleans if we only have one one solid.
-            if (solids.Count() == 1)
+            // Don't try CSG booleans if we only have one one solid and no voids.
+            if (solids.Count() == 1 && voids.Count() == 0)
             {
                 csg = solids.First();
             }

--- a/Elements/src/Geometry/Solids/SolidExtensions.cs
+++ b/Elements/src/Geometry/Solids/SolidExtensions.cs
@@ -37,7 +37,15 @@ namespace Elements.Geometry.Solids
         internal static Plane Plane(this Face f)
         {
             var v = f.Outer.Edges.Select(e => e.Vertex.Point).ToList();
-            return new Plane(v[0], v.NormalFromPlanarWoundPoints());
+            var n = v.NormalFromPlanarWoundPoints();
+            if (n.Length() > 0)
+            {
+                return new Plane(v[0], v.NormalFromPlanarWoundPoints());
+            }
+            else
+            {
+                throw new System.Exception("Could not get valid normal from points.");
+            }
         }
 
         internal static Csg.Solid ToCsg(this Solid solid)

--- a/Elements/src/Opening.cs
+++ b/Elements/src/Opening.cs
@@ -40,13 +40,25 @@ namespace Elements
         public Vector3 Normal { get; set; }
 
         /// <summary>
+        /// Create an opening normal to the ZAxis.
+        /// </summary>
+        public Opening(Polygon perimeter,
+                       double depthFront = 1.0,
+                       double depthBack = 1.0,
+                       Transform transform = null,
+                       Representation representation = null,
+                       bool isElementDefinition = false,
+                       Guid id = default(Guid),
+                       string name = null) : this(perimeter, Vector3.ZAxis, depthFront, depthBack, transform, representation, isElementDefinition, id, name) { }
+
+        /// <summary>
         /// Create an opening.
         /// </summary>
         [JsonConstructor]
         public Opening(Polygon perimeter,
+                       Vector3 normal,
                        double depthFront = 1.0,
                        double depthBack = 1.0,
-                       Vector3 normal = default(Vector3),
                        Transform transform = null,
                        Representation representation = null,
                        bool isElementDefinition = false,

--- a/Elements/src/Opening.cs
+++ b/Elements/src/Opening.cs
@@ -35,12 +35,18 @@ namespace Elements
         public double DepthBack { get; set; }
 
         /// <summary>
+        /// The normal direction of the opening.
+        /// </summary>
+        public Vector3 Normal { get; set; }
+
+        /// <summary>
         /// Create an opening.
         /// </summary>
         [JsonConstructor]
         public Opening(Polygon perimeter,
                        double depthFront = 1.0,
                        double depthBack = 1.0,
+                       Vector3 normal = default(Vector3),
                        Transform transform = null,
                        Representation representation = null,
                        bool isElementDefinition = false,
@@ -52,6 +58,14 @@ namespace Elements
                                                   id != default(Guid) ? id : Guid.NewGuid(),
                                                   name)
         {
+            if (normal == default(Vector3))
+            {
+                Normal = Vector3.ZAxis; // legacy openings don't have a normal and assume normal is the Z axis
+            }
+            else
+            {
+                Normal = normal.Unitized();
+            }
             this.Perimeter = perimeter;
             this.DepthBack = depthBack;
             this.DepthFront = depthFront;
@@ -65,11 +79,11 @@ namespace Elements
             this.Representation.SolidOperations.Clear();
             if (this.DepthFront > 0)
             {
-                this.Representation.SolidOperations.Add(new Extrude(this.Perimeter, this.DepthFront, Vector3.ZAxis, true));
+                this.Representation.SolidOperations.Add(new Extrude(this.Perimeter, this.DepthFront, Normal, true));
             }
             if (this.DepthBack > 0)
             {
-                this.Representation.SolidOperations.Add(new Extrude(this.Perimeter, this.DepthBack, Vector3.ZAxis.Negate(), true));
+                this.Representation.SolidOperations.Add(new Extrude(this.Perimeter, this.DepthBack, Normal.Negate(), true));
             }
         }
     }

--- a/Elements/src/StandardWall.cs
+++ b/Elements/src/StandardWall.cs
@@ -85,7 +85,7 @@ namespace Elements
         public Opening AddOpening(double width, double height, double x, double y, double depthFront = 1.0, double depthBack = 1.0)
         {
             var openingTransform = GetOpeningTransform(x, y);
-            var o = new Opening(Polygon.Rectangle(width, height), depthFront, depthBack, openingTransform);
+            var o = new Opening(Polygon.Rectangle(width, height), depthFront, depthBack, transform: openingTransform);
             this.Openings.Add(o);
             return o;
         }
@@ -101,7 +101,7 @@ namespace Elements
         public Opening AddOpening(Polygon perimeter, double x, double y, double depthFront = 1.0, double depthBack = 1.0)
         {
             var openingTransform = GetOpeningTransform(x, y);
-            var o = new Opening(perimeter, depthFront, depthBack, openingTransform);
+            var o = new Opening(perimeter, depthFront, depthBack, transform: openingTransform);
             this.Openings.Add(o);
             return o;
         }

--- a/Elements/src/StandardWall.cs
+++ b/Elements/src/StandardWall.cs
@@ -81,7 +81,7 @@ namespace Elements
 
         /// <summary>
         /// Add an Opening in the Wall. The Opening x and y sets the position relative to the Wall's Centerline.Start point
-        /// in the well elevation coordinate system.  The x and y will position the bottom left corner of the rectangular opening.
+        /// in the wall elevation coordinate system.  The x and y will position origin of the rectangular opening.
         /// </summary>
         /// <param name="width">The width of the opening.</param>
         /// <param name="height">The height of the opening.</param>
@@ -99,7 +99,7 @@ namespace Elements
 
         /// <summary>
         /// Add an Opening in the Wall. The Opening x and y sets the position relative to the Wall's Centerline.Start point
-        /// in the well elevation coordinate system.  The x and y will position the first point of the polygon opening.
+        /// in the wall elevation coordinate system.  The x and y will position the origin of the polygon opening.
         /// </summary>
         /// <param name="perimeter">The perimeter of the opening.</param>
         /// <param name="x">The distance to the origin of the perimeter opening along the center line of the wall.</param>

--- a/Elements/src/StandardWall.cs
+++ b/Elements/src/StandardWall.cs
@@ -24,6 +24,12 @@ namespace Elements
         public double Thickness { get; set; }
 
         /// <summary>
+        /// The height of the wall.
+        /// </summary>
+        public new double Height { get; protected set; }
+
+
+        /// <summary>
         /// Construct a wall along a line.
         /// </summary>
         /// <param name="centerLine">The center line of the wall.</param>

--- a/Elements/src/StandardWall.cs
+++ b/Elements/src/StandardWall.cs
@@ -80,7 +80,8 @@ namespace Elements
         }
 
         /// <summary>
-        /// Add an opening in the wall.
+        /// Add an Opening in the Wall. The Opening x and y sets the position relative to the Wall's Centerline.Start point
+        /// in the well elevation coordinate system.  The x and y will position the bottom left corner of the rectangular opening.
         /// </summary>
         /// <param name="width">The width of the opening.</param>
         /// <param name="height">The height of the opening.</param>
@@ -91,13 +92,14 @@ namespace Elements
         public Opening AddOpening(double width, double height, double x, double y, double depthFront = 1.0, double depthBack = 1.0)
         {
             var openingTransform = GetOpeningTransform(x, y);
-            var o = new Opening(Polygon.Rectangle(width, height), depthFront, depthBack, transform: openingTransform);
+            var o = new Opening(Polygon.Rectangle(width, height), depthFront, depthBack, openingTransform);
             this.Openings.Add(o);
             return o;
         }
 
         /// <summary>
-        /// Add an opening in the wall.
+        /// Add an Opening in the Wall. The Opening x and y sets the position relative to the Wall's Centerline.Start point
+        /// in the well elevation coordinate system.  The x and y will position the first point of the polygon opening.
         /// </summary>
         /// <param name="perimeter">The perimeter of the opening.</param>
         /// <param name="x">The distance to the origin of the perimeter opening along the center line of the wall.</param>
@@ -107,7 +109,7 @@ namespace Elements
         public Opening AddOpening(Polygon perimeter, double x, double y, double depthFront = 1.0, double depthBack = 1.0)
         {
             var openingTransform = GetOpeningTransform(x, y);
-            var o = new Opening(perimeter, depthFront, depthBack, transform: openingTransform);
+            var o = new Opening(perimeter, depthFront, depthBack, openingTransform);
             this.Openings.Add(o);
             return o;
         }

--- a/Elements/src/Wall.cs
+++ b/Elements/src/Wall.cs
@@ -15,13 +15,13 @@ namespace Elements
         /// <summary>
         /// The height of the wall.
         /// </summary>
-        [Obsolete]
+        [Obsolete("The height property on the Wall base class is obsolete, check the methods of an inherited class like StandardWall or WallByProfile.")]
         public double Height { get; protected set; }
 
         /// <summary>
         /// The profile of the wall.
         /// </summary>
-        [Obsolete]
+        [Obsolete("The profile property on the Wall base class is obsolete, check the methods of an inherited class like StandardWall or WallByProfile.")]
         public Profile Profile { get; protected set; }
 
         /// <summary>

--- a/Elements/src/Wall.cs
+++ b/Elements/src/Wall.cs
@@ -15,11 +15,13 @@ namespace Elements
         /// <summary>
         /// The height of the wall.
         /// </summary>
+        [Obsolete]
         public double Height { get; protected set; }
 
         /// <summary>
         /// The profile of the wall.
         /// </summary>
+        [Obsolete]
         public Profile Profile { get; protected set; }
 
         /// <summary>

--- a/Elements/src/WallByProfile.cs
+++ b/Elements/src/WallByProfile.cs
@@ -22,7 +22,7 @@ namespace Elements
         public double Thickness { get; set; }
 
         /// <summary>The perimeter of the wall's profile.  It is assumed to be in the same plane as the centerline, and will often be projected to that plane during internal operations.</summary>
-        [Newtonsoft.Json.JsonProperty("perimeter", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("Perimeter", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Polygon Perimeter { get; set; }
 
         /// <summary>The Centerline of the wall</summary>
@@ -70,6 +70,16 @@ namespace Elements
         public Profile GetProfile()
         {
             return new Profile(Perimeter, Openings.Select(o => o.Perimeter).ToList());
+        }
+
+        /// <summary>
+        /// The computed height of the wall.
+        /// </summary>
+        public double GetHeight()
+        {
+            var bottom = Math.Min(Centerline.Start.Z, Centerline.End.Z);
+            var top = Perimeter.Vertices.Max(v => v.Z);
+            return top - bottom;
         }
 
         /// <summary>

--- a/Elements/src/WallByProfile.cs
+++ b/Elements/src/WallByProfile.cs
@@ -12,16 +12,19 @@ namespace Elements
     [Newtonsoft.Json.JsonConverter(typeof(Elements.Serialization.JSON.JsonInheritanceConverter), "discriminator")]
     public class WallByProfile : Wall
     {
-        /// <summary>The profile, which includes openings that will be extruded.</summary>
+        /// <summary>The Profile, which includes Openings that will be extruded.</summary>
         [Newtonsoft.Json.JsonProperty("Profile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Obsolete("The Profile property is obsolete, use the GetProfile method to access a profile created from the perimeter and the openings.")]
         public new Profile Profile { get; set; }
 
-        /// <summary>The overall thickness of the wall</summary>
+        /// <summary>The overall thickness of the Wall</summary>
         [Newtonsoft.Json.JsonProperty("Thickness", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Thickness { get; set; }
 
-        /// <summary>The perimeter of the wall's profile.  It is assumed to be in the same plane as the centerline, and will often be projected to that plane during internal operations.</summary>
+        /// <summary>
+        /// The perimeter of the Wall's elevation.  It is assumed to be in the same Plane as the Centerline,
+        /// and will often be projected to that Plane during internal operations.
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("Perimeter", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Polygon Perimeter { get; set; }
 
@@ -43,6 +46,7 @@ namespace Elements
         /// <param name="id">The id of the wall.</param>
         /// <param name="name">The name of the wall.</param>
         [Newtonsoft.Json.JsonConstructor]
+        [Obsolete("Do not use.  This constructor is only preserved to maintain backwards compatibility upon serialization/deserialization.")]
         public WallByProfile(Polygon @perimeter,
                              Profile @profile,
                              double @thickness,
@@ -64,7 +68,7 @@ namespace Elements
         }
 
         /// <summary>
-        /// The profile of the wall computed from it's Perimeter and the openings.
+        /// The Profile of the Wall computed from its Perimeter and the Openings.
         /// </summary>
         /// <returns></returns>
         public Profile GetProfile()
@@ -73,7 +77,7 @@ namespace Elements
         }
 
         /// <summary>
-        /// The computed height of the wall.
+        /// The computed height of the Wall.
         /// </summary>
         public double GetHeight()
         {
@@ -83,9 +87,9 @@ namespace Elements
         }
 
         /// <summary>
-        /// Create a wall from a profile and thickness.  If a centerline is not include it will be
-        /// computed from the profile.  The profile will be projected to the
-        /// centerline plane, and used to find openings of the Wall.
+        /// Create a Wall from a Profile and thickness.  If centerline is not included it will be
+        /// computed from the Profile.  The Profile will be projected to the
+        /// centerline Plane, and used to find Openings of the Wall.
         /// </summary>
         public WallByProfile(Profile @profile,
                              double @thickness,
@@ -108,7 +112,7 @@ namespace Elements
             var perpendicularToWall = centerline.Direction().Cross(Vector3.ZAxis);
             foreach (var v in profile.Voids)
             {
-                var opening = new Opening(v, 1.1 * thickness, 1.1 * thickness, normal: perpendicularToWall);
+                var opening = new Opening(v, perpendicularToWall, 1.1 * thickness, 1.1 * thickness);
                 this.Openings.Add(opening);
             }
 
@@ -116,7 +120,7 @@ namespace Elements
             this.Centerline = @centerline;
         }
 
-        /// <summary>Update the geometric representation of this wall.</summary>
+        /// <summary>Update the geometric representation of this Wall.</summary>
         public override void UpdateRepresentations()
         {
             this.Representation.SolidOperations.Clear();
@@ -124,7 +128,7 @@ namespace Elements
             if (this.Profile != null)
             {
                 //TODO remove this geometry path once we completely delete the obsolete Profile property.
-                // to ensure the correct direction, we find the direction form a point on the polygon to the vertical plane of the centerline
+                // To ensure the correct direction, we find the direction from a point on the Polygon to the vertical plane of the Centerline
                 var point = Profile.Perimeter.Vertices.First();
                 var centerPlane = new Plane(Centerline.Start, Centerline.End, Centerline.End + Vector3.ZAxis);
                 var direction = new Line(point, point.Project(centerPlane)).Direction();

--- a/Elements/src/WallByProfile.cs
+++ b/Elements/src/WallByProfile.cs
@@ -14,11 +14,16 @@ namespace Elements
     {
         /// <summary>The profile, which includes openings that will be extruded.</summary>
         [Newtonsoft.Json.JsonProperty("Profile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Obsolete("The Profile property is obsolete, use the GetProfile method to access a profile created from the perimeter and the openings.")]
         public new Profile Profile { get; set; }
 
         /// <summary>The overall thickness of the wall</summary>
         [Newtonsoft.Json.JsonProperty("Thickness", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Thickness { get; set; }
+
+        /// <summary>The perimeter of the wall's profile.  It is assumed to be in the same plane as the centerline, and will often be projected to that plane during internal operations.</summary>
+        [Newtonsoft.Json.JsonProperty("perimeter", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Polygon Perimeter { get; set; }
 
         /// <summary>The Centerline of the wall</summary>
         [Newtonsoft.Json.JsonProperty("Centerline", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -27,7 +32,8 @@ namespace Elements
         /// <summary>
         /// Construct a wall by profile.
         /// </summary>
-        /// <param name="profile">The elevation of the wall.</param>
+        /// <param name="perimeter">The perimeter of the wall elevation.</param>
+        /// <param name="profile">This value should be left null.</param>
         /// <param name="thickness">The thickness of the wall.</param>
         /// <param name="centerline">The centerline of the wall.</param>
         /// <param name="transform">The transform of the wall.</param>
@@ -37,28 +43,43 @@ namespace Elements
         /// <param name="id">The id of the wall.</param>
         /// <param name="name">The name of the wall.</param>
         [Newtonsoft.Json.JsonConstructor]
-        public WallByProfile(Profile @profile,
+        public WallByProfile(Polygon @perimeter,
+                             Profile @profile,
                              double @thickness,
                              Line @centerline,
                              Transform @transform,
                              Material @material,
+                             List<Opening> @openings,
                              Representation @representation,
                              bool @isElementDefinition,
                              System.Guid @id,
                              string @name)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
+            this.Perimeter = @perimeter;
             this.Profile = @profile;
             this.Thickness = @thickness;
             this.Centerline = @centerline;
+            this.Openings.AddRange(@openings);
         }
 
         /// <summary>
-        /// Create a wall requiring only the profile, thickness and centerline.
+        /// The profile of the wall computed from it's Perimeter and the openings.
+        /// </summary>
+        /// <returns></returns>
+        public Profile GetProfile()
+        {
+            return new Profile(Perimeter, Openings.Select(o => o.Perimeter).ToList());
+        }
+
+        /// <summary>
+        /// Create a wall from a profile and thickness.  If a centerline is not include it will be
+        /// computed from the profile.  The profile will be projected to the
+        /// centerline plane, and used to find openings of the Wall.
         /// </summary>
         public WallByProfile(Profile @profile,
                              double @thickness,
-                             Line @centerline,
+                             Line @centerline = null,
                              Transform @transform = null,
                              Material @material = null,
                              Representation @representation = null,
@@ -70,8 +91,17 @@ namespace Elements
                    Guid.NewGuid(),
                    "Wall by Profile")
         {
+            var point = profile.Perimeter.Vertices.First();
+            var centerPlane = new Plane(centerline.Start, centerline.End, centerline.End + Vector3.ZAxis);
+            this.Perimeter = profile.Perimeter.Project(centerPlane);
 
-            this.Profile = @profile;
+            var perpendicularToWall = centerline.Direction().Cross(Vector3.ZAxis);
+            foreach (var v in profile.Voids)
+            {
+                var opening = new Opening(v, 1.1 * thickness, 1.1 * thickness, normal: perpendicularToWall);
+                this.Openings.Add(opening);
+            }
+
             this.Thickness = @thickness;
             this.Centerline = @centerline;
         }
@@ -81,12 +111,23 @@ namespace Elements
         {
             this.Representation.SolidOperations.Clear();
 
-            // to ensure the correct direction, we find the direction form a point on the polygon to the vertical plane of the centerline
-            var point = Profile.Perimeter.Vertices.First();
-            var centerPlane = new Plane(Centerline.Start, Centerline.End, Centerline.End + Vector3.ZAxis);
-            var direction = new Line(point, point.Project(centerPlane)).Direction();
+            if (this.Profile != null)
+            {
+                //TODO remove this geometry path once we completely delete the obsolete Profile property.
+                // to ensure the correct direction, we find the direction form a point on the polygon to the vertical plane of the centerline
+                var point = Profile.Perimeter.Vertices.First();
+                var centerPlane = new Plane(Centerline.Start, Centerline.End, Centerline.End + Vector3.ZAxis);
+                var direction = new Line(point, point.Project(centerPlane)).Direction();
 
-            this.Representation.SolidOperations.Add(new Extrude(this.Profile, this.Thickness, direction, false));
+                this.Representation.SolidOperations.Add(new Extrude(this.Profile, this.Thickness, direction, false));
+            }
+            else
+            {
+                var direction = Centerline.Direction().Cross(Vector3.ZAxis);
+                var shiftedProfile = GetProfile().Transformed(new Transform(direction.Negate() * Thickness / 2));
+
+                this.Representation.SolidOperations.Add(new Extrude(shiftedProfile, this.Thickness, direction, false));
+            }
         }
     }
 }

--- a/Elements/test/FloorTests.cs
+++ b/Elements/test/FloorTests.cs
@@ -11,7 +11,7 @@ namespace Elements.Tests
         {
             this.Name = "Elements_Floor";
 
-            // <example>            
+            // <example>
             // Create a floor with no elevation.
             var p = Polygon.L(10, 20, 5);
             var floor1 = new Floor(p, 0.1);
@@ -54,6 +54,14 @@ namespace Elements.Tests
             Assert.Equal(0.5, floor1.Elevation);
             Assert.Equal(0.1, floor1.Thickness);
             Assert.Equal(0.5, floor1.Transform.Origin.Z);
+
+            floor1.UpdateRepresentations();
+            Assert.Single(floor1.GetSolids());
+            Assert.Equal(25, floor1.GetFinalCsgFromSolids().Polygons.Count);
+
+            floor2.UpdateRepresentations();
+            Assert.Single(floor2.GetSolids());
+            Assert.Equal(8, floor2.GetFinalCsgFromSolids().Polygons.Count);
 
             this.Model.AddElements(new[] { floor1, floor2 });
         }

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -206,6 +206,19 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void NormalFromPlanarWoundPoints()
+        {
+            var points = new List<Vector3>() {
+                new Vector3(0,1,0),
+                new Vector3(0,1,1),
+                new Vector3(0,0,1),
+                new Vector3(0,0,0),
+            };
+            points.Reverse();
+            var normal = points.NormalFromPlanarWoundPoints();
+        }
+
+        [Fact]
         public void CCW()
         {
             var a = new Vector3();

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -216,6 +216,7 @@ namespace Elements.Tests
             };
             points.Reverse();
             var normal = points.NormalFromPlanarWoundPoints();
+            Assert.Equal(Vector3.XAxis.Negate(), normal);
         }
 
         [Fact]

--- a/Elements/test/WallTests.cs
+++ b/Elements/test/WallTests.cs
@@ -38,6 +38,30 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void WallByProfileFromProfileCreatesOpenings()
+        {
+            this.Name = nameof(WallByProfileFromProfileCreatesOpenings);
+
+            var boundary = new Polygon(new[] {  new Vector3(),
+                                                new Vector3(0,0,10),
+                                                new Vector3(0,10,10),
+                                                new Vector3(0,10,0) });
+            var window = new Polygon(new[] {new Vector3(0,2,2),
+                                            new Vector3(0,2,4),
+                                            new Vector3(0,4,4),
+                                            new Vector3(0,4,2)});
+            var wallProfile = new Profile(boundary, window);
+            var wall = new WallByProfile(wallProfile, 0.1, new Line(Vector3.Origin, new Vector3(0, 10)));
+
+            Assert.Single(wall.Openings);
+            Assert.Null(wall.Profile);
+            Assert.True(wall.GetProfile().Equals(wallProfile));
+
+            this.Model.AddElement(wall);
+            this.Model.AddElement(wall.Centerline);
+        }
+
+        [Fact]
         public void ZeroHeightThrows()
         {
             var a = Vector3.Origin;


### PR DESCRIPTION
BACKGROUND:
- We want to change walls to support a variety of diverse wall types and to improve the openings API.

DESCRIPTION:
- update floor tests to confirm opening behavior is unchanged.
- deprecate wall Height and Profile of Wall.
- add Perimeter to WallByProfile and update constructors.
- add a direction to opening to support openings that are vertical
- add a test for `NormalFromPlanarWoundPoints` wich wasn't the problem (opening normals was) but I figure doesn't hurt.


TESTING:
- WallByProfileFromProfile test produces a wall with an opening.
  
FUTURE WORK:
- More WallByProfile changes and opening tweaks are likely as I work with exporting from Revit.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/673)
<!-- Reviewable:end -->
