### PR TITLE
use content name instead of URL as rule name

### DIFF
--- a/Elements.Components/src/SpaceConfiguration.cs
+++ b/Elements.Components/src/SpaceConfiguration.cs
@@ -186,7 +186,7 @@ namespace Elements.Components
                 var closestAnchor = baseAnchors[anchorIndex];
                 var element = contentItem.ContentElement;
                 var offsetXform = contentItem.Transform.Concatenated(new Transform(anchor.Negate())).Concatenated(new Transform(anchor - closestAnchor));
-                rules.Add(new PositionPlacementRule(contentItem.Url, anchorIndex, element, offsetXform));
+                rules.Add(new PositionPlacementRule(contentItem.Name ?? contentItem.Url, anchorIndex, element, offsetXform));
             }
             return rules;
         }


### PR DESCRIPTION
BACKGROUND:
- @serenayl noticed that instances of content elements in hyparspace were named with their URLs

DESCRIPTION:
- Uses the content item's name, instead of its url, if present as the basis for the rule name, which ultimately becomes the instance name.

TESTING:
- I published a version of lounge layout on dev built against this version of elements.components, and verified that the name was correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/674)
<!-- Reviewable:end -->
