### PR TITLE
AdaptiveGrid: Remove AddEdge that does intersections. Double the Tolerance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Improved the logic of `AreCollinear` to utilize perpendicular distance for tolerance checks.
 - `BBox3` constructor now takes an `IEnumerable<Vector3>` instead of a `IList<Vector3>` as input.
 - `Vector3Extensions.Unitized` no longer takes a tolerance for its zero-length check.
+- `AdaptiveGrid` no longer inrsect new edges with all existing edges when new region is added to the grid.
 
 ### Fixed
 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -7,7 +7,10 @@ using System.Linq;
 namespace Elements.Spatial.AdaptiveGrid
 {
     /// <summary>
-    /// A graph like edge-vertex structure with planar spaces connected by vertical edges
+    /// A graph like edge-vertex structure with planar spaces connected by vertical edges.
+    /// The grid doesn't do any intersections when new sections are added, they are stitched 
+    /// only by common vertices. Make sure that regions that are added into the graph are 
+    /// aligned with respect to boundaries and split points.
     /// </summary>
     public class AdaptiveGrid
     {
@@ -56,8 +59,9 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// Tolerance for points being considered the same.
         /// Applies individually to X, Y, and Z coordinates, not the cumulative difference!
+        /// Tolerance is twice the epsilon to make sure graph has no cracks when new sections are added.
         /// </summary>
-        public double Tolerance { get; set; } = Vector3.EPSILON;
+        public double Tolerance { get; } = Vector3.EPSILON * 2;
 
         /// <summary>
         /// Transformation with which planar spaces are aligned
@@ -85,8 +89,8 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// Add graph section using bounding box, divided by a set of key points. 
         /// Key points don't respect "MinimumResolution" at the moment.
-        /// If edges of new section are intersecting with edges of other existing regions - 
-        /// two regions are connected.
+        /// Any vertices that already exist are not created but reused.
+        /// This way new region is connected with the rest of the graph.
         /// </summary>
         /// <param name="bBox">Box which region is populated with graph.</param>
         /// <param name="keyPoints">Set of 3D points, region is split with.</param>
@@ -105,8 +109,8 @@ namespace Elements.Spatial.AdaptiveGrid
 
         /// <summary>
         /// Add graph section using polygon, extruded in given direction.
-        /// If edges of new section are intersecting with edges of other existing regions - 
-        /// two regions are connected.
+        /// Any vertices that already exist are not created but reused.
+        /// This way new region is connected with the rest of the graph.
         /// </summary>
         /// <param name="boundingPolygon">Base polygon</param>
         /// <param name="extrusionAxis">Extrusion direction</param>
@@ -142,8 +146,8 @@ namespace Elements.Spatial.AdaptiveGrid
 
         /// <summary>
         /// Add single planar region to the graph section using polygon.
-        /// If edges of new section are intersecting with edges of other existing regions - 
-        /// two regions are connected.
+        /// Any vertices that already exist are not created but reused.
+        /// This way new region is connected with the rest of the graph.
         /// </summary>
         /// <param name="boundingPolygon">Base polygon</param>
         /// <param name="keyPoints">Set of 3D points, region is split with.</param>
@@ -347,143 +351,6 @@ namespace Elements.Spatial.AdaptiveGrid
             }
         }
 
-        private List<Edge> AddEdge(ulong startId, ulong endId,
-            IEnumerable<Edge> edgesToIntersect, BBox3 checkBox)
-        {
-            var addedEdges = new List<Edge>();
-            var startVertex = GetVertex(startId);
-            var endVertex = GetVertex(endId);
-            var sp = startVertex.Point;
-            var ep = endVertex.Point;
-
-            var intersectionPoints = new List<Vector3>();
-            if (edgesToIntersect.Any() && (checkBox.Contains(sp) || checkBox.Contains(ep)))
-            {
-                Vector3 min = new Vector3();
-                Vector3 max = new Vector3();
-                (min.X, max.X) = sp.X > ep.X ? (ep.X, sp.X) : (sp.X, ep.X);
-                (min.X, max.X) = sp.X > ep.X ? (ep.X, sp.X) : (sp.X, ep.X);
-                (min.X, max.X) = sp.X > ep.X ? (ep.X, sp.X) : (sp.X, ep.X);
-                foreach (var edge in edgesToIntersect)
-                {
-                    var edgeV0 = GetVertex(edge.StartId);
-                    var edgeV1 = GetVertex(edge.EndId);
-
-                    PointOrientation startZ = Orientation(edgeV0.Point.Z, min.Z, max.Z);
-                    PointOrientation endZ = Orientation(edgeV1.Point.Z, min.Z, max.Z);
-                    if (startZ == endZ && startZ != PointOrientation.Inside)
-                        continue;
-
-                    PointOrientation startX = Orientation(edgeV0.Point.X, min.X, max.X);
-                    PointOrientation startY = Orientation(edgeV0.Point.Y, min.Y, max.Y);
-                    PointOrientation endX = Orientation(edgeV1.Point.X, min.X, max.X);
-                    PointOrientation endY = Orientation(edgeV1.Point.Y, min.Y, max.Y);
-
-                    if ((startX == endX && startX != PointOrientation.Inside) ||
-                        (startY == endY && startY != PointOrientation.Inside) ||
-                        !Vector3.AreCoplanar(sp, ep, edgeV0.Point, edgeV1.Point))
-                    {
-                        continue;
-                    }
-
-                    var newEdgeLine = new Line(sp, ep);
-                    var oldEdgeLine = new Line(edgeV0.Point, edgeV1.Point);
-                    if (newEdgeLine.Intersects(oldEdgeLine, out var intersectionPoint))
-                    {
-                        intersectionPoints.Add(intersectionPoint);
-                        var newVertex = AddVertex(intersectionPoint);
-                        if (edge.StartId != newVertex.Id)
-                        {
-                            AddEdge(edge.StartId, newVertex.Id);
-                        }
-                        if (edge.EndId != newVertex.Id)
-                        {
-                            AddEdge(edge.EndId, newVertex.Id);
-                        }
-
-                        DeleteEdge(edge);
-                    }
-                    else if (oldEdgeLine.Direction().IsParallelTo(newEdgeLine.Direction()))
-                    {
-                        var isNewEdgeStartOnOldEdge = oldEdgeLine.PointOnLine(newEdgeLine.Start);
-                        var isNewEdgeEndOnOldEdge = oldEdgeLine.PointOnLine(newEdgeLine.End);
-                        var isOldEdgeStartOnNewEdge = newEdgeLine.PointOnLine(oldEdgeLine.Start, true);
-                        var isOldEdgeEndOnNewEdge = newEdgeLine.PointOnLine(oldEdgeLine.End, true);
-                        // new edge is inside old edge
-                        if (isNewEdgeStartOnOldEdge && isNewEdgeEndOnOldEdge)
-                        {
-                            if (oldEdgeLine.Start.DistanceTo(newEdgeLine.Start) < oldEdgeLine.Start.DistanceTo(newEdgeLine.End))
-                            {
-                                AddEdge(edge.StartId, startVertex.Id);
-                                AddEdge(edge.EndId, endVertex.Id);
-                            }
-                            else
-                            {
-                                AddEdge(edge.StartId, endVertex.Id);
-                                AddEdge(edge.EndId, startVertex.Id);
-                            }
-                            DeleteEdge(edge);
-                        }
-                        // edges overlap
-                        else if (isNewEdgeStartOnOldEdge || isNewEdgeEndOnOldEdge)
-                        {
-                            if (isOldEdgeEndOnNewEdge)
-                            {
-                                intersectionPoints.Add(oldEdgeLine.End);
-                                if (oldEdgeLine.Start.DistanceTo(newEdgeLine.Start) < oldEdgeLine.Start.DistanceTo(newEdgeLine.End))
-                                {
-                                    AddEdge(edge.StartId, startVertex.Id);
-                                }
-                                else
-                                {
-                                    AddEdge(edge.StartId, endVertex.Id);
-                                }
-                            }
-                            else if (isOldEdgeStartOnNewEdge)
-                            {
-                                intersectionPoints.Add(oldEdgeLine.Start);
-                                if (oldEdgeLine.End.DistanceTo(newEdgeLine.Start) < oldEdgeLine.End.DistanceTo(newEdgeLine.End))
-                                {
-                                    AddEdge(edge.EndId, startVertex.Id);
-                                }
-                                else
-                                {
-                                    AddEdge(edge.EndId, endVertex.Id);
-                                }
-                            }
-                            DeleteEdge(edge);
-                        }
-                        // old edge is inside new edge
-                        else if (isOldEdgeStartOnNewEdge && isOldEdgeEndOnNewEdge)
-                        {
-                            intersectionPoints.Add(oldEdgeLine.Start);
-                            intersectionPoints.Add(oldEdgeLine.End);
-                            DeleteEdge(edge);
-                        }
-                    }
-                }
-            }
-            if (intersectionPoints.Any())
-            {
-                intersectionPoints = intersectionPoints.OrderBy(p => p.DistanceTo(startVertex.Point)).ToList();
-                intersectionPoints.Insert(0, startVertex.Point);
-                intersectionPoints.Add(endVertex.Point);
-                intersectionPoints = intersectionPoints.Distinct().ToList();
-                for (var i = 0; i < intersectionPoints.Count - 1; i++)
-                {
-                    var v1 = AddVertex(intersectionPoints[i]);
-                    var v2 = AddVertex(intersectionPoints[i + 1]);
-                    addedEdges.Add(AddEdge(v1.Id, v2.Id));
-                }
-            }
-            else
-            {
-                addedEdges.Add(AddEdge(startVertex.Id, endVertex.Id));
-            }
-
-            return addedEdges;
-        }
-
         private Edge AddEdge(ulong vertexId1, ulong vertexId2)
         {
             if (vertexId1 == vertexId2)
@@ -600,17 +467,9 @@ namespace Elements.Spatial.AdaptiveGrid
                 }
             }
 
-            if (edgeCandidates.Any())
+            foreach (var edge in edgeCandidates)
             {
-                var vertices = edgesToIntersect.Select(e => GetVertex(e.StartId).Point);
-                vertices.Concat(edgesToIntersect.Select(e => GetVertex(e.EndId).Point));
-                BBox3 checkBox = new BBox3(vertices.ToList());
-
-                foreach (var edge in edgeCandidates)
-                {
-                    var edges = AddEdge(edge.Item1, edge.Item2, edgesToIntersect, checkBox);
-                    edges.ForEach(e => addedEdges.Add(e));
-                }
+                addedEdges.Add(AddEdge(edge.Item1, edge.Item2));
             }
 
             return addedEdges;

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -132,5 +132,29 @@ namespace Elements.Tests
  
             adaptiveGrid.AddFromExtrude(polygon, Vector3.ZAxis, 2, points);
         }
+
+        [Fact]
+        public void AdaptiveGridTwoAlignedSections()
+        {
+            var adaptiveGrid = new AdaptiveGrid(new Transform());
+            var polygon1 = Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10));
+            var polygon2 = Polygon.Rectangle(new Vector3(10, 2), new Vector3(20, 12));
+
+            var points = new List<Vector3>();
+            points.AddRange(polygon1.Vertices);
+            points.AddRange(polygon2.Vertices);
+
+            adaptiveGrid.AddFromExtrude(polygon1, Vector3.ZAxis, 2, points);
+            adaptiveGrid.AddFromExtrude(polygon2, Vector3.ZAxis, 2, points);
+
+            ulong id;
+            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(10, 2), out id));
+            var vertex = adaptiveGrid.GetVertex(id);
+            //Up, North, South, East, West
+            Assert.Equal(5, vertex.Edges.Count);
+            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(10, 10), out id));
+            vertex = adaptiveGrid.GetVertex(id);
+            Assert.Equal(5, vertex.Edges.Count);
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- After updating Elements to the latest version code that used Adaptive grid didn't traverse it as expected anymore.
- The reason was changing tolerance of intersect from Epsilon to Epsilon * 2. New tolerance is still better because grid doesn't fail randomly anymore but only individual cells with width [0, Epsilon] may appear. 
- Was also discovered that `AddEdge` that should have created new vertices after a lot of intersection operations didn't do so because it has wrong calculations inside of its fast checks that were designed to improve operation performance. Everything worked fine before because split points were aligned between regions of the grid.  Since adding regions to the grid was biggest bottleneck for large grid create from many regions, I decided not to fix broken function but to skip intersections completely and rely only on split points.

DESCRIPTION:
- Tolerance is doubled to ignore tiny cracks  that may be produced by Grid2D.
- AddEdge is removed because it never truly worked: was huge performance bottleneck and simplified version never worked correctly.

TESTING:
- Added test "AdaptiveGridTwoAlignedSections" covering two aligned regions
  
FUTURE WORK:
- The AdaptiveGrid is complex to use at the moment because you need to choose split points carefully. We might need to add something new that simplifies the process without introducing performance bottleneck.

REQUIRED:
- [ x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
@serenayl  this is performance improvement we discussed together with regression fix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/718)
<!-- Reviewable:end -->
