### PR TITLE
Grid2d change tolerance used for GetTrimmedGeometry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 - `Position.ToVectorMeters` now requires a `relativeToOrigin` Position, so that it will actually give meaningful measurements in meters.
 - glTF generation now uses material IDs instead of names for material names, to prevent collisions.
 - Line.PointAt does not round input values near 0 or 1 anymore.
+- `Polygon` constructor throws error if there are less than 3 vertices provided.
+- Decrease intersection tolerance for Grid2d polygon splitting.
 
 ### Fixed
 

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -33,7 +33,7 @@ namespace Elements.Geometry
                 }
 
                 this.Vertices = Vector3.RemoveSequentialDuplicates(this.Vertices, true);
-                
+
                 if (this.Vertices.Count < 3)
                 {
                     throw new ArgumentException("The polygon could not be created. At least 3 vertices are required.");

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -33,6 +33,12 @@ namespace Elements.Geometry
                 }
 
                 this.Vertices = Vector3.RemoveSequentialDuplicates(this.Vertices, true);
+                
+                if (this.Vertices.Count < 3)
+                {
+                    throw new ArgumentException("The polygon could not be created. At least 3 vertices are required.");
+                }
+
                 var segments = Polygon.SegmentsInternal(this.Vertices);
                 Polyline.CheckSegmentLengthAndThrow(segments);
                 var t = this.Vertices.ToTransform();

--- a/Elements/src/Spatial/Grid2d.cs
+++ b/Elements/src/Spatial/Grid2d.cs
@@ -711,7 +711,8 @@ namespace Elements.Spatial
                 return new[] { GetCellGeometry() };
             }
             Polygon baseRect = GetBaseRectangleTransformed();
-            var trimmedRect = Polygon.Intersection(new[] { baseRect }, boundariesInGridSpace);
+            var trimmedRect = Polygon.Intersection(new[] { baseRect },
+                boundariesInGridSpace, PolygonIntersectionTolerance);
             if (trimmedRect != null && trimmedRect.Count() > 0)
             {
                 return fromGrid.OfPolygons(trimmedRect);
@@ -773,7 +774,8 @@ namespace Elements.Spatial
             {
                 return true;
             }
-            var trimmedRect = Polygon.Intersection(new[] { baseRect }, boundariesInGridSpace);
+            var trimmedRect = Polygon.Intersection(new[] { baseRect },
+                boundariesInGridSpace, PolygonIntersectionTolerance);
             if (trimmedRect == null || trimmedRect.Count < 1) { return false; }
             if (trimmedRect.Count > 1) { return true; }
             return !trimmedRect[0].IsAlmostEqualTo(baseRect, Vector3.EPSILON);
@@ -988,6 +990,17 @@ namespace Elements.Spatial
         /// We pass along a much smaller tolerance when we run our line extensions for Grid2d.
         /// </summary>
         private const double ExtensionTolerance = Vector3.EPSILON * Vector3.EPSILON;
+
+        /// <summary>
+        /// Intersection returns quantized distances with step of tolerance.
+        /// If intersection region is one EPSILON wide it's highly unstable:
+        /// 4.00001 - 4 = 9.9999999996214228E-06 but 4 - 3.99999 = 1.0000000000065512E-05.
+        /// And so, such region may be cut off by Intersection - in this case the cell is just skipped.
+        /// But if number passed the tolerance test - chances are high it will fail after fromGrid
+        /// transformation is applied and then whole trimming process will fail.
+        /// To avloid unpredictable behavior double tolerance is used.
+        /// </summary>
+        private const double PolygonIntersectionTolerance = Vector3.EPSILON * 2;
 
         /// <summary>
         /// Modifies a list of lines intended to represent uv guides in place to hit the bounds.

--- a/Elements/src/Spatial/Grid2d.cs
+++ b/Elements/src/Spatial/Grid2d.cs
@@ -998,7 +998,7 @@ namespace Elements.Spatial
         /// And so, such region may be cut off by Intersection - in this case the cell is just skipped.
         /// But if number passed the tolerance test - chances are high it will fail after fromGrid
         /// transformation is applied and then whole trimming process will fail.
-        /// To avloid unpredictable behavior double tolerance is used.
+        /// To avoid unpredictable behavior double tolerance is used.
         /// </summary>
         private const double PolygonIntersectionTolerance = Vector3.EPSILON * 2;
 

--- a/Elements/test/Grid2dTests.cs
+++ b/Elements/test/Grid2dTests.cs
@@ -542,6 +542,5 @@ namespace Elements.Tests
             }
             Assert.Equal(3, cellBoundaries.Where(cb => cb.Any()).Count());
         }
-
     }
 }

--- a/Elements/test/Grid2dTests.cs
+++ b/Elements/test/Grid2dTests.cs
@@ -516,5 +516,32 @@ namespace Elements.Tests
                 Assert.True(trimmed.Count() == 0);
             }
         }
+
+        [Fact]
+        public void RotateGridWithClosePointDoNotThrow()
+        {
+            var boundary = new Polygon
+            (
+                new[]
+                {
+                    new Vector3(),
+                    new Vector3(3.998, 0.0),
+                    new Vector3(4 , 2),
+                    new Vector3(0.0, 1.998)
+                }
+            );
+
+            Transform t = new Transform(new Vector3(2, 0));
+            var grid = new Grid2d(boundary, t);
+            grid.SplitAtPoint(new Vector3(3.998, 0.01));
+
+            List<Curve[]> cellBoundaries = new List<Curve[]>();
+            foreach (var cell in grid.GetCells())
+            {
+                cellBoundaries.Add(cell.GetTrimmedCellGeometry());
+            }
+            Assert.Equal(3, cellBoundaries.Where(cb => cb.Any()).Count());
+        }
+
     }
 }


### PR DESCRIPTION
BACKGROUND:
- When working on Grid2d based on boundary that is not rectangular - getting trimmed geometry is failed completely sometimes.  Intersection returns quantized distances with step of tolerance.
If intersection region is one EPSILON wide it's highly unstable:
4.00001 - 4 = 9.9999999996214228E-06 but 4 - 3.99999 = 1.0000000000065512E-05.
And so, such region may be cut off by Intersection - in this case the cell is just skipped.
But if number passed the tolerance test - chances are high it will fail after fromGrid transformation is applied and then whole trimming process will fail.

 Also, since polygon doesn't check number of vertices where was other unstable behaviour:
-Polygon has RemoveSequentialDuplicates in constructor that removes points less than tolerance away.
- Then, if only 2 points left Polyline.CheckSelfIntersectionAndThrow may or may not fail. This function uses Vertices.ToTransform() that takes first and second points difference as local X and other points as local Y. Since there are only 2 points → only X axis is initiated in transformation. If 2 given points have only X difference - the code will pass all the checks, otherwise will produce an exception.

DESCRIPTION:
- Added Vertex number check to Polygon constructor to avoid late exceptions.
- Raised tolerance used in Intersects to avoid tolerance fluctuations. As alternative - we could add distance check to ToPolygon that works with Int points but it would be required only in the case if tolerance parameter is equal to EPSILON that makes code clunky.

TESTING:
- Added  RotateGridWithClosePointDoNotThrow test to show the case that failed before due to transformation of the grid

FUTURE WORK:
- Are any other places that uses Intersects need update?
- Other boolean operations?
 
REQUIRED:
- [ x] All changes are up to date in `CHANGELOG.md`. (Do we need to mention something)

COMMENTS:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/701)
<!-- Reviewable:end -->
