### PR TITLE
Support curved gridlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.9.7
 
 ### Added
+- `GridLine.GetCircleTransform`
 
 ### Changed
 - Support non-linear gridlines by deprecating `GridLine.Line` and replacing it with `GridLine.Curve`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.9.7
 
 ### Added
-- `GridLine.GetCircleTransform`
+- `GridLine.GetCircleTransform()`
 
 ### Changed
 - Support non-linear gridlines by deprecating `GridLine.Line` and replacing it with `GridLine.Curve`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- Support non-linear gridlines by deprecating `GridLine.Line` and replacing it with `GridLine.Curve`.
 
 ### Fixed
 

--- a/Elements/src/GridLine.cs
+++ b/Elements/src/GridLine.cs
@@ -13,7 +13,14 @@ namespace Elements
         /// Line that runs from the start of the gridline to its end.
         /// </summary>
         /// <value></value>
+        [Obsolete("We now use 'Curve' instead.")]
         public Line Line { get; set; }
+
+        /// <summary>
+        /// Curve that runs from the start of the gridline to its end.
+        /// </summary>
+        /// <value></value>
+        public Curve Curve { get; set; }
 
         /// <summary>
         /// Radius of the gridline head.
@@ -32,7 +39,7 @@ namespace Elements
 
         internal override Boolean TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
         {
-            if (this.Line == null)
+            if (this.Curve == null)
             {
                 return base.TryToGraphicsBuffers(out graphicsBuffers, out id, out mode);
             }
@@ -41,25 +48,45 @@ namespace Elements
             mode = glTFLoader.Schema.MeshPrimitive.ModeEnum.LINES;
             graphicsBuffers = new List<GraphicsBuffers>();
 
-            var line = new ModelCurve(this.Line);
-            graphicsBuffers.Add(line.ToGraphicsBuffers(true));
+            var curve = new ModelCurve(this.Curve);
+            graphicsBuffers.Add(curve.ToGraphicsBuffers(true));
 
-            var dir = this.Line.Direction();
+            var start = this.Curve.PointAt(0);
+            var end = this.Curve.PointAt(1);
+
+            var dirStart = this.Curve.TransformAt(0).ZAxis;
+            var dirEnd = this.Curve.TransformAt(1).ZAxis;
+
+            // TransformAt does not seem to consistently point either from start to end, or end to start,
+            // so we normalize for that here.
+            // TODO: fix TransformAt for all curves so that they point in a consistent direction?
+
+            var segments = this.Curve.ToPolyline().Segments();
+            var firstSegment = segments[0];
+            if (firstSegment.Direction().PlaneAngleTo(dirStart) > Math.PI / 2)
+            {
+                dirStart = dirStart.Negate();
+            }
+            var lastSegment = segments[segments.Length - 1];
+            if (lastSegment.Direction().PlaneAngleTo(dirEnd) > Math.PI / 2)
+            {
+                dirEnd = dirEnd.Negate();
+            }
 
             if (ExtensionBeginning > 0)
             {
-                var extensionBeginning = new ModelCurve(new Line(this.Line.Start, this.Line.Start - dir * ExtensionBeginning));
+                var extensionBeginning = new ModelCurve(new Line(start, start - dirStart * ExtensionBeginning));
                 graphicsBuffers.Add(extensionBeginning.ToGraphicsBuffers(true));
             }
 
             if (ExtensionEnd > 0)
             {
-                var extensionEnd = new ModelCurve(new Line(this.Line.End, this.Line.End + dir * ExtensionEnd));
+                var extensionEnd = new ModelCurve(new Line(end, end + dirEnd * ExtensionEnd));
                 graphicsBuffers.Add(extensionEnd.ToGraphicsBuffers(true));
             }
 
             var circle = new Circle(Radius);
-            circle.Center = this.Line.Start - dir * (ExtensionBeginning + Radius);
+            circle.Center = start - dirStart * (ExtensionBeginning + Radius);
             graphicsBuffers.Add(new ModelCurve(circle).ToGraphicsBuffers(true));
             return true;
         }

--- a/Elements/src/GridLine.cs
+++ b/Elements/src/GridLine.cs
@@ -15,7 +15,10 @@ namespace Elements
         /// </summary>
         /// <value></value>
         [Obsolete("We now use 'Curve' instead.")]
-        public Line Line { get; set; }
+        public Line Line {
+            get { return this.Curve as Line; }
+            set { this.Curve = Line; }
+        }
 
         /// <summary>
         /// Curve that runs from the start of the gridline to its end.

--- a/Elements/src/GridLine.cs
+++ b/Elements/src/GridLine.cs
@@ -76,23 +76,14 @@ namespace Elements
         }
 
         /// <summary>
-        /// TODO: This function can be sidestepped altogether if curve.TransformAt consistently pointed from start to end or vice versa.
+        /// Get normal and direction at a point on the curve. The direction is the invert of TransformAt's Z Axis.
         /// </summary>
         private (Vector3 point, Vector3 dir) GetPointAndDirectionAt(double u)
         {
             var transform = this.Curve.TransformAt(u);
             var point = transform.Origin;
             var dir = transform.ZAxis;
-
-            // TransformAt does not seem to consistently point either from start to end, or end to start,
-            // so we normalize for that here in a very rough way.
-            var segments = this.Curve.ToPolyline().Segments();
-            var segment = u < 0.5 ? segments[0] : segments[segments.Length - 1];
-            if (segment.Direction().PlaneAngleTo(dir) > Math.PI / 2)
-            {
-                dir = dir.Negate();
-            }
-            return (point, dir);
+            return (point, dir.Negate());
         }
 
         /// <summary>
@@ -110,6 +101,17 @@ namespace Elements
             var circleCenter = start.point - start.dir * (ExtensionBeginning + Radius);
             var circleVertexTransform = new Transform(circleCenter, start.dir, normal);
             return circleVertexTransform;
+        }
+
+        /// <summary>
+        /// Add gridline's text data to a text collection for insertion into ModelText.
+        /// </summary>
+        /// <param name="texts">Collection of texts to add to.</param>
+        /// <param name="color">Color for this text.</param>
+        public void AddTextToCollection(List<(Vector3 location, Vector3 facingDirection, Vector3 lineDirection, string text, Color? color)> texts, Color? color = null)
+        {
+            var circleCenter = this.GetCircleTransform();
+            texts.Add((circleCenter.Origin, circleCenter.ZAxis, circleCenter.XAxis, this.Name, color));
         }
     }
 }

--- a/Elements/src/GridLine.cs
+++ b/Elements/src/GridLine.cs
@@ -51,18 +51,12 @@ namespace Elements
 
             var renderVertices = new List<Vector3>();
 
-            var start = GetPointAndDirectionAt(this.Curve, 0);
-            var end = GetPointAndDirectionAt(this.Curve, 1);
-
-            var normal = Vector3.ZAxis;
-            if (normal.Dot(start.dir) > 1 - Vector3.EPSILON)
-            {
-                normal = Vector3.XAxis;
-            }
+            var start = GetPointAndDirectionAt(0);
+            var end = GetPointAndDirectionAt(1);
 
             var circle = new Circle(Radius);
-            var circleCenter = start.point - start.dir * (ExtensionBeginning + Radius);
-            var circleVertexTransform = new Transform(circleCenter, start.dir, normal);
+            var circleVertexTransform = GetCircleTransform();
+
             renderVertices.AddRange(circle.RenderVertices().Select(v => circleVertexTransform.OfPoint(v)));
 
             if (ExtensionBeginning > 0)
@@ -85,9 +79,9 @@ namespace Elements
         /// <summary>
         /// TODO: This function can be sidestepped altogether if curve.TransformAt consistently pointed from start to end or vice versa.
         /// </summary>
-        private (Vector3 point, Vector3 dir) GetPointAndDirectionAt(Curve curve, double u)
+        private (Vector3 point, Vector3 dir) GetPointAndDirectionAt(double u)
         {
-            var transform = curve.TransformAt(u);
+            var transform = this.Curve.TransformAt(u);
             var point = transform.Origin;
             var dir = transform.ZAxis;
 
@@ -100,6 +94,23 @@ namespace Elements
                 dir = dir.Negate();
             }
             return (point, dir);
+        }
+
+        /// <summary>
+        /// Get the transform of the circle created by the gridline.
+        /// </summary>
+        /// <returns></returns>
+        public Transform GetCircleTransform()
+        {
+            var start = GetPointAndDirectionAt(0);
+            var normal = Vector3.ZAxis;
+            if (normal.Dot(start.dir) > 1 - Vector3.EPSILON)
+            {
+                normal = Vector3.XAxis;
+            }
+            var circleCenter = start.point - start.dir * (ExtensionBeginning + Radius);
+            var circleVertexTransform = new Transform(circleCenter, start.dir, normal);
+            return circleVertexTransform;
         }
     }
 }

--- a/Elements/test/GridLineTests.cs
+++ b/Elements/test/GridLineTests.cs
@@ -47,7 +47,7 @@ namespace Elements.Tests.Examples
         {
             this.Name = "Elements_GridLinesCurved";
 
-            var size = 50;
+            var size = 10;
             var texts = new List<(Vector3 location, Vector3 facingDirection, Vector3 lineDirection, string text, Color? color)>();
 
             // Semicircle
@@ -55,9 +55,9 @@ namespace Elements.Tests.Examples
             {
                 Name = "A",
                 Material = new Material("Red", new Color(1, 0, 0, 1)),
-                Curve = new Arc(new Vector3(), size, 0, 180),
-                ExtensionBeginning = 100,
-                ExtensionEnd = 100,
+                Curve = new Arc(new Vector3(size, 0, 0), size, 0, 180),
+                ExtensionBeginning = size / 2,
+                ExtensionEnd = size / 2,
             };
             gridline.AddTextToCollection(texts, Colors.White);
 

--- a/Elements/test/GridLineTests.cs
+++ b/Elements/test/GridLineTests.cs
@@ -17,12 +17,31 @@ namespace Elements.Tests.Examples
         {
             this.Name = "Elements_GridLines";
 
-            var gridline = new GridLine();
-            gridline.Name = "A";
-            gridline.Curve = new Line(new Vector3(), new Vector3(25, 25, 0));
-            gridline.Material = new Material("Red", new Color(1, 0, 0, 1));
+            var gridData = new List<(string name, Vector3 origin)>() {
+                ("A", new Vector3()),
+                ("B", new Vector3(10, 0, 0)),
+                ("C", new Vector3(20, 0, 0)),
+                ("D", new Vector3(30, 0, 0)),
+            };
 
-            this.Model.AddElement(gridline);
+            var texts = new List<(Vector3 location, Vector3 facingDirection, Vector3 lineDirection, string text, Color? color)>();
+            var radius = 1;
+            var material = new Material("Red", new Color(1, 0, 0, 1));
+
+            foreach (var (name, origin) in gridData)
+            {
+                var gridline = new GridLine();
+                gridline.Name = name;
+                gridline.Curve = new Line(origin, origin + new Vector3(25, 25, 0));
+                gridline.Material = material;
+                gridline.Radius = radius;
+
+                var circleCenter = gridline.GetCircleTransform();
+                texts.Add((circleCenter.Origin, circleCenter.ZAxis, circleCenter.XAxis, name, Colors.White));
+                this.Model.AddElement(gridline);
+            }
+
+            this.Model.AddElement(new ModelText(texts, FontSize.PT72, 50));
         }
 
         [Fact]

--- a/Elements/test/GridLineTests.cs
+++ b/Elements/test/GridLineTests.cs
@@ -19,8 +19,25 @@ namespace Elements.Tests.Examples
 
             var gridline = new GridLine();
             gridline.Name = "A";
-            gridline.Line = new Line(new Vector3(), new Vector3(25, 25, 0));
+            gridline.Curve = new Line(new Vector3(), new Vector3(25, 25, 0));
             gridline.Material = new Material("Red", new Color(1, 0, 0, 1));
+
+            this.Model.AddElement(gridline);
+        }
+
+        [Fact]
+        public void CurvedGridline()
+        {
+            this.Name = "Elements_GridLinesCurved";
+
+            var size = 50;
+
+            var gridline = new GridLine();
+            gridline.Name = "A";
+            gridline.Material = new Material("Red", new Color(1, 0, 0, 1));
+            gridline.Curve = new Arc(new Vector3(), size, 0, 180);
+            gridline.ExtensionBeginning = 100;
+            gridline.ExtensionEnd = 100;
 
             this.Model.AddElement(gridline);
         }

--- a/Elements/test/GridLineTests.cs
+++ b/Elements/test/GridLineTests.cs
@@ -35,9 +35,7 @@ namespace Elements.Tests.Examples
                 gridline.Curve = new Line(origin, origin + new Vector3(25, 25, 0));
                 gridline.Material = material;
                 gridline.Radius = radius;
-
-                var circleCenter = gridline.GetCircleTransform();
-                texts.Add((circleCenter.Origin, circleCenter.ZAxis, circleCenter.XAxis, name, Colors.White));
+                gridline.AddTextToCollection(texts, Colors.White);
                 this.Model.AddElement(gridline);
             }
 
@@ -50,24 +48,47 @@ namespace Elements.Tests.Examples
             this.Name = "Elements_GridLinesCurved";
 
             var size = 50;
+            var texts = new List<(Vector3 location, Vector3 facingDirection, Vector3 lineDirection, string text, Color? color)>();
 
-            var gridline = new GridLine();
-            gridline.Name = "A";
-            gridline.Material = new Material("Red", new Color(1, 0, 0, 1));
-            gridline.Curve = new Arc(new Vector3(), size, 0, 180);
-            gridline.ExtensionBeginning = 100;
-            gridline.ExtensionEnd = 100;
+            // Semicircle
+            var gridline = new GridLine
+            {
+                Name = "A",
+                Material = new Material("Red", new Color(1, 0, 0, 1)),
+                Curve = new Arc(new Vector3(), size, 0, 180),
+                ExtensionBeginning = 100,
+                ExtensionEnd = 100,
+            };
+            gridline.AddTextToCollection(texts, Colors.White);
 
-            this.Model.AddElement(gridline);
-
-            var verticalGridline = new GridLine
+            // Bezier
+            var bezierGridline = new GridLine
             {
                 Name = "B",
-                Line = new Line(new Vector3(), new Vector3(0, 0, 25)),
+                Curve = new Bezier(new List<Vector3>() { new Vector3(0, size * 2, 0), new Vector3(size, size * 3, 0), new Vector3(size * 2, size * 2, 0), new Vector3(size * 3, size * 3, 0) }),
+                Material = new Material("Yellow", new Color(1, 1, 0, 1))
+            };
+            bezierGridline.AddTextToCollection(texts, Colors.White);
+
+            // Polyline
+            var polyGridline = new GridLine
+            {
+                Name = "C",
+                Curve = new Polyline(new List<Vector3>() { new Vector3(0, size * 3, 0), new Vector3(size, size * 4, 0), new Vector3(size * 2, size * 3, 0), new Vector3(size * 3, size * 4, 0) }),
                 Material = new Material("Green", new Color(0, 1, 0, 1))
             };
+            polyGridline.AddTextToCollection(texts, Colors.White);
 
-            this.Model.AddElements(gridline, verticalGridline);
+            // Vertical
+            var verticalGridline = new GridLine
+            {
+                Name = "D",
+                Curve = new Line(new Vector3(), new Vector3(0, 0, 50)),
+                Material = new Material("Blue", new Color(0, 0, 1, 1))
+            };
+            verticalGridline.AddTextToCollection(texts, Colors.White);
+
+            this.Model.AddElements(gridline, bezierGridline, polyGridline, verticalGridline, new ModelText(texts, FontSize.PT72, 50));
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- The gridlines as currently specified in the schema manager support arbitrary geometry. We would like to retain this flexibility.

DESCRIPTION:
- Deprecates `GridLine.Line` and uses `GridLine.Curve` instead.
- Adds `GridLine.GetCircleTransform()` method to help with text placement, which is still currently separate from GridLine geometry.

TESTING:
- Try the updated test examples for multiple gridlines with `ModelText`, as well as for a curved GridLine.
  
FUTURE WORK:
- How can we also include the text piece of this?

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Rolls in and should supersede #713

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/727)
<!-- Reviewable:end -->
