### PR TITLE
Fix Line Trim when a vertex is very close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.9.7
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Under some circumstances when a line originated nearly within tolerance of a polygon, `Line.Trim` would return the wrong result.
+
 ## 0.9.6
 
 ### Added

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -876,6 +876,12 @@ namespace Elements.Geometry
                 var B = intersectionsOrdered[i + 1];
                 if (A.IsAlmostEqualTo(B)) // skip duplicate points
                 {
+                    // it's possible that A is outside, but B is at an edge, even 
+                    // if they are within tolerance of each other. 
+                    // This can happen due to floating point error when the point is almost exactly
+                    // epsilon distance from the edge.
+                    // so if we have duplicate points, we have to update the containment value.
+                    polygon.Contains(B, out containment);
                     continue;
                 }
                 var segment = new Line(A, B);

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -1867,5 +1867,17 @@ namespace Elements.Geometry.Tests
             var extension = line.ExtendTo(pgon.Segments());
             Assert.True(extension.Direction() == line.Direction());
         }
+
+        [Fact]
+        public void LineTrim()
+        {
+            Name = nameof(LineTrim);
+            var boundary = JsonConvert.DeserializeObject<Polygon>("{\"discriminator\":\"Elements.Geometry.Polygon\",\"Vertices\":[{\"X\":27.25008,\"Y\":19.98296,\"Z\":0.0},{\"X\":-14.78244,\"Y\":19.98296,\"Z\":0.0},{\"X\":-14.78244,\"Y\":16.4675,\"Z\":0.0},{\"X\":27.25008,\"Y\":16.4675,\"Z\":0.0}]}");
+            var line = JsonConvert.DeserializeObject<Line>("{\"discriminator\": \"Elements.Geometry.Line\",\"Start\": {\"X\": -0.771609999999999,\"Y\": 16.46749,\"Z\": 0.0},\"End\": {\"X\": -0.771609999999999,\"Y\": 19.98295,\"Z\": 0.0}\n}");
+
+            var trimmed = line.Trim(boundary, out var remainder);
+            Assert.True(trimmed.Sum(l => l.Length()) > 0);
+
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- a Hypar Space workflow demonstrated an issue where no walls were being generated between offices.  This turned out to trace backwards through `Grid.GetCellSeparators()` => `Line.Trim(Polygon)`.
- Specifically, a line that started just outside of a polygon — almost exactly within tolerance of the edge — was showing as "greater than tolerance" in one check (The perpendicular distance check in Polygon.Contains, Polygon.cs, line 495) but "less than tolerance" in the other (The "duplicate point" check in Line.Trim, Line.cs line 877).
![image](https://user-images.githubusercontent.com/31935763/144879601-fe4596f5-be93-48d5-84a7-7fb494d5c425.png)
- Since the point was seen as outside, but then the second point was ignored as a duplicate, `Line.Trim` was assuming the whole segment lay outside of the trimming polygon. If the first check had been under tolerance, it would have returned a containment of `CoincidentAtEdge` instead of `Outside`, and we would have gotten the right behavior. 

DESCRIPTION:
- If we encounter a duplicate vertex in `Line.Trim`, we have to update the containment check using the "skipped" vertex, so we can correctly classify the segment.

TESTING:
- I added a new test that demonstrates the behavior in question. This test was failing prior to this change.
- I also ran a local version of the function that was failing, and verified that it produced walls as expected.
  
REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/721)
<!-- Reviewable:end -->
