### PR TITLE
use material id for name instead of name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Change default for `useReferenceOrientation` when generating content catalogs.
 - `Position.ToVectorMeters` now requires a `relativeToOrigin` Position, so that it will actually give meaningful measurements in meters.
+- glTF generation now uses material IDs instead of names for material names, to prevent collisions.
 
 ### Fixed
 
@@ -83,7 +84,7 @@
 
 - Deduplicate catalog names during code generation.
 - Fix some issues with code generation and deserialization of `Vector3` and `Mesh` types.
-- Fixed an issue where GLTFs would occasionally be generated with incorrect vertex normals.
+- Fixed an issue where gLTFs would occasionally be generated with incorrect vertex normals.
 
 ## 0.9.2
 

--- a/Elements/src/BuiltInMaterials.cs
+++ b/Elements/src/BuiltInMaterials.cs
@@ -8,101 +8,84 @@ namespace Elements
     /// </summary>
     public static class BuiltInMaterials
     {
-        private static Material _glass = new Material("glass", new Color(1.0f, 1.0f, 1.0f, 0.2f), 1.0f, 1.0f, null, false, false, id: Guid.Parse("28c5c2b1-d65c-4c46-8689-d651f50f07e7"));
-        private static Material _steel = new Material("steel", new Color(0.6f, 0.5f, 0.5f, 1.0f), 0.1f, 0.4f, null, false, false, id: Guid.Parse("13bef3c8-64c5-4283-a471-2571239cc14d"));
-        private static Material _default = new Material("default", new Color(1.0f, 1.0f, 1.0f, 1.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("9babb829-9b96-4e73-97f4-9658d4d6c31c"));
-        private static Material _concrete = new Material("concrete", new Color(0.5f, 0.5f, 0.5f, 1.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("e7492160-3d9c-4fde-83a9-618abd381169"));
-        private static Material _mass = new Material("mass", new Color(0.5f, 0.5f, 1.0f, 0.2f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("323c9495-d84e-4c57-b5af-a2e9fd1a8a19"));
-        private static Material _wood = new Material("wood", new Color(224f / 255f, 206f / 255f, 155f / 255f, 1.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("f6fa27a7-dbe1-4bcf-823c-3d6d3c34876d"));
-        private static Material _black = new Material("black", new Color(0.0f, 0.0f, 0.0f, 1.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("7298d643-9049-4a2b-960d-ae775b50fd80"));
-        private static Material _edges = new Material("edges", new Color(0.1f, 0.1f, 0.1f, 1.0f), 0.0f, 0.0f, null, true, false, id: Guid.Parse("d0c7a361-f32f-4fae-bd39-c1abc56b4b6f"));
-        private static Material _points = new Material("points", new Color(1.0f, 0.0f, 0.0f, 1.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("9f4c28e7-a140-4b4a-85f5-3551d468e921"));
-        private static Material _topography = new Material("topography", new Color(0.59f, 0.59f, 0.39f, 1.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("ab838896-b7ef-43a2-afac-f3294153b3db"));
-        private static Material _edgesHighlighted = new Material("edge_highlighted", new Color(1.0f, 1.0f, 0.0f, 1.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("43bbbd67-bb4d-4f66-a69b-40b5ae772db6"));
-        private static Material _void = new Material("void", new Color(Colors.Lime.Red, Colors.Lime.Green, Colors.Lime.Blue, 0.1f), 0.1f, 0.1f, null, false, false, id: Guid.Parse("f616193d-6cca-42bc-b0d8-ccdc4f457693"));
-        private static Material _xAxis = new Material("X", new Color(1.0f, 0.0f, 0.0f, 1.0f), 0.1f, 0.1f, null, true, false, id: Guid.Parse("a7059e89-d331-401b-9cd9-9f77b281f068"));
-        private static Material _yAxis = new Material("Y", new Color(0.0f, 1.0f, 0.0f, 1.0f), 0.1f, 0.1f, null, true, false, id: Guid.Parse("30ab5b47-7ef8-4376-98c1-8d58f3c61c5f"));
-        private static Material _zAxis = new Material("Z", new Color(0.0f, 0.0f, 1.0f, 1.0f), 0.1f, 0.1f, null, true, false, id: Guid.Parse("0dd0b2da-f4ca-47c5-a50e-6d4f8b044c36"));
-        private static Material _trans = new Material("trans", new Color(0.0f, 0.0f, 0.0f, 0.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("0af9722a-3bbc-4731-aaff-1d023e02b573"));
-
         /// <summary>
         /// Glass.
         /// </summary>
-        public static Material Glass => _glass;
+        public static Material Glass { get; } = new Material("glass", new Color(1.0f, 1.0f, 1.0f, 0.2f), 1.0f, 1.0f, null, false, false, id: Guid.Parse("28c5c2b1-d65c-4c46-8689-d651f50f07e7"));
 
         /// <summary>
         /// Steel.
         /// </summary>
-        public static Material Steel => _steel;
+        public static Material Steel { get; } = new Material("steel", new Color(0.6f, 0.5f, 0.5f, 1.0f), 0.1f, 0.4f, null, false, false, id: Guid.Parse("13bef3c8-64c5-4283-a471-2571239cc14d"));
 
         /// <summary>
         /// The default material.
         /// </summary>
-        public static Material Default => _default;
+        public static Material Default { get; } = new Material("default", new Color(1.0f, 1.0f, 1.0f, 1.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("9babb829-9b96-4e73-97f4-9658d4d6c31c"));
 
         /// <summary>
         /// Concrete.
         /// </summary>
-        public static Material Concrete = _concrete;
+        public static Material Concrete { get; } = new Material("concrete", new Color(0.5f, 0.5f, 0.5f, 1.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("e7492160-3d9c-4fde-83a9-618abd381169"));
 
         /// <summary>
         /// Default material used to represent masses.
         /// </summary>
-        public static Material Mass => _mass;
+        public static Material Mass { get; } = new Material("mass", new Color(0.5f, 0.5f, 1.0f, 0.2f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("323c9495-d84e-4c57-b5af-a2e9fd1a8a19"));
 
         /// <summary>
         /// Wood.
         /// </summary>
-        public static Material Wood => _wood;
+        public static Material Wood { get; } = new Material("wood", new Color(224f / 255f, 206f / 255f, 155f / 255f, 1.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("f6fa27a7-dbe1-4bcf-823c-3d6d3c34876d"));
 
         /// <summary>
         /// Black
         /// </summary>
-        public static Material Black => _black;
+        public static Material Black { get; } = new Material("black", new Color(0.0f, 0.0f, 0.0f, 1.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("7298d643-9049-4a2b-960d-ae775b50fd80"));
 
         /// <summary>
         /// Edges
         /// </summary>
-        public static Material Edges => _edges;
+        public static Material Edges { get; } = new Material("edges", new Color(0.1f, 0.1f, 0.1f, 1.0f), 0.0f, 0.0f, null, true, false, id: Guid.Parse("d0c7a361-f32f-4fae-bd39-c1abc56b4b6f"));
 
         /// <summary>
         /// Points
         /// </summary>
-        public static Material Points => _points;
+        public static Material Points { get; } = new Material("points", new Color(1.0f, 0.0f, 0.0f, 1.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("9f4c28e7-a140-4b4a-85f5-3551d468e921"));
 
         /// <summary>
         /// Topography
         /// </summary>
-        public static Material Topography => _topography;
+        public static Material Topography { get; } = new Material("topography", new Color(0.59f, 0.59f, 0.39f, 1.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("ab838896-b7ef-43a2-afac-f3294153b3db"));
 
         /// <summary>
         /// Edges Highlighted
         /// </summary>
-        public static Material EdgesHighlighted => _edgesHighlighted;
+        public static Material EdgesHighlighted { get; } = new Material("edge_highlighted", new Color(1.0f, 1.0f, 0.0f, 1.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("43bbbd67-bb4d-4f66-a69b-40b5ae772db6"));
 
         /// <summary>
         /// Void
         /// </summary>
-        public static Material Void => _void;
+        public static Material Void { get; } = new Material("void", new Color(Colors.Lime.Red, Colors.Lime.Green, Colors.Lime.Blue, 0.1f), 0.1f, 0.1f, null, false, false, id: Guid.Parse("f616193d-6cca-42bc-b0d8-ccdc4f457693"));
 
         /// <summary>
         /// X Axis
         /// </summary>
-        public static Material XAxis => _xAxis;
+        public static Material XAxis { get; } = new Material("X", new Color(1.0f, 0.0f, 0.0f, 1.0f), 0.1f, 0.1f, null, true, false, id: Guid.Parse("a7059e89-d331-401b-9cd9-9f77b281f068"));
 
         /// <summary>
         /// Y Axis
         /// </summary>
-        public static Material YAxis => _yAxis;
+        public static Material YAxis { get; } = new Material("Y", new Color(0.0f, 1.0f, 0.0f, 1.0f), 0.1f, 0.1f, null, true, false, id: Guid.Parse("30ab5b47-7ef8-4376-98c1-8d58f3c61c5f"));
 
         /// <summary>
         /// Z Axis
         /// </summary>
-        public static Material ZAxis => _zAxis;
+        public static Material ZAxis { get; } = new Material("Z", new Color(0.0f, 0.0f, 1.0f, 1.0f), 0.1f, 0.1f, null, true, false, id: Guid.Parse("0dd0b2da-f4ca-47c5-a50e-6d4f8b044c36"));
 
         /// <summary>
         /// Fully transparent material.
         /// </summary>
-        public static Material Trans => _trans;
+        public static Material Trans { get; } = new Material("trans", new Color(0.0f, 0.0f, 0.0f, 0.0f), 0.0f, 0.0f, null, false, false, id: Guid.Parse("0af9722a-3bbc-4731-aaff-1d023e02b573"));
     }
 }

--- a/Elements/src/Material.cs
+++ b/Elements/src/Material.cs
@@ -142,7 +142,7 @@ namespace Elements
                         bool repeatTexture = true,
                         string normalTexture = null,
                         bool interpolateTexture = true,
-                        Guid id = default(Guid)) :
+                        Guid id = default) :
             this(color,
                  specularFactor,
                  glossinessFactor,
@@ -152,7 +152,7 @@ namespace Elements
                  repeatTexture,
                  normalTexture,
                  interpolateTexture,
-                 id != default(Guid) ? id : Guid.NewGuid(),
+                 id != default ? id : Guid.NewGuid(),
                  name)
         { }
 
@@ -162,8 +162,7 @@ namespace Elements
         /// <param name="obj"></param>
         public override bool Equals(object obj)
         {
-            var m = obj as Material;
-            if (m == null)
+            if (!(obj is Material m))
             {
                 return false;
             }

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -855,7 +855,7 @@ namespace Elements.Serialization.glTF
                     }
                     var id = $"{GetNextId()}_edge";
                     var gb = lineSet.ToGraphicsBuffers(false);
-                    gltf.AddPointsOrLines(id, buffer, bufferViews, accessors, materialIndexMap[BuiltInMaterials.Edges.Name], gb, MeshPrimitive.ModeEnum.LINES, meshes, nodes, null);
+                    gltf.AddPointsOrLines(id, buffer, bufferViews, accessors, materialIndexMap[BuiltInMaterials.Edges.Id.ToString()], gb, MeshPrimitive.ModeEnum.LINES, meshes, nodes, null);
                 }
             }
 
@@ -1074,7 +1074,7 @@ namespace Elements.Serialization.glTF
                 var mc = (ModelCurve)e;
                 var id = $"{e.Id}_curve";
                 var gb = mc.ToGraphicsBuffers(true);
-                gltf.AddPointsOrLines(id, buffer, bufferViews, accessors, materialIndexMap[mc.Material.Name], gb, MeshPrimitive.ModeEnum.LINES, meshes, nodes, mc.Transform);
+                gltf.AddPointsOrLines(id, buffer, bufferViews, accessors, materialIndexMap[mc.Material.Id.ToString()], gb, MeshPrimitive.ModeEnum.LINES, meshes, nodes, mc.Transform);
             }
 
             if (e is ModelPoints)
@@ -1084,7 +1084,7 @@ namespace Elements.Serialization.glTF
                 {
                     var id = $"{e.Id}_point";
                     var gb = mp.ToGraphicsBuffers();
-                    gltf.AddPointsOrLines(id, buffer, bufferViews, accessors, materialIndexMap[mp.Material.Name], gb, MeshPrimitive.ModeEnum.POINTS, meshes, nodes, mp.Transform);
+                    gltf.AddPointsOrLines(id, buffer, bufferViews, accessors, materialIndexMap[mp.Material.Id.ToString()], gb, MeshPrimitive.ModeEnum.POINTS, meshes, nodes, mp.Transform);
                 }
             }
 
@@ -1095,7 +1095,7 @@ namespace Elements.Serialization.glTF
                 {
                     var id = $"{e.Id}_arrow";
                     var gb = ma.ToGraphicsBuffers();
-                    gltf.AddPointsOrLines(id, buffer, bufferViews, accessors, materialIndexMap[ma.Material.Name], gb, MeshPrimitive.ModeEnum.LINES, meshes, nodes, ma.Transform);
+                    gltf.AddPointsOrLines(id, buffer, bufferViews, accessors, materialIndexMap[ma.Material.Id.ToString()], gb, MeshPrimitive.ModeEnum.LINES, meshes, nodes, ma.Transform);
                 }
             }
 

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -147,7 +147,7 @@ namespace Elements.Serialization.glTF
 
             foreach (var material in materials)
             {
-                if (materialDict.ContainsKey(material.Name))
+                if (materialDict.ContainsKey(material.Id.ToString()))
                 {
                     continue;
                 }
@@ -160,7 +160,7 @@ namespace Elements.Serialization.glTF
                 m.PbrMetallicRoughness.MetallicFactor = 1.0f;
                 m.DoubleSided = material.DoubleSided;
 
-                m.Name = material.Name;
+                m.Name = material.Id.ToString();
 
                 if (material.Unlit)
                 {
@@ -644,7 +644,7 @@ namespace Elements.Serialization.glTF
 
             var accessors = new List<Accessor>();
 
-            var meshId = gltf.AddTriangleMesh("mesh", buffer, bufferViews, accessors, materials[BuiltInMaterials.Default.Name], gbuffers, null, meshes);
+            var meshId = gltf.AddTriangleMesh("mesh", buffer, bufferViews, accessors, materials[BuiltInMaterials.Default.Id.ToString()], gbuffers, null, meshes);
 
             NodeUtilities.CreateNodeForMesh(meshId, nodes, null);
 
@@ -670,7 +670,7 @@ namespace Elements.Serialization.glTF
                 // Draw standard edges
                 var id = $"{100000}_curve";
                 var gb = vertices.ToArray(vertices.Count).ToGraphicsBuffers(false);
-                gltf.AddPointsOrLines(id, buffer, bufferViews, accessors, materials[BuiltInMaterials.Edges.Name], gb, MeshPrimitive.ModeEnum.LINES, meshes, nodes, null);
+                gltf.AddPointsOrLines(id, buffer, bufferViews, accessors, materials[BuiltInMaterials.Edges.Id.ToString()], gb, MeshPrimitive.ModeEnum.LINES, meshes, nodes, null);
             }
 
             if (verticesHighlighted.Count > 0)
@@ -678,7 +678,7 @@ namespace Elements.Serialization.glTF
                 // Draw highlighted edges
                 var id = $"{100001}_curve";
                 var gb = verticesHighlighted.ToArray(verticesHighlighted.Count).ToGraphicsBuffers(false);
-                gltf.AddPointsOrLines(id, buffer, bufferViews, accessors, materials[BuiltInMaterials.EdgesHighlighted.Name], gb, MeshPrimitive.ModeEnum.LINES, meshes, nodes, null);
+                gltf.AddPointsOrLines(id, buffer, bufferViews, accessors, materials[BuiltInMaterials.EdgesHighlighted.Id.ToString()], gb, MeshPrimitive.ModeEnum.LINES, meshes, nodes, null);
             }
 
             var buff = new glTFLoader.Schema.Buffer();
@@ -918,7 +918,7 @@ namespace Elements.Serialization.glTF
                                                     bool drawEdges,
                                                     bool mergeVertices = false)
         {
-            var materialName = BuiltInMaterials.Default.Name;
+            var materialId = BuiltInMaterials.Default.Id.ToString();
             int meshId = -1;
 
             if (e is GeometricElement)
@@ -980,7 +980,7 @@ namespace Elements.Serialization.glTF
                                                                 meshElementMap,
                                                                 lines,
                                                                 drawEdges,
-                                                                materialName,
+                                                                materialId,
                                                                 ref meshId,
                                                                 content,
                                                                 mergeVertices);
@@ -993,7 +993,7 @@ namespace Elements.Serialization.glTF
                 else
                 {
                     var geometricElement = (GeometricElement)e;
-                    materialName = geometricElement.Material.Name;
+                    materialId = geometricElement.Material.Id.ToString();
 
                     meshId = ProcessGeometricRepresentation(e,
                                                             ref gltf,
@@ -1006,7 +1006,7 @@ namespace Elements.Serialization.glTF
                                                             meshElementMap,
                                                             lines,
                                                             drawEdges,
-                                                            materialName,
+                                                            materialId,
                                                             ref meshId,
                                                             geometricElement,
                                                             mergeVertices);
@@ -1117,7 +1117,7 @@ namespace Elements.Serialization.glTF
                                      buffer,
                                      bufferViews,
                                      accessors,
-                                     materialIndexMap[materialName],
+                                     materialIndexMap[materialId],
                                      gbuffers,
                                      null,
                                      meshes);
@@ -1194,7 +1194,7 @@ namespace Elements.Serialization.glTF
                                                            Dictionary<Guid, List<int>> meshElementMap,
                                                            List<Vector3> lines,
                                                            bool drawEdges,
-                                                           string materialName,
+                                                           string materialId,
                                                            ref int meshId,
                                                            GeometricElement geometricElement,
                                                            bool mergeVertices = false)
@@ -1214,7 +1214,7 @@ namespace Elements.Serialization.glTF
             {
                 meshId = ProcessSolidsAsCSG(geometricElement,
                                     e.Id.ToString(),
-                                    materialName,
+                                    materialId,
                                     ref gltf,
                                     ref materialIndexMap,
                                     ref buffers,
@@ -1243,7 +1243,7 @@ namespace Elements.Serialization.glTF
 
         private static int ProcessSolidsAsCSG(GeometricElement geometricElement,
                                       string id,
-                                      string materialName,
+                                      string materialId,
                                       ref Gltf gltf,
                                       ref Dictionary<string, int> materials,
                                       ref List<byte> buffer,
@@ -1278,7 +1278,7 @@ namespace Elements.Serialization.glTF
                                         buffer,
                                         bufferViews,
                                         accessors,
-                                        materials[materialName],
+                                        materials[materialId],
                                         buffers,
                                         null,
                                         meshes);


### PR DESCRIPTION
BACKGROUND:
- gltf materials are keyed by name. This can cause errors like https://github.com/hypar-io/Elements/issues/460, and complicates mapping from materials in a model to the materials in the gltf.

DESCRIPTION:
- Changes our GLTF generation to utilize material ids instead of material names

TESTING:
- I built a function with this branch, and verified that materials still rendered correctly and had appropriate ids. 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/683)
<!-- Reviewable:end -->
