### PR TITLE
Use colorization when SkipCSGUnion is true

### DIFF
--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -1261,7 +1261,7 @@ namespace Elements.Serialization.glTF
                 // skip CSG unions. In this case, we tessellate all solids
                 // individually, and do no booleaning. Voids are also ignored.
                 var solids = geometricElement.GetSolids();
-                buffers = solids.Tessellate(mergeVertices);
+                buffers = solids.Tessellate(mergeVertices, geometricElement.ModifyVertexAttributes);
             }
             else
             {


### PR DESCRIPTION
BACKGROUND:
- When skip CSG unions is _true_ we still should be able to modify vertex attributes

DESCRIPTION:
- Added passing `geometricElement.ModifyVertexAttributes` to the Tesselate method when CSG unions are skipped

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/689)
<!-- Reviewable:end -->
