### PR TITLE
Updated condition of the Traverse function exit;

### DIFF
--- a/Elements/src/Search/Network.cs
+++ b/Elements/src/Search/Network.cs
@@ -396,6 +396,15 @@ namespace Elements.Search
                 {
                     break;
                 }
+
+                if (path.Contains(currentIndex))
+                {
+                    // if we have already passed two elements in the same order, we've achieved a loop
+                    if (path.IndexOf(path[path.Count - 1]) == path.IndexOf(currentIndex) - 1)
+                    {
+                        break;
+                    }
+                }
             }
 
             // Allow closing a loop.


### PR DESCRIPTION
BACKGROUND:
Network Traverse function can loop in some cases. For example, if leaf is very close to the edge, so for all calculations it's on the edge, but Network is still "think" that it's a leaf (it's smth we need to fix). So, when we are trying to travers network CCW, we got loop:

![image](https://user-images.githubusercontent.com/88673491/147138044-14a54029-9eda-45b3-ac8c-5542e86eb1e4.png)

Because Leaf is almost on nearest edge, algorithm cannot use it and finds other edge that can be CCW. As result in a few step we get loop.

DESCRIPTION:
This PR contains condition inside Traverse  method: exit if we have already passed two elements in the same order

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/738)
<!-- Reviewable:end -->
