### PR TITLE
Fix warning about missing documentation to Polyline.Split(IList<Vector3>, bool)

### DIFF
--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -796,6 +796,13 @@ namespace Elements.Geometry
             Split(points);
         }
 
+        /// <summary>
+        /// Insert a point into the polyline if it lies along one
+        /// of the polyline's segments.
+        /// </summary>
+        /// <param name="points">The points at which to split the polyline.</param>
+        /// <param name="closed">Flag as closed to include a segment between the first and last vertex.</param>
+        /// <returns>The index of the new vertex.</returns>
         protected void Split(IList<Vector3> points, bool closed = false)
         {
             for (var i = 0; i < this.Vertices.Count; i++)


### PR DESCRIPTION
BACKGROUND:
Warning message when running `dotnet test`:

```
Elements\src\Geometry\Polyline.cs(799,24): warning CS1591: Missing XML comment for publicly visible type or member 'Polyline.Split(IList<Vector3>, bool)'
```

DESCRIPTION:
Adds documentation to Polyline.Split

TESTING:
Warning message, described above, is not present.
  
FUTURE WORK:
No, none

REQUIRED:
- [ ] ~All changes are up to date in `CHANGELOG.md`.~  _Documentation fix only, no feature change_

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/752)
<!-- Reviewable:end -->
