### PR TITLE
Build Docs on Release

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,7 +1,8 @@
-name: Build Docs
+name: Build Docs On Release
 
 on:
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   build-docs:


### PR DESCRIPTION
BACKGROUND:
- the `Build Docs` action had to be manually triggered via `workflow_dispatch`, so it hadn't been updated in 8 months

DESCRIPTION:
- Switches `Build Docs` to run on major version release.

TESTING:
- I tested the previous build docs action to make sure it still worked, but the trigger won't be tested until we do another release. If it fails then, it's not catastrophic, but we'll follow up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/724)
<!-- Reviewable:end -->
