### PR TITLE
Fixes xUnit2013 warning

### DIFF
--- a/Elements/test/Grid2dTests.cs
+++ b/Elements/test/Grid2dTests.cs
@@ -113,7 +113,7 @@ namespace Elements.Tests
             var grid = new Grid2d(polygons);
             var profiles = grid.GetTrimmedCellProfiles();
 
-            Assert.Equal(1, profiles.Count());
+            Assert.Single(profiles);
             var profile = profiles.FirstOrDefault();
             Assert.Equal(3, profile.Voids.Count());
             Assert.Equal(100, profile.Perimeter.Area());
@@ -143,19 +143,19 @@ namespace Elements.Tests
 
             var cell = cells[0];
             var profiles = cell.GetTrimmedCellProfiles();
-            Assert.Equal(1, profiles.Count());
-            Assert.Equal(1, profiles.First().Voids.Count());
+            Assert.Single(profiles);
+            Assert.Single(profiles.First().Voids);
 
             cell = cells[1];
             profiles = cell.GetTrimmedCellProfiles();
             Assert.Equal(2, profiles.Count());
-            Assert.Equal(0, profiles.First().Voids.Count());
-            Assert.Equal(0, profiles.Last().Voids.Count());
+            Assert.Empty(profiles.First().Voids);
+            Assert.Empty(profiles.Last().Voids);
 
             cell = cells[2];
             profiles = cell.GetTrimmedCellProfiles();
-            Assert.Equal(1, profiles.Count());
-            Assert.Equal(1, profiles.First().Voids.Count());
+            Assert.Single(profiles);
+            Assert.Single(profiles.First().Voids);
         }
 
 


### PR DESCRIPTION
BACKGROUND:
Warning when running `dotnet test`:

```
Elements\test\Grid2dTests.cs(116,13): warning xUnit2013: Do not use Assert.Equal() to check for collection size.
```

DESCRIPTION:
This PR addresses the xUnit2013 warning.  `Assert.Zero` is used to assert a collection of zero expected elements, `Assert.Single` for asserting a collection of one expected element. https://xunit.net/xunit.analyzers/rules/xUnit2013

TESTING:
The xUnit2013 warning is not displayed when running `dotnet test`
  
FUTURE WORK:
None anticipated

REQUIRED:
- [x] ~All changes are up to date in `CHANGELOG.md`.~ _Assumed not required._

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/753)
<!-- Reviewable:end -->
