### PR TITLE
Intersect fix for Plane Normal Zero error

### DIFF
--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -297,6 +297,8 @@ namespace Elements.Geometry
             if (!(new[] { start1, end1, start2 }).AreCollinear())
             {
                 plane = new Plane(start1, end1, start2);
+                if (plane.Normal.IsZero())
+                    plane = new Plane(end1, start2, end2);
                 testpoint = end2;
 
             } // this only occurs in the rare case that the start point of the other line is collinear with this line (still need to generate a plane)

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -69,6 +69,24 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
+        public void Polyline_OffsetOnSide_threeSegment()
+        {
+            var line = new Polyline(new List<Vector3>()
+            {
+                new Vector3(13540, 430),
+                new Vector3(13540, -1240),
+                new Vector3(9840, -1240),
+                new Vector3(6914, -1190),
+            });
+
+            var polygons = line.OffsetOnSide(2, false);
+            Assert.Equal(3,polygons.Length);
+
+            // A rectangle extruded down from the original line.
+            Assert.Equal(new Vector3[] { new Vector3(13540, 430, 0), new Vector3(13538, 430, 0), new Vector3(13538, -1238, 0), new Vector3(13540, -1240, 0) }, polygons.First().Vertices);
+        }
+
+        [Fact]
         public void Polyline_OffsetOnSide_SingleSegmentFlipped()
         {
             var line = new Polyline(new List<Vector3>(){

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -82,7 +82,7 @@ namespace Elements.Geometry.Tests
             var polygons = line.OffsetOnSide(2, false);
             Assert.Equal(3,polygons.Length);
 
-            // A rectangle extruded down from the original line.
+            // A 3 segment line with the end segment endpoint almost parallel to the second line
             Assert.Equal(new Vector3[] { new Vector3(13540, 430, 0), new Vector3(13538, 430, 0), new Vector3(13538, -1238, 0), new Vector3(13540, -1240, 0) }, polygons.First().Vertices);
         }
 


### PR DESCRIPTION
BACKGROUND:
- Currently as 2 lines get close to parallel if using the first 3 points of a line the plane normal will be zero and you will get an error return.

DESCRIPTION:
- This performs a  simple check to see if the plane normal is zero and if so check the next 3 points between the two lines to get a plane.

TESTING:
- Run the test before using the fix then run the test after
  
FUTURE WORK:
- Potentially there could be other conditions where the plane normal is zero but hopefully this solves 99% of the use cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/712)
<!-- Reviewable:end -->
