### PR TITLE
Open Polyline Offset

### DIFF
--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -388,7 +388,7 @@ namespace Elements.Geometry
             {
                 if (s.Length() == 0)
                 {
-                    throw new ArgumentException("A segment fo the polyline has zero length.");
+                    throw new ArgumentException("A segment of the polyline has zero length.");
                 }
             }
         }
@@ -731,6 +731,58 @@ namespace Elements.Geometry
             }
 
             return polygons.ToArray();
+        }
+
+        /// <summary>
+        /// A naïve control-point-only 2D open offset. This algorithm does not
+        /// do any self-intersection checking.
+        /// </summary>
+        /// <param name="offset">The offset distance.</param>
+        /// <returns>A new polyline with the same number of control points.</returns>
+        public Polyline OffsetOpen(double offset)
+        {
+            var newVertices = new List<Vector3>();
+            var segments = Segments().Select(s => s.Offset(offset, false)).ToList();
+            if (segments.Count == 1)
+            {
+                return new Polyline(segments[0].Start, segments[0].End);
+            }
+            for (int i = 0; i < segments.Count - 1; i++)
+            {
+                var currSegment = segments[i];
+                var nextSegment = segments[i + 1];
+                if (i == 0)
+                {
+                    newVertices.Add(currSegment.Start);
+                }
+
+                if (currSegment.Direction().Dot(nextSegment.Direction()) > 1 - Vector3.EPSILON)
+                {
+                    newVertices.Add(currSegment.End);
+                }
+                else
+                {
+                    if (currSegment.Intersects(nextSegment, out Vector3 intersection, true, true))
+                    {
+                        newVertices.Add(intersection);
+                    }
+                    else
+                    {
+                        newVertices.Add(currSegment.End);
+                    }
+                }
+
+                if (i == segments.Count - 2)
+                {
+                    newVertices.Add(nextSegment.End);
+                }
+            }
+            var polyline = new Polyline(newVertices);
+            if (polyline.Vertices.Count < 2)
+            {
+                throw new Exception("The offset of the polyline resulted in invalid geometry, such as a single point.");
+            }
+            return polyline;
         }
 
         /// <summary>

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -177,5 +177,67 @@ namespace Elements.Geometry.Tests
 
             Assert.Empty(matches);
         }
+
+        [Fact]
+        public void OffsetOpen()
+        {
+            Name = nameof(OffsetOpen);
+
+            var right = new Polyline(
+                (0, 10),
+                (0, 0),
+                (10, 0)
+            );
+            var acute = new Polyline(
+                (5, 10),
+                (0, 0),
+                (10, 0)
+            );
+            var obtuse = new Polyline(
+                (-5, 10),
+                (0, 0),
+                (10, 0)
+            );
+            var straight = new Polyline(
+                (-5, 0),
+                (0, 0),
+                (10, 0)
+            );
+            var line = new Polyline(
+                (0, 0),
+                (10, 0)
+            );
+            var tightCorner = new Polyline(
+                (0, 10),
+                (0, 1),
+                (1, 0),
+                (10, 0)
+            );
+            var z = new Polyline(
+                (0, 10),
+                (10, 10),
+                (0, 0),
+                (10, 0)
+            );
+
+            Assert.Throws<System.Exception>(() =>
+            {
+                right.OffsetOpen(-10);
+            });
+
+            var testPolylines = new[] { right, acute, obtuse, straight, line, tightCorner, z };
+            for (int i = 0; i < testPolylines.Length; i++)
+            {
+                var xform = new Transform(i * 40, 0, 0);
+                Polyline p = testPolylines[i].TransformedPolyline(xform);
+                Model.AddElement(p);
+                for (double j = -9; j < 9; j += 0.5)
+                {
+                    if (j == 0) continue;
+                    var offset = p.OffsetOpen(j);
+                    Model.AddElement(new ModelCurve(offset, BuiltInMaterials.XAxis));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- All our polyline offset methods produce closed polygons. We need one that can produce an open polyline from an open polyline.

DESCRIPTION:
- adds a new `Polyline.OffsetOpen` method

TESTING:
- A new `OffsetOpen` test is added:
![image](https://user-images.githubusercontent.com/31935763/144483288-68bd3306-7b6f-4269-bbc6-993a11f62b66.png)
  
FUTURE WORK:
- This is a very naïve method. It does not handle eliminating self-intersections at concave corners, as seen in the test image. It also assumes 2D only. `OffsetOnSide` has better corner handling (but does not join the individual polygonal segments), and it would be nice to shift the logic of this method to take on similar behavior for the sake of consistency.

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/717)
<!-- Reviewable:end -->
