### PR TITLE
Use a single buffer for a gridline

### DIFF
--- a/Elements/src/GridLine.cs
+++ b/Elements/src/GridLine.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Elements.Geometry;
 
 namespace Elements
@@ -40,27 +41,18 @@ namespace Elements
             id = $"{this.Id}_gridline";
             mode = glTFLoader.Schema.MeshPrimitive.ModeEnum.LINES;
             graphicsBuffers = new List<GraphicsBuffers>();
-
-            var line = new ModelCurve(this.Line);
-            graphicsBuffers.Add(line.ToGraphicsBuffers(true));
-
             var dir = this.Line.Direction();
-
-            if (ExtensionBeginning > 0)
+            var line = new Line(this.Line.Start - dir * ExtensionBeginning, this.Line.End + dir * ExtensionEnd);
+            var center = this.Line.Start - dir * (ExtensionBeginning + Radius);
+            var normal = Vector3.ZAxis;
+            if (normal.Dot(dir) > 1 - Vector3.EPSILON)
             {
-                var extensionBeginning = new ModelCurve(new Line(this.Line.Start, this.Line.Start - dir * ExtensionBeginning));
-                graphicsBuffers.Add(extensionBeginning.ToGraphicsBuffers(true));
+                normal = Vector3.XAxis;
             }
-
-            if (ExtensionEnd > 0)
-            {
-                var extensionEnd = new ModelCurve(new Line(this.Line.End, this.Line.End + dir * ExtensionEnd));
-                graphicsBuffers.Add(extensionEnd.ToGraphicsBuffers(true));
-            }
-
             var circle = new Circle(Radius);
-            circle.Center = this.Line.Start - dir * (ExtensionBeginning + Radius);
-            graphicsBuffers.Add(new ModelCurve(circle).ToGraphicsBuffers(true));
+            var circleVertexTransform = new Transform(center, dir, normal);
+            var renderVertices = circle.RenderVertices().Select(v => circleVertexTransform.OfPoint(v)).Union(line.RenderVertices()).ToList();
+            graphicsBuffers.Add(renderVertices.ToGraphicsBuffers(true));
             return true;
         }
     }

--- a/Elements/test/GridLineTests.cs
+++ b/Elements/test/GridLineTests.cs
@@ -17,12 +17,23 @@ namespace Elements.Tests.Examples
         {
             this.Name = "Elements_GridLines";
 
-            var gridline = new GridLine();
-            gridline.Name = "A";
-            gridline.Line = new Line(new Vector3(), new Vector3(25, 25, 0));
-            gridline.Material = new Material("Red", new Color(1, 0, 0, 1));
+            var gridline = new GridLine
+            {
+                Name = "A",
+                Line = new Line(new Vector3(), new Vector3(25, 25, 0)),
+                Material = new Material("Red", new Color(1, 0, 0, 1))
+            };
 
             this.Model.AddElement(gridline);
+
+            var verticalGridline = new GridLine
+            {
+                Name = "B",
+                Line = new Line(new Vector3(), new Vector3(0, 0, 25)),
+                Material = new Material("Green", new Color(0, 1, 0, 1))
+            };
+
+            this.Model.AddElements(gridline, verticalGridline);
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- I noticed while testing the new selectable gridlines that because it produces multiple buffers, each section of the grid would highlight / "select" individually. 

DESCRIPTION:
- Uses a single buffer for a gridline, so that it appears as a single selectable object.

TESTING:
- I ran the test and visualized the GLB to verify that it looked correct with a single buffer.
  
FUTURE WORK:
- In a case of multiple buffers, we might want to create some sort of a parent node in the glb so that multiple buffers can be treated as a single selectable object. 

