### PR TITLE
Setup for tessellation tracing.

### DIFF
--- a/Elements.Benchmarks/ElementCreation.cs
+++ b/Elements.Benchmarks/ElementCreation.cs
@@ -45,12 +45,15 @@ namespace Elements.Benchmarks
             var x = 0.0;
             var z = 0.0;
             var model = new Model();
+            model.AddElement(BuiltInMaterials.Steel, false);
             foreach (var profile in profiles)
             {
                 var color = new Color((float)(x / 20.0), (float)(z / profiles.Count), 0.0f, 1.0f);
                 var line = new Line(new Vector3(x, 0, z), new Vector3(x, 3, z));
                 var beam = new Beam(line, profile);
-                model.AddElement(beam);
+                beam.Representation.SkipCSGUnion = true;
+                model.AddElement(profile, false);
+                model.AddElement(beam, false);
                 x += 2.0;
                 if (x > 20.0)
                 {

--- a/Elements.Benchmarks/Trace.cs
+++ b/Elements.Benchmarks/Trace.cs
@@ -2,12 +2,13 @@ using System.Linq;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnosers;
 using Elements.Geometry.Profiles;
+using Elements.Serialization.glTF;
 
 namespace Elements.Benchmarks
 {
     [EventPipeProfiler(EventPipeProfile.CpuSampling)]
-    [SimpleJob(launchCount: 1, warmupCount: 0, targetCount: 1)]
-    public class Trace
+    [SimpleJob]
+    public class TraceJsonSerialization
     {
         [Benchmark(Description = "Create all HSS beams and serialize to JSON.")]
         public void TraceModelCreation()
@@ -15,7 +16,21 @@ namespace Elements.Benchmarks
             var factory = new HSSPipeProfileFactory();
             var hssProfiles = factory.AllProfiles().ToList();
             var model = ElementCreation.DrawAllBeams(hssProfiles);
-            var json = model.ToJson();
+            model.ToJson();
+        }
+    }
+
+    [EventPipeProfiler(EventPipeProfile.CpuSampling)]
+    [SimpleJob]
+    public class TraceGltfSerialization
+    {
+        [Benchmark(Description = "Create all HSS beams and serialize to glTF.")]
+        public void TraceModelCreation()
+        {
+            var factory = new HSSPipeProfileFactory();
+            var hssProfiles = factory.AllProfiles().ToList();
+            var model = ElementCreation.DrawAllBeams(hssProfiles);
+            model.ToGlTF();
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
In prepation for #742, we need to have trace tests that enable us to generate speedscope files for JSON and glTF serialization.

DESCRIPTION:
- This PR separates the trace tests into two:
  - `TraceJsonSerialization`
  - `TraceGltfSerialization`
- This PR makes slight modifications to the `DrawAllBeams` benchmark method to minimize model recursion and to set the `SkipCsgUnion` flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/743)
<!-- Reviewable:end -->
