### PR TITLE
generate empty constructors for element types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@
 - `Profile.Project(Plane)`
 
 ### Changed
+
 - Wall doesn't have Height or Profile any more.
 - WallByProfile deprecates `Profile` and has methods/constructors to use Perimeter and Openings only.
 - `Polygon.Area()` will now calculate the area of a polygon in 3D.
 - WallByProfile updated constructor options and `UpdateRepresentation` logic.
-
+- Code generation includes an empty constructor for generated types.
 
 ### Fixed
+
 - WallByProfile was failing to deserialize walls without openings.
 
 ## 0.9.4

--- a/Elements.CodeGeneration/src/Templates/Class.Constructor.Record.liquid
+++ b/Elements.CodeGeneration/src/Templates/Class.Constructor.Record.liquid
@@ -20,3 +20,11 @@
 this.{{property.PropertyName}} = @{{property.Name | safeidentifierlower}};
     {% endfor -%}
 }
+
+// Empty constructor
+{% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}()
+{% if HasInheritance -%}
+    : base()
+{% endif -%}
+{
+}

--- a/Elements/src/Element.cs
+++ b/Elements/src/Element.cs
@@ -17,7 +17,7 @@ namespace Elements
         /// <param name="id">The unique id of the element.</param>
         /// <param name="name">The name of the element.</param>
         [Newtonsoft.Json.JsonConstructor]
-        public Element(System.Guid @id, string @name)
+        public Element(System.Guid @id = default(Guid), string @name = null)
         {
             this._id = @id;
             this._name = @name;


### PR DESCRIPTION
BACKGROUND:
- Changes to schemas, such as adding/removing properties, can introduce breaking code changes because they alter the constructor signature
- Element types often have a large number of optional or inessential parameters, and setting them all is tedious

DESCRIPTION:
- auto-generates an additional, empty constructor for code-generated element types. 

TESTING:
- I created a function with a range of complex element_types references, ("https://prod-api.hypar.io/schemas/DrainableRoofSection",
"https://prod-api.hypar.io/schemas/TiledCeilingConfiguration",
"https://prod-api.hypar.io/schemas/ProgramRequirement") including those inheriting from other elements. I verified that I could create elements with a `new Foo() {...properties}` syntax, and that the function would execute successfully. 
  
FUTURE WORK:
- Required properties will throw an exception at runtime / serialization time if they are absent. Error messages are reasonably clear, but it might be worth finding a way to make this more intuitive, or alerting the user somehow before we hit serialization. Or do away with required properties altogether. 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

