### PR TITLE
Add notebook helpers for elements

### DIFF
--- a/Elements/src/Elements.csproj
+++ b/Elements/src/Elements.csproj
@@ -56,4 +56,7 @@
       <HintPath>../lib/Octree.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="extension.dib" Pack="true" PackagePath="interactive-extensions/dotnet" />
+  </ItemGroup>
 </Project>

--- a/Elements/src/extension.dib
+++ b/Elements/src/extension.dib
@@ -1,0 +1,142 @@
+#!markdown
+
+This script is packaged with the NuGet package, and only
+called when the package is imported in a dotnet interactive
+notebook via:
+
+`#r "nuget: Hypar.Elements"`
+
+#!csharp
+
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using Microsoft.DotNet.Interactive;
+using Microsoft.DotNet.Interactive.Formatting;
+using Elements;
+using Elements.Geometry;
+using Elements.Serialization.glTF;
+
+var viewerSrc = @"
+<div id=""main_DIV_ID"" style=""height:400px;width:400px;""></div>
+</div>
+<script type=""module"">
+import * as THREE from 'https://unpkg.com/three@0.126.0/build/three.module.js';
+import { GLTFLoader } from 'https://unpkg.com/three@0.126.0/examples/jsm/loaders/GLTFLoader.js';
+import { OrbitControls } from 'https://unpkg.com/three@0.126.0/examples/jsm/controls/OrbitControls.js';
+const loader = new GLTFLoader();
+const scene = new THREE.Scene();
+
+let loaderScene = new THREE.Scene();
+scene.add(loaderScene);
+
+const width = WIDTH_VAR;
+const height = HEIGHT_VAR;
+const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+const light = new THREE.AmbientLight(0xaaaaaa);
+scene.add(light);
+
+const directionalLight = new THREE.DirectionalLight(0xaaaaaa, 0.5);
+scene.add(directionalLight);
+
+
+const renderer = new THREE.WebGLRenderer();
+renderer.setSize(width, height);
+document.getElementById('main_DIV_ID').appendChild(renderer.domElement);
+
+camera.position.z = 5;
+
+const controls = new OrbitControls(camera, renderer.domElement);
+
+function base64ToArrayBuffer (base64) {
+    var binary_string = window.atob(base64);
+    var len = binary_string.length;
+    var bytes = new Uint8Array(len);
+    for (var i = 0; i < len; i++) {
+        bytes[i] = binary_string.charCodeAt(i);
+    }
+    return bytes.buffer;
+}
+// adapted from looeee's solution https://discourse.threejs.org/t/camera-zoom-to-fit-object/936/3
+const fitCameraToObject = function (scene, offset = 1.25) {
+    offset = offset || 1.25;
+    let boundingBox = null;
+    scene.traverseVisible((child) => {
+        const objectBox = new THREE.Box3().setFromObject(child)
+        if (boundingBox === null) {
+            boundingBox = objectBox
+        } else {
+            boundingBox = boundingBox.union(objectBox)
+        }
+    })
+    const center = boundingBox.getCenter(new THREE.Vector3());
+    const size = boundingBox.getSize(new THREE.Vector3());
+
+    // get the max side of the bounding box (fits to width OR height as needed )
+    const maxDim = Math.max(size.x, size.y, size.z);
+    const fov = camera.fov * (Math.PI / 180);
+    let cameraZ = Math.abs(maxDim / 4 * Math.tan(fov * 2));
+
+    camera.position.copy(center.clone().add(size.clone().multiplyScalar(offset)))
+
+    const minZ = boundingBox.min.z;
+    const cameraToFarEdge = (minZ < 0) ? -minZ + cameraZ : cameraZ - minZ;
+
+    camera.far = cameraToFarEdge * 3;
+    camera.updateProjectionMatrix();
+
+    if (controls) {
+        // set camera to rotate around center of loaded object
+        controls.target = center;
+        // prevent camera from zooming out far enough to create far plane cutoff
+        controls.maxDistance = cameraToFarEdge * 2;
+        controls.saveState();
+
+    } else {
+        camera.lookAt(center)
+    }
+}
+
+function animate () {
+    requestAnimationFrame(animate);
+    controls.update();
+    renderer.render(scene, camera);
+};
+
+const modelBytes = ""MODEL_BYTES_HERE"";
+
+const gltf = loader.parse(base64ToArrayBuffer(modelBytes), null, (glb) => {
+    loaderScene.add(glb.scene);
+    fitCameraToObject(scene);
+});
+
+
+animate();
+
+</script>
+";
+
+if (KernelInvocationContext.Current is { } currentContext)
+{
+    currentContext.DisplayAs("Just add `return model;` at the end of a cell, or call `DisplayModel(model, width, height)` to display an Elements model.", "text/markdown");
+}
+
+string GetModelViewerSrc(Model model, double width=400, double height=400) {
+    var gltf = model.ToGlTF();
+    var gltfString = Convert.ToBase64String(gltf, 0, gltf.Length);
+    return viewerSrc
+    .Replace("MODEL_BYTES_HERE", gltfString)
+    .Replace("WIDTH_VAR", width.ToString())
+    .Replace("HEIGHT_VAR", height.ToString())
+    .Replace("DIV_ID", Guid.NewGuid().ToString());
+}
+
+Formatter.Register<Model>((model, writer) => {
+    var src = GetModelViewerSrc(model);
+    writer.Write(src);
+
+}, "text/html");
+
+void DisplayModel(Model model, double width=400, double height=400) {
+    var src = GetModelViewerSrc(model, width, height);
+    KernelInvocationContext.Current.DisplayAs(src, "text/html");
+}

--- a/Elements/src/extension.dib
+++ b/Elements/src/extension.dib
@@ -32,6 +32,7 @@ scene.add(loaderScene);
 const width = WIDTH_VAR;
 const height = HEIGHT_VAR;
 const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+// TODO: Configure this lighting to match what we do on Hypar's web UI.
 const light = new THREE.AmbientLight(0xaaaaaa);
 scene.add(light);
 

--- a/Elements/src/extension.dib
+++ b/Elements/src/extension.dib
@@ -117,7 +117,7 @@ animate();
 
 if (KernelInvocationContext.Current is { } currentContext)
 {
-    currentContext.DisplayAs("Just add `return model;` at the end of a cell, or call `DisplayModel(model, width, height)` to display an Elements model.", "text/markdown");
+    currentContext.DisplayAs("Add `return model;` at the end of a cell or call `DisplayModel(model, width, height);` to display an Elements model.", "text/markdown");
 }
 
 string GetModelViewerSrc(Model model, double width=400, double height=400) {


### PR DESCRIPTION
BACKGROUND:
- Dotnet Interactive Notebooks support [extensions configured as scripts](https://github.com/dotnet/interactive/blob/788323abc710272a6fbd6bd9f51e3958e408b71a/docs/extending-dotnet-interactive.md#script-based-extensions). This permits adding special notebook-only functionality, without adding any dependencies on notebook-specific packages to the core library.

DESCRIPTION:
- Adds a helper script that runs when `Hypar.Elements` is imported into a dotnet interactive notebook. This helper creates a formatter for the `Model` type which renders a small threejs window to display a model, so that in code you can just `return model;` and see the model in 3d. It also adds a global `DisplayModel` method which can take a variable width and height.

TESTING:
- I temporarily renamed the package id in the csproj to "Hypar.ElementsTest", built the package locally using `dotnet build -c release`, and then referenced the local package source in a notebook like so:
```
#i "nuget: file:///Users/andrewheumann/Dev/elements/nupkg"
#r "nuget: Hypar.ElementsTest"
```

https://user-images.githubusercontent.com/31935763/147881667-284f27ed-26b0-4e2f-9f23-d1926ae4a051.mp4


FUTURE WORK:
- I'm not sure the helpful message I'm trying to render on load is working correctly. This might be a bug or a local package limitation, or maybe I've made a mistake somewhere.
- It would be nice not to have to bundle the JS inline, but I had trouble getting it to import from an externally hosted script. Probably I'm just missing something obvious.

REQUIRED:
- [N/A] All changes are up to date in `CHANGELOG.md`. (not gonna publicize this until we're sure it works)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/745)
<!-- Reviewable:end -->
