### PR TITLE
Add ModifyVertexAttributes func to GeometricElement

### DIFF
--- a/Elements/src/GeometricElement.cs
+++ b/Elements/src/GeometricElement.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Elements.Geometry;
 using Elements.Geometry.Solids;
 using Elements.Interfaces;
+using Newtonsoft.Json;
 
 namespace Elements
 {
@@ -27,6 +28,15 @@ namespace Elements
         /// <summary>When true, this element will act as the base definition for element instances, and will not appear in visual output.</summary>
         [Newtonsoft.Json.JsonProperty("IsElementDefinition", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool IsElementDefinition { get; set; } = false;
+
+        /// <summary>
+        /// A function used to colorize vertices of the object's mesh
+        /// during tesselation. Each vertex location is passed to the colorizer
+        /// as the object is tessellated. The resulting color will be blended
+        /// with the material's color.
+        /// </summary>
+        [JsonIgnore]
+        public Func<Vector3, Color> Colorize { get; set; }
 
         /// <summary>
         /// Create a geometric element.

--- a/Elements/src/Geometry/CsgExtensions.cs
+++ b/Elements/src/Geometry/CsgExtensions.cs
@@ -22,20 +22,20 @@ namespace Elements.Geometry
         /// Triangulate this csg and pack the triangulated data into buffers
         /// appropriate for use with gltf.
         /// </summary>
-        internal static GraphicsBuffers Tessellate(this Csg.Solid csg, bool mergeVertices = false)
+        internal static GraphicsBuffers Tessellate(this Csg.Solid csg, bool mergeVertices = false, Func<Vector3, Color> colorize = null)
         {
-            return Tessellate(new[] { csg }, mergeVertices);
+            return Tessellate(new[] { csg }, mergeVertices, colorize);
         }
 
         /// <summary>
         /// Triangulate a collection of CSGs and pack the triangulated data into
         /// buffers appropriate for use with gltf. 
         /// </summary>
-        internal static GraphicsBuffers Tessellate(this Csg.Solid[] csgs, bool mergeVertices = false)
+        internal static GraphicsBuffers Tessellate(this Csg.Solid[] csgs, bool mergeVertices = false, Func<Vector3, Color> colorize = null)
         {
             var buffers = new GraphicsBuffers();
 
-            Tessellate(csgs, buffers, mergeVertices);
+            Tessellate(csgs, buffers, mergeVertices, colorize);
             return buffers;
         }
 
@@ -43,7 +43,7 @@ namespace Elements.Geometry
         /// Triangulate a collection of CSGs and pack the triangulated data into
         /// a supplied buffers object. 
         /// </summary>
-        internal static void Tessellate(Csg.Solid[] csgs, IGraphicsBuffers buffers, bool mergeVertices = false)
+        internal static void Tessellate(Csg.Solid[] csgs, IGraphicsBuffers buffers, bool mergeVertices = false, Func<Vector3, Color> colorize = null)
         {
             (Vector3 U, Vector3 V) basis;
 
@@ -127,7 +127,15 @@ namespace Elements.Geometry
 
             foreach (var v in allVertices)
             {
-                buffers.AddVertex(v.Item1, v.Item2, v.Item3);
+                if (colorize != null)
+                {
+                    var color = colorize(v.Item1);
+                    buffers.AddVertex(v.Item1, v.Item2, v.Item3, color);
+                }
+                else
+                {
+                    buffers.AddVertex(v.Item1, v.Item2, v.Item3);
+                }
             }
         }
 

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -1266,7 +1266,7 @@ namespace Elements.Serialization.glTF
             else
             {
                 var csg = geometricElement.GetFinalCsgFromSolids();
-                buffers = csg.Tessellate(mergeVertices);
+                buffers = csg.Tessellate(mergeVertices, geometricElement.Colorize);
             }
 
             if (buffers.Vertices.Count == 0)

--- a/Elements/test/GeometricElementTests.cs
+++ b/Elements/test/GeometricElementTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Elements.Geometry;
 using Xunit;
@@ -48,6 +47,19 @@ namespace Elements.Tests
 
             Assert.Equal(panel.Area() * 2, mesh.Triangles.Sum(t => t.Area()), 5);
             Assert.Equal(panel.Area() * 2, meshTransformed.Triangles.Sum(t => t.Area()), 5);
+        }
+
+        [Fact]
+        public void Colorize()
+        {
+            this.Name = nameof(Colorize);
+            var height = 5.0;
+            var mass = new Mass(Polygon.L(2, 2, 1), height, BuiltInMaterials.Default);
+            mass.Colorize = (v) =>
+            {
+                return new Color(v.Z / height, v.Z / height, 1, 1);
+            };
+            this.Model.AddElement(mass);
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:

We don't currently have the ability to edit vertices generated on solid geometry. If we did, we could do things like re-color objects or add UV coordinates to generated geometry.

DESCRIPTION:
This PR adds the `ModifyVertexAttributes` func property to `GeometricElement` which is called during geometry generation and creation of graphics buffers, allowing the caller to inject vertex modification logic.

TESTING:
- How should a reviewer observe the behavior desired by this pull request?
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.
