### PR TITLE
Suppress 612 and 618 warnings for Wall properties

### DIFF
--- a/Elements/src/Wall.cs
+++ b/Elements/src/Wall.cs
@@ -59,9 +59,10 @@ namespace Elements
             {
                 throw new ArgumentOutOfRangeException("The wall could not be created. The height of the wall must be greater than 0.0.");
             }
-
+#pragma warning disable 612, 618
             this.Profile = profile;
             this.Height = height;
+#pragma warning restore 612, 618
         }
 
         /// <summary>
@@ -70,7 +71,9 @@ namespace Elements
         public override void UpdateRepresentations()
         {
             this.Representation.SolidOperations.Clear();
+#pragma warning disable 612, 618
             this.Representation.SolidOperations.Add(new Extrude(this.Profile, this.Height, Vector3.ZAxis, false));
+#pragma warning restore 612, 618
         }
 
         /// <summary>

--- a/Elements/src/WallByProfile.cs
+++ b/Elements/src/WallByProfile.cs
@@ -90,7 +90,9 @@ namespace Elements
             this.Thickness = @thickness;
             this.Centerline = @centerline;
             this.Perimeter = @perimeter.Project(GetCenterPlane());
+#pragma warning disable 612, 618
             this.Profile = GetProfile();
+#pragma warning restore 612, 618
         }
 
         /// <summary>
@@ -99,10 +101,12 @@ namespace Elements
         /// <returns></returns>
         public Profile GetProfile()
         {
+#pragma warning disable 612, 618
             if (Perimeter == null && Profile != null) // this might be a legacy style WallByProfile, we should check for Profile directly
             {
                 return Profile;
             }
+#pragma warning restore 612, 618
             return new Profile(Perimeter, Openings.Select(o => o.Perimeter).ToList());
         }
 
@@ -147,7 +151,9 @@ namespace Elements
 
             // TODO remove when we remove Profile.
             var perpendicularToWall = Centerline.Direction().Cross(Vector3.ZAxis);
+#pragma warning disable 612, 618
             this.Profile = GetProfile().Transformed(new Transform(perpendicularToWall * this.Thickness / 2));
+#pragma warning restore 612, 618
         }
 
         /// <summary>


### PR DESCRIPTION
BACKGROUND:
When running `dotnet test`, CS0618 warnings were generated for use of Obsolete Wall.Profile and Wall.Height properties; e.g.:
```
Elements\src\WallByProfile.cs(93,13): warning CS0618: 'Wall.Profile' is obsolete: 'The profile property on the Wall base class is obsolete, check the methods of an inherited class like StandardWall or WallByProfile.'
```

DESCRIPTION:
This suppresses the warning without fixing the underlying cause i.e. the obsolete properties continue to be used.

TESTING:
- The warnings, described above, are no longer present when running `dotnet test`
  
FUTURE WORK:
- It may be possible to remove the root cause of the warnings (i.e. not to use the obsolete properties) rather than suppressing them.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.
    - Change log is assumed not required as this does not change behaviour for the end-user.
   
COMMENTS:
- I am not certain whether the code style of inline disable and enabling pragma directives are correct; elsewhere the pragma is at the top of the file and disables the warning for the entire file.
- The inline pragma warnings are not indented; this is to highlight their presence but may not be compatible with style guidelines.

I'd welcome comments as to whether this PR is the correct approach for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/755)
<!-- Reviewable:end -->
