### PR TITLE
Permit using Content Configurations dynamically

### DIFF
--- a/Elements.Components/src/ContentCatalogRetrieval.cs
+++ b/Elements.Components/src/ContentCatalogRetrieval.cs
@@ -41,16 +41,7 @@ namespace Elements.Components
                     throw new Exception("Catalog not found. To use this class, make sure you have a content catalog stored at catalog.json in the build directory.");
                 }
                 var json = File.ReadAllText(catalogPath);
-                // there are two catalog formats in the wild — one encoded as a model, one with the content catalog encoded bare.
-                try
-                {
-                    var model = Model.FromJson(json);
-                    catalog = model.AllElementsOfType<ContentCatalog>().First();
-                }
-                catch
-                {
-                    catalog = JsonConvert.DeserializeObject<ContentCatalog>(json);
-                }
+                catalog = ContentCatalog.FromJson(json);
                 // Mutate IDs, otherwise we run into a bug with the export server, collisions with shared catalogs, big messy mess.
                 foreach (var element in catalog.Content)
                 {

--- a/Elements.Components/src/ContentCatalogRetrieval.cs
+++ b/Elements.Components/src/ContentCatalogRetrieval.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using Elements.Geometry;
 using Newtonsoft.Json;
 
@@ -12,7 +14,19 @@ namespace Elements.Components
     public static class ContentCatalogRetrieval
     {
         private static ContentCatalog catalog = null;
-        
+
+        private static string catalogFilePath = null;
+
+        /// <summary>
+        /// If you're using a different location for the catalog file, you can 
+        /// set it here.
+        /// </summary>
+        /// <param name="path"></param>
+        public static void SetCatalogFilePath(string path)
+        {
+            catalogFilePath = path;
+        }
+
         /// <summary>
         /// Get the ContentCatalog stored in `catalog.json`.
         /// </summary>
@@ -21,12 +35,22 @@ namespace Elements.Components
         {
             if (catalog == null)
             {
-                if (!File.Exists("./catalog.json"))
+                var catalogPath = catalogFilePath ?? Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "catalog.json");
+                if (!File.Exists(catalogPath))
                 {
                     throw new Exception("Catalog not found. To use this class, make sure you have a content catalog stored at catalog.json in the build directory.");
                 }
-                var json = File.ReadAllText("./catalog.json");
-                catalog = JsonConvert.DeserializeObject<ContentCatalog>(json);
+                var json = File.ReadAllText(catalogPath);
+                // there are two catalog formats in the wild — one encoded as a model, one with the content catalog encoded bare.
+                try
+                {
+                    var model = Model.FromJson(json);
+                    catalog = model.AllElementsOfType<ContentCatalog>().First();
+                }
+                catch
+                {
+                    catalog = JsonConvert.DeserializeObject<ContentCatalog>(json);
+                }
                 // Mutate IDs, otherwise we run into a bug with the export server, collisions with shared catalogs, big messy mess.
                 foreach (var element in catalog.Content)
                 {

--- a/Elements.Components/src/SpaceConfiguration.cs
+++ b/Elements.Components/src/SpaceConfiguration.cs
@@ -71,7 +71,7 @@ namespace Elements.Components
             /// <summary>
             /// The reference position this content item should move with.
             /// </summary>
-    
+
             public Vector3 Anchor { get; set; }
 
             /// <summary>
@@ -99,6 +99,7 @@ namespace Elements.Components
             /// <summary>
             /// The content element corresponding to this item.
             /// </summary>
+            [Newtonsoft.Json.JsonIgnore]
             public ContentElement ContentElement
             {
                 get


### PR DESCRIPTION
BACKGROUND:
- There were some challenges in utilizing content configurations dynamically within a function.
- The ContentConfiguration class dynamically matches content in referenced configurations to a loaded catalog assumed to be at `./catalog.json`  via the `ContentCatalogRetrival` class.

DESCRIPTION:
- Adds `[JsonIgnore]` attribute to the computed ContentElement property, which is only needed at runtime
- Support specifying a different `catalog.json` path in case the catalog was fetched dynamically in a function and needs to be saved to a `temp` location.

TESTING:
- I created a `Create Content Configuration` function (see dev workflow `acdeaa39-f97a-46fd-856d-50fc76910bb9`) that loads a content catalog on the fly and then instantiates it using the components framework.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/720)
<!-- Reviewable:end -->
