### PR TITLE
Set name on new profile created during Transform.

### DIFF
--- a/Elements/src/Geometry/Profile.cs
+++ b/Elements/src/Geometry/Profile.cs
@@ -119,7 +119,7 @@ namespace Elements.Geometry
         /// <param name="transform">The transform.</param>
         public Profile Transformed(Transform transform)
         {
-            return new Profile(this.Perimeter.TransformedPolygon(transform), this.Voids?.Select(v => v.TransformedPolygon(transform)).ToList() ?? new List<Polygon>(), null, this.Name);
+            return new Profile(this.Perimeter.TransformedPolygon(transform), this.Voids?.Select(v => v.TransformedPolygon(transform)).ToList() ?? new List<Polygon>(), Guid.NewGuid(), this.Name);
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Profile.cs
+++ b/Elements/src/Geometry/Profile.cs
@@ -119,7 +119,7 @@ namespace Elements.Geometry
         /// <param name="transform">The transform.</param>
         public Profile Transformed(Transform transform)
         {
-            return new Profile(this.Perimeter.TransformedPolygon(transform), this.Voids?.Select(v => v.TransformedPolygon(transform)).ToList() ?? new List<Polygon>());
+            return new Profile(this.Perimeter.TransformedPolygon(transform), this.Voids?.Select(v => v.TransformedPolygon(transform)).ToList() ?? new List<Polygon>(), null, this.Name);
         }
 
         /// <summary>


### PR DESCRIPTION
See Hypar postmortem here: https://www.notion.so/hyparaec/2021-12-10-SkyCiv-fails-because-Structure-function-has-beams-with-unnamed-profiles-4d4fa6973ca441e6b77bc28284b96573

This PR sets the name on a new `Profile` created using `Profile.Transformed()` to the value of the `Name` on the original `Profile`. It does not carry over the `Id`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/728)
<!-- Reviewable:end -->
