### PR TITLE
Adds missing param declaration to docs for SetPropertiesFromProfileData

### DIFF
--- a/Elements/src/Geometry/Profiles/ParametricProfile.cs
+++ b/Elements/src/Geometry/Profiles/ParametricProfile.cs
@@ -135,6 +135,7 @@ namespace Elements.Geometry.Profiles
         /// to the values contained in the supplied dictionary.
         /// </summary>
         /// <param name="profileData">A dictionary of property values.</param>
+        /// <param name="name">The name of the profile.</param>
         public void SetPropertiesFromProfileData(Dictionary<string, double> profileData, string name)
         {
             var t = GetType();


### PR DESCRIPTION
BACKGROUND:
- On running `dotnet test` the following warning was seen:

```
Elements\src\Geometry\Profiles\ParametricProfile.cs(138,97): warning CS1573: Parameter 'name' has no matching param tag in the XML comment for 'ParametricProfile.SetPropertiesFromProfileData(Dictionary<string, double>, string)' (but other parameters do)
```

DESCRIPTION:
Adds the missing parameter to address the warning

TESTING:
The above mentioned warning is no longer seen after applying this PR
  
FUTURE WORK:
None anticipated

REQUIRED:
- [x] ~All changes are up to date in `CHANGELOG.md`.~  _This is a ocumentation addition, so does not change behaviour to consumers; Changelog is assumed not required_

COMMENTS:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/754)
<!-- Reviewable:end -->
