### PR TITLE
set up an optional disk cache for content element glbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Content Elements can now use an optional disk cache when running locally for testing purposes, to speed up repeated tests or runs, by setting `GltfExtensions.GltfCachePath`.
+
 ### Changed
 
 ### Fixed

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -42,8 +42,22 @@ namespace Elements.Serialization.glTF
         /// explicitly loaded by calling LoadGltfCacheFromDisk(). This is used
         /// by `hypar run` and test capabilities to speed up repeated runs. 
         /// </summary>
-        public static string GltfCachePath { get; set; } = null;
-
+        public static string GltfCachePath
+        {
+            get => gltfCachePath;
+            set
+            {
+                if (Directory.Exists(value))
+                {
+                    gltfCachePath = value;
+                }
+                else
+                {
+                    throw new ArgumentException("GltfCachePath must be a valid directory path.");
+                }
+            }
+        }
+        private static string gltfCachePath = null;
         private const string GLTF_CACHE_FOLDER_NAME = "elementsGltfCache";
 
         private const string emptyGltf = @"{
@@ -1144,7 +1158,7 @@ namespace Elements.Serialization.glTF
 
         private static void WriteGltfCacheForKey(string key, MemoryStream stream)
         {
-            if (GltfCachePath == null || !Directory.Exists(GltfCachePath))
+            if (GltfCachePath == null)
             {
                 return;
             }
@@ -1173,10 +1187,6 @@ namespace Elements.Serialization.glTF
                 return;
             }
             var path = Path.Combine(GltfCachePath, GLTF_CACHE_FOLDER_NAME);
-            if (!Directory.Exists(path))
-            {
-                return;
-            }
 
             foreach (var file in Directory.GetFiles(path))
             {


### PR DESCRIPTION
BACKGROUND:
- https://github.com/hypar-io/Elements/issues/719
- Repeatedly running a test, or using `hypar run` with a function utilizing content elements can be painfully slow, since the referenced GLBs were getting fetched every single time. 

DESCRIPTION:
- Adds a completely optional disk cache for `GltfExtensions.gltfCache`, which is only utilized if `gltfExtensions.GltfCachePath` is set. 

TESTING:
- Running off local elements, I tested the following:
  - running a generated function test with content elements that I modified by setting `GltfCachePath` at the beginning of the test. I verified that each subsequent test ran MUCH faster than the first one, and that files were getting stored at the specified directory.
  - Using the `hypar run` command, with its server project modified to set `GltfCachePath` at the beginning. I verified that it was much faster than previously in after a restart. 
  
FUTURE WORK:
- Once this is released, we should update `HyparServer.StartAsync` and our `generate test` templates to call this automatically with a temp directory, so that the user doesn't even need to know about this option.

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/726)
<!-- Reviewable:end -->
