### PR TITLE
Don't bundle other language resources.

### DIFF
--- a/Elements.CodeGeneration/src/Elements.CodeGeneration.csproj
+++ b/Elements.CodeGeneration/src/Elements.CodeGeneration.csproj
@@ -12,13 +12,12 @@
         <PackageProjectUrl>https://github.com/hypar-io/elements</PackageProjectUrl>
         <RepositoryUrl>https://github.com/hypar-io/elements</RepositoryUrl>
         <Version>$(Version)</Version>
+        <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="NJsonSchema.CodeGeneration" Version="10.1.21" />
         <PackageReference Include="NJsonSchema.CodeGeneration.CSharp" Version="10.1.21" />
-        <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis" Version="3.11.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Elements/src/Elements.csproj
+++ b/Elements/src/Elements.csproj
@@ -11,6 +11,7 @@
     <PackageProjectUrl>https://github.com/hypar-io/elements</PackageProjectUrl>
     <RepositoryUrl>https://github.com/hypar-io/elements</RepositoryUrl>
     <Version>$(Version)</Version>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="glTF2Loader" Version="1.1.3-alpha" />

--- a/Elements/src/Geometry/Profiles/ParametricProfile.cs
+++ b/Elements/src/Geometry/Profiles/ParametricProfile.cs
@@ -14,6 +14,7 @@ namespace Elements.Geometry.Profiles
     /// </summary>
     public class ParametricProfile : Profile
     {
+        [ThreadStatic]
         private static Script<Polygon> _script;
         ScriptOptions _options;
         private readonly string _perimeterScript;


### PR DESCRIPTION
BACKGROUND:
We've recently noticed that the size of Elements build directory has started to increase, affecting the size of functions on Hypar. One major cause of this bloat is the inclusion of extra language resources related to the use of the `Microsoft.CodeAnalysis.Scripting` package used by the parametric profile.

DESCRIPTION:
This PR reduces the Elements published size from 22.3mb to 16.4mb by disabling the inclusion of satellite resources. Sorry Italy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/702)
<!-- Reviewable:end -->
