### PR TITLE
support for topography from mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - `HalfEdgeGraph.Construct(IEnumerable<Line> lines)`
 - `Polyline.Project(Plane plane)`
 - `new Mesh(Mesh mesh)`
--
+- `new Topography(Mesh mesh, Material material, Transform transform, Guid id, string name)`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
 - `Ceiling`
 - `GridLine`
 - `FitLine(IList<Point2d> points)`
+- `HalfEdgeGraph.Construct(IEnumerable<Line> lines)`
+- `Polyline.Project(Plane plane)`
+- `new Mesh(Mesh mesh)`
+-
 
 ### Changed
 
@@ -40,6 +44,7 @@
 - Decrease intersection tolerance for Grid2d polygon splitting.
 - Added `includeCoincidenceAtEdge` parameter to `Line.Trim`.
 - Improved the logic of `AreCollinear` to utilize perpendicular distance for tolerance checks.
+- `BBox3` constructor now takes an `IEnumerable<Vector3>` instead of a `IList<Vector3>` as input.
 
 ### Fixed
 

--- a/Elements/src/Geometry/BBox3.cs
+++ b/Elements/src/Geometry/BBox3.cs
@@ -42,13 +42,13 @@ namespace Elements.Geometry
         /// Construct a bounding box from an array of points.
         /// </summary>
         /// <param name="points">The points which are contained within the bounding box.</param>
-        public BBox3(IList<Vector3> points)
+        public BBox3(IEnumerable<Vector3> points)
         {
             this.Min = new Vector3(double.MaxValue, double.MaxValue, double.MaxValue);
             this.Max = new Vector3(double.MinValue, double.MinValue, double.MinValue);
-            for (var i = 0; i < points.Count; i++)
+            foreach (Vector3 v in points)
             {
-                this.Extend(points[i]);
+                this.Extend(v);
             }
         }
 

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -1608,7 +1608,7 @@ namespace Elements.Geometry
         /// Project this polygon onto the plane.
         /// </summary>
         /// <param name="plane">The plane of the returned polygon.</param>
-        public Polygon Project(Plane plane)
+        public new Polygon Project(Plane plane)
         {
             var projected = new Vector3[this.Vertices.Count];
             for (var i = 0; i < projected.Length; i++)
@@ -2046,7 +2046,7 @@ namespace Elements.Geometry
             return polygons.Select(p => p.Reversed()).ToArray();
         }
 
-        internal static ContourVertex[] ToContourVertexArray(this Polygon poly)
+        internal static ContourVertex[] ToContourVertexArray(this Polyline poly)
         {
             var contour = new ContourVertex[poly.Vertices.Count];
             for (var i = 0; i < poly.Vertices.Count; i++)

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -755,6 +755,20 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Project this polyline onto the plane.
+        /// </summary>
+        /// <param name="plane">The plane of the returned polyline.</param>
+        public Polyline Project(Plane plane)
+        {
+            var projected = new Vector3[this.Vertices.Count];
+            for (var i = 0; i < projected.Length; i++)
+            {
+                projected[i] = this.Vertices[i].Project(plane);
+            }
+            return new Polyline(projected);
+        }
+
+        /// <summary>
         /// Identify any shared segments between two polylines.
         /// </summary>
         /// <param name="a">The first polyline to compare.</param>

--- a/Elements/src/Geometry/Solids/Solid.cs
+++ b/Elements/src/Geometry/Solids/Solid.cs
@@ -442,46 +442,10 @@ namespace Elements.Geometry.Solids
                 }
 
                 tess.Tessellate(WindingRule.Positive, LibTessDotNet.Double.ElementType.Polygons, 3);
-
-                var faceMesh = new Mesh();
-                (Vector3 U, Vector3 V) basis = (default(Vector3), default(Vector3));
-                Vector3 normal = default(Vector3);
-
-                for (var i = 0; i < tess.ElementCount; i++)
-                {
-                    var a = tess.Vertices[tess.Elements[i * 3]].Position.ToVector3();
-                    var b = tess.Vertices[tess.Elements[i * 3 + 1]].Position.ToVector3();
-                    var c = tess.Vertices[tess.Elements[i * 3 + 2]].Position.ToVector3();
-
-                    if (transform != null)
-                    {
-                        a = transform.OfPoint(a);
-                        b = transform.OfPoint(b);
-                        c = transform.OfPoint(c);
-                    }
-
-                    if (i == 0)
-                    {
-                        // Calculate the texture space basis vectors
-                        // from the first triangle. This is acceptable
-                        // for planar faces.
-                        // TODO: Update this when we support non-planar faces.
-                        // https://gamedev.stackexchange.com/questions/172352/finding-texture-coordinates-for-plane
-                        normal = f.Plane().Normal;
-                        basis = normal.ComputeDefaultBasisVectors();
-                    }
-
-                    var v1 = faceMesh.AddVertex(a, new UV(basis.U.Dot(a), basis.V.Dot(a)), normal, color: color);
-                    var v2 = faceMesh.AddVertex(b, new UV(basis.U.Dot(b), basis.V.Dot(b)), normal, color: color);
-                    var v3 = faceMesh.AddVertex(c, new UV(basis.U.Dot(c), basis.V.Dot(c)), normal, color: color);
-
-                    faceMesh.AddTriangle(v1, v2, v3);
-                }
+                var faceMesh = tess.ToMesh(transform, color, f.Plane().Normal);
                 mesh.AddMesh(faceMesh);
             }
         }
-
-
 
         /// <summary>
         /// Triangulate this solid and pack the triangulated data into buffers

--- a/Elements/src/Topography.cs
+++ b/Elements/src/Topography.cs
@@ -127,12 +127,13 @@ namespace Elements
             this.RowWidth = (int)Math.Sqrt(elevations.Length);
             this.CellWidth = width / (this.RowWidth - 1);
             this.CellHeight = this.CellWidth;
-
-            ConstructMeshesAndRegisterPropertyChangeHandlers();
+            ConstructMeshes();
+            RegisterPropertyChangeHandlers();
         }
 
         [JsonConstructor]
-        internal Topography(double[] elevations,
+        internal Topography(Mesh mesh,
+                            double[] elevations,
                             Vector3 origin,
                             int rowWidth,
                             double cellWidth,
@@ -151,41 +152,103 @@ namespace Elements
             this.RowWidth = rowWidth;
             this.CellWidth = cellWidth;
             this.CellHeight = cellHeight;
-
-            ConstructMeshesAndRegisterPropertyChangeHandlers();
+            if (mesh == null)
+            {
+                ConstructMeshes();
+            }
+            else
+            {
+                this.Mesh = mesh;
+                var bbox = new BBox3(mesh.Vertices.Select(v => v.Position));
+                this._minElevation = bbox.Min.Z;
+                this._maxElevation = bbox.Max.Z;
+            }
+            RegisterPropertyChangeHandlers();
         }
 
-        internal void ConstructMeshesAndRegisterPropertyChangeHandlers()
+        /// <summary>
+        /// Create a topography from a custom mesh. It is assumed that the mesh is an open mesh that's roughly parallel to the XY plane. 
+        /// </summary>
+        /// <param name="mesh">The mesh geometry of the topography.</param>
+        /// <param name="material">The topography's material.</param>
+        /// <param name="transform">The topography's transform.</param>
+        /// <param name="id">The topography's id.</param>
+        /// <param name="name">The topography's name.</param>
+        /// <returns></returns>
+        public Topography(Mesh mesh, Material material, Transform transform, Guid id, string name) : base(material,
+                                                                                                            transform,
+                                                                                                            false,
+                                                                                                            id,
+                                                                                                            name)
         {
-            GenerateMeshAndSetInternals();
-            double absoluteMinimumElevation = this.AbsoluteMinimumElevation.HasValue ? this.AbsoluteMinimumElevation.Value : this.MinElevation - this.DepthBelowMinimumElevation;
+            var newMesh = new Mesh(mesh);
+            var bbox = new BBox3(mesh.Vertices.Select(v => v.Position));
+            this._minElevation = bbox.Min.Z;
+            this._maxElevation = bbox.Max.Z;
+            double absoluteMinimumElevation = this.AbsoluteMinimumElevation ?? this.MinElevation - this.DepthBelowMinimumElevation;
+            var nakedBoundaries = mesh.GetNakedBoundaries();
+            var basePlane = new Plane((0, 0, absoluteMinimumElevation), (0, 0, 1));
+            foreach (var polygon in nakedBoundaries)
+            {
+                // construct bottom
+                var bottomPolygon = polygon.Project(basePlane);
+                var tess = new Tess
+                {
+                    NoEmptyPolygons = true
+                };
+                tess.AddContour(bottomPolygon.Reversed().ToContourVertexArray());
+                tess.Tessellate(WindingRule.Positive, ElementType.Polygons, 3);
+                var faceMesh = tess.ToMesh(normal: (0, 0, -1));
+                this._baseVerts = new List<Vertex>(faceMesh.Vertices);
+                newMesh.AddMesh(faceMesh);
+                // construct sides
+                var upperSegments = polygon.Segments();
+                var lowerSegments = bottomPolygon.Segments();
+                for (int i = 0; i < upperSegments.Count(); i++)
+                {
+                    var topEdge = upperSegments[i];
+                    var bottomEdge = lowerSegments[i];
+                    var normal = topEdge.Direction().Cross(Vector3.ZAxis).Unitized();
+                    var a = newMesh.AddVertex(topEdge.Start, normal: normal);
+                    var b = newMesh.AddVertex(topEdge.End, normal: normal);
+                    var c = newMesh.AddVertex(bottomEdge.End, normal: normal);
+                    var d = newMesh.AddVertex(bottomEdge.Start, normal: normal);
+                    newMesh.AddTriangle(a, c, b);
+                    newMesh.AddTriangle(a, d, c);
+                }
+            }
+            this.Mesh = newMesh;
+        }
+
+        internal void RegisterPropertyChangeHandlers()
+        {
+            this.PropertyChanged += (sender, args) =>
+            {
+                if (args.PropertyName == "DepthBelowMinimumElevation" || args.PropertyName == "AbsoluteMinimumElevation")
+                {
+                    var minHeight = this.AbsoluteMinimumElevation ?? this.MinElevation - this.DepthBelowMinimumElevation;
+                    MoveBaseVerts(minHeight);
+                }
+            };
+        }
+        internal void ConstructMeshes()
+        {
+
+            var generatedMesh = GenerateMesh(this.Elevations,
+                                               this.Origin,
+                                               this.RowWidth,
+                                               this.CellWidth,
+                                               this.CellWidth);
+            this._mesh = generatedMesh.Mesh;
+            this._minElevation = generatedMesh.MinElevation;
+            this._maxElevation = generatedMesh.MaxElevation;
+            double absoluteMinimumElevation = this.AbsoluteMinimumElevation ?? this.MinElevation - this.DepthBelowMinimumElevation;
             CreateSidesAndBottomMesh(this._mesh,
                                      this.RowWidth,
                                      absoluteMinimumElevation,
                                      this.CellHeight,
                                      this.CellWidth,
                                      this.Origin);
-
-            this.PropertyChanged += (sender, args) =>
-            {
-                if (args.PropertyName == "DepthBelowMinimumElevation" || args.PropertyName == "AbsoluteMinimumElevation")
-                {
-                    var minHeight = this.AbsoluteMinimumElevation.HasValue ? this.AbsoluteMinimumElevation.Value : this.MinElevation - this.DepthBelowMinimumElevation;
-                    MoveBaseVerts(minHeight);
-                }
-            };
-        }
-
-        private void GenerateMeshAndSetInternals()
-        {
-            var mesh = GenerateMesh(this.Elevations,
-                                    this.Origin,
-                                    this.RowWidth,
-                                    this.CellWidth,
-                                    this.CellWidth);
-            this._mesh = mesh.Mesh;
-            this._minElevation = mesh.MinElevation;
-            this._maxElevation = mesh.MaxElevation;
         }
 
         private static (Mesh Mesh, double MaxElevation, double MinElevation) GenerateMesh(

--- a/Elements/test/HalfEdgeGraph2dTests.cs
+++ b/Elements/test/HalfEdgeGraph2dTests.cs
@@ -1,0 +1,53 @@
+using System;
+using Elements.Geometry;
+using Xunit;
+using System.Linq;
+using System.Collections.Generic;
+using Elements.Spatial;
+using Elements.Serialization.JSON;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace Elements.Tests
+{
+    public class HalfEdgeGraph2dTests : ModelTest
+    {
+        // see also: Profile.Split (which calls into the HalfEdgeGraph2d API and has many of its own tests)
+
+        [Fact]
+        public void HalfEdgeGraphFromLines()
+        {
+            Name = nameof(HalfEdgeGraphFromLines);
+            // not in order, but clockwise-wound
+            var lines = new List<Line> {
+                new Line((0,0), (10,0)),
+                new Line((10,10), (5,15)),
+                new Line((10,0), (10,10)),
+                new Line((0,10), (0,0)),
+                new Line((5,15), (0,10)),
+            };
+            var heg = HalfEdgeGraph2d.Construct(lines);
+            var polygons = heg.Polygonize();
+            Assert.Single(polygons);
+            Model.AddElement(polygons[0]);
+        }
+
+        [Fact]
+        public void HalfEdgeGraphFromLinesBothWays()
+        {
+            Name = nameof(HalfEdgeGraphFromLinesBothWays);
+            // not in order and inconsistently wound
+            var lines = new List<Line> {
+                new Line((0,0), (10,0)),
+                new Line((10,10), (5,15)),
+                new Line((10,0), (10,10)),
+                new Line((0,0), (0,10)),
+                new Line((0,10), (5,15)),
+            };
+            var heg = HalfEdgeGraph2d.Construct(lines, true);
+            var polygons = heg.Polygonize();
+            Assert.Equal(2, polygons.Count);
+            Assert.Single(polygons.Where(p => p.Normal().Dot(Vector3.ZAxis) > 0));
+        }
+    }
+}

--- a/Elements/test/TopographyTests.cs
+++ b/Elements/test/TopographyTests.cs
@@ -378,6 +378,36 @@ namespace Elements.Tests
             Assert.Equal(1, result.CutVolume, 3);
         }
 
+        [Fact]
+        public void CreateTopoFromMesh()
+        {
+            Name = nameof(CreateTopoFromMesh);
+            var mesh = new Mesh();
+            // e---f---g---h
+            // | / | / | / |
+            // a---b---c---d
+            var a = mesh.AddVertex((0, 0, 10));
+            var b = mesh.AddVertex((5, 0, 11));
+            var c = mesh.AddVertex((10, -1, 12));
+            var d = mesh.AddVertex((15, 1, 9));
+            var e = mesh.AddVertex((-1, 5, 8));
+            var f = mesh.AddVertex((6, 6, 9));
+            var g = mesh.AddVertex((11, 5, 10));
+            var h = mesh.AddVertex((16, 4, 11));
+            mesh.AddTriangle(a, b, f);
+            mesh.AddTriangle(f, e, a);
+            mesh.AddTriangle(b, c, g);
+            mesh.AddTriangle(g, f, b);
+            mesh.AddTriangle(c, d, h);
+            mesh.AddTriangle(h, g, c);
+
+            var topo = new Topography(mesh, null, new Transform(), Guid.NewGuid(), "Topo From Mesh");
+
+            var tunnel = new Line((7, -5, 5), (7, 10, 5));
+            topo.Tunnel(tunnel, 3);
+            Model.AddElement(topo);
+        }
+
         private static Topography CreateTopoFromMapboxElevations(Vector3 origin = default(Vector3), Material material = null)
         {
             // Read topo elevations


### PR DESCRIPTION
BACKGROUND:
- Users have requested the ability to create new Topography elements from a mesh.

DESCRIPTION:
- Adds an overload for the Topography constructor which can consume a custom mesh.

This required a number of additional changes:
-  added `HalfEdgeGraph.Construct(IEnumerable<Line> lines)`
-  added `Polyline.Project(Plane plane)`
-  added a new mesh constructor that duplicates an existing mesh `new Mesh(Mesh mesh)`
- refactored `Polygonize` to support different (non-polygon) output

TESTING:
- I added a `CreateTopoFromMesh` test which creates a topography from mesh.
- I added several `HalfEdgeGraphFromLines` tests which test creating polygons from line networks
- I created a function which makes a mesh via Delaunay triangulation, and verified that I could create a topography from it, and pass it to the `CutAndFill` function:

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/716)
<!-- Reviewable:end -->
