### PR TITLE
Add ToModelText method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.9.7
 
 ### Added
+- `Network.ToModelText(List<Vector3> nodeLocations, Color color)`
 
 ### Changed
 

--- a/Elements/src/Search/Network.cs
+++ b/Elements/src/Search/Network.cs
@@ -336,6 +336,37 @@ namespace Elements.Search
         }
 
         /// <summary>
+        /// Draw node indices and connected node indices at each node.
+        /// </summary>
+        /// <param name="nodeLocations">A collection of node locations.</param>
+        /// <param name="color">The color of the model text.</param>
+        public List<ModelText> ToModelText(List<Vector3> nodeLocations, Color color)
+        {
+            var textData = new List<(Vector3 location, Vector3 facingDirection, Vector3 lineDirection, string text, Color? color)>();
+            var texts = new List<ModelText>();
+
+            for (var i = 0; i < NodeCount(); i++)
+            {
+                var start = nodeLocations[i];
+                var indexStr = $"{i}: {string.Join(",", EdgesAt(i).Select(e => e.Item1.ToString()))}";
+                textData.Add((nodeLocations[i], Vector3.ZAxis, Vector3.XAxis, indexStr, color));
+
+                if (textData.Count > 100)
+                {
+                    texts.Add(new ModelText(textData, FontSize.PT24));
+                    textData = new List<(Vector3 location, Vector3 facingDirection, Vector3 lineDirection, string text, Color? color)>();
+                }
+            }
+
+            if (textData.Count > 0)
+            {
+                texts.Add(new ModelText(textData, FontSize.PT24));
+            }
+
+            return texts;
+        }
+
+        /// <summary>
         /// Traverse the network from the specified node index.
         /// Traversal concludes when there are no more 
         /// available nodes to traverse.

--- a/Elements/src/Search/Network.cs
+++ b/Elements/src/Search/Network.cs
@@ -345,22 +345,20 @@ namespace Elements.Search
             var textData = new List<(Vector3 location, Vector3 facingDirection, Vector3 lineDirection, string text, Color? color)>();
             var texts = new List<ModelText>();
 
+            var count = NodeCount();
             for (var i = 0; i < NodeCount(); i++)
             {
                 var start = nodeLocations[i];
                 var indexStr = $"{i}: {string.Join(",", EdgesAt(i).Select(e => e.Item1.ToString()))}";
                 textData.Add((nodeLocations[i], Vector3.ZAxis, Vector3.XAxis, indexStr, color));
 
-                if (textData.Count > 100)
+                // Break up text data objects to avoid overflowing maximum 
+                // texture and geometry buffer sizes.
+                if (textData.Count > 100 || i == count - 1)
                 {
                     texts.Add(new ModelText(textData, FontSize.PT24));
                     textData = new List<(Vector3 location, Vector3 facingDirection, Vector3 lineDirection, string text, Color? color)>();
                 }
-            }
-
-            if (textData.Count > 0)
-            {
-                texts.Add(new ModelText(textData, FontSize.PT24));
             }
 
             return texts;

--- a/Elements/test/NetworkTests.cs
+++ b/Elements/test/NetworkTests.cs
@@ -57,12 +57,7 @@ namespace Elements.Tests
             var arrows = network.ToModelArrows(allNodeLocations, Colors.Red);
             this.Model.AddElement(arrows);
 
-            var textData = new List<(Vector3 location, Vector3 facingDirection, Vector3 lineDirection, string text, Color? color)>();
-            for (var i = 0; i < allNodeLocations.Count; i++)
-            {
-                textData.Add((allNodeLocations[i], Vector3.ZAxis, Vector3.XAxis, $"[{i}]:{string.Join(',', network.EdgesAt(i).Select(x => x.Item1))}", Colors.Black));
-            }
-            this.Model.AddElement(new ModelText(textData, FontSize.PT24));
+            this.Model.AddElements(network.ToModelText(allNodeLocations, Colors.Black));
 
             Assert.Equal(5, allNodeLocations.Count);
         }
@@ -125,12 +120,7 @@ namespace Elements.Tests
 
             Assert.Equal(18, allNodeLocations.Count);
 
-            var textData = new List<(Vector3 location, Vector3 facingDirection, Vector3 lineDirection, string text, Color? color)>();
-            for (var i = 0; i < allNodeLocations.Count; i++)
-            {
-                textData.Add((allNodeLocations[i], Vector3.ZAxis, Vector3.XAxis, $"[{i}]:{string.Join(',', network.EdgesAt(i).Select(x => x.Item1))}", Colors.Black));
-            }
-            this.Model.AddElement(new ModelText(textData, FontSize.PT24));
+            this.Model.AddElements(network.ToModelText(allNodeLocations, Colors.Black));
         }
 
         [Fact]
@@ -157,7 +147,7 @@ namespace Elements.Tests
             var scale = 15;
 
             var lines = new List<Line>();
-            for (var i = 0; i < 100; i++)
+            for (var i = 0; i < 50; i++)
             {
                 var start = new Vector3(r.NextDouble() * scale, r.NextDouble() * scale, 0);
                 var end = new Vector3(r.NextDouble() * scale, r.NextDouble() * scale, 0);

--- a/Elements/test/NetworkTests.cs
+++ b/Elements/test/NetworkTests.cs
@@ -147,7 +147,7 @@ namespace Elements.Tests
             var scale = 15;
 
             var lines = new List<Line>();
-            for (var i = 0; i < 50; i++)
+            for (var i = 0; i < 100; i++)
             {
                 var start = new Vector3(r.NextDouble() * scale, r.NextDouble() * scale, 0);
                 var end = new Vector3(r.NextDouble() * scale, r.NextDouble() * scale, 0);


### PR DESCRIPTION
BACKGROUND:
- @mattc's work on path finding identified that debugging networks was difficult.

DESCRIPTION:
- This PR adds the `Network.ToModelText` method to visualize network node indices and their connected indices, and replaces several places in the code where we were doing this, with calls to the new method.

TESTING:
- The network tests have been updated to include this functionality. Run the network tests and visualize the results in your glTF viewer of choice.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

![image](https://user-images.githubusercontent.com/1139788/145262778-e646a419-5553-4502-8e62-44aedbc05816.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/725)
<!-- Reviewable:end -->
