### PR TITLE
make polyline placement rule overridable

### DIFF
--- a/Elements.Components/src/Rules/PolylinePlacementRule.cs
+++ b/Elements.Components/src/Rules/PolylinePlacementRule.cs
@@ -70,7 +70,7 @@ namespace Elements.Components
         /// Construct a set of elements from this rule for a given definition.
         /// </summary>
         /// <param name="definition">The definition to instantiate.</param>
-        public List<Element> Instantiate(ComponentDefinition definition)
+        public virtual List<Element> Instantiate(ComponentDefinition definition)
         {
             var transformedCurves = new List<Element>();
             List<Vector3> newVertices = TransformPolyline(this, definition);


### PR DESCRIPTION
I needed to override the behavior of Instantiate in a derived class, so I have to mark it virtual.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/684)
<!-- Reviewable:end -->
