### PR TITLE
Fix `Bezier.Length()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- Under some circumstances `Bezier.Length()` would return incorrect results
 
 ## 0.9.8
 

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -99,6 +99,7 @@ namespace Elements.Geometry
                 var pt = PointAt(t);
                 if (t == 0.0)
                 {
+                    last = pt;
                     continue;
                 }
                 length += pt.DistanceTo(last);

--- a/Elements/test/BezierTests.cs
+++ b/Elements/test/BezierTests.cs
@@ -48,8 +48,6 @@ namespace Hypar.Tests
 
             var targetLength = 0;
             Assert.Equal(targetLength, bezier.Length());
-            var polylineLength = bezier.ToPolyline(2).Length();
-            Assert.Equal(polylineLength, bezier.Length());
         }
 
         [Fact]

--- a/Elements/test/BezierTests.cs
+++ b/Elements/test/BezierTests.cs
@@ -36,5 +36,38 @@ namespace Hypar.Tests
 
             this.Model.AddElement(new ModelCurve(bezier));
         }
+
+        [Fact]
+        public void Bezier_Length_ZeroLength()
+        {
+            var a = Vector3.Origin;
+            var b = Vector3.Origin;
+            var c = Vector3.Origin;
+            var ctrlPts = new List<Vector3>{ a, b, c };
+            var bezier = new Bezier(ctrlPts);
+
+            var targetLength = 0;
+            Assert.Equal(targetLength, bezier.Length());
+            var polylineLength = bezier.ToPolyline(2).Length();
+            Assert.Equal(polylineLength, bezier.Length());
+        }
+
+        [Fact]
+        public void Bezier_Length_OffsetFromOrigin()
+        {
+            var b = new Vector3(5, 0, 1);
+            var c = new Vector3(5, 5, 2);
+            var d = new Vector3(0, 5, 3);
+            var e = new Vector3(0, 0, 4);
+            var f = new Vector3(5, 0, 5);
+            var ctrlPts = new List<Vector3>{b,c,d,e,f};
+            var bezier = new Bezier(ctrlPts);
+
+            var expectedLength = 11.45;  // approximation as the linear interpolation used for calculating length is not hugely accurate
+            Assert.Equal(expectedLength, bezier.Length(), 2);
+            var divisions = 50; // brittle as it relies on number of samples within Bezier being unchanged
+            var polylineLength = bezier.ToPolyline(divisions).Length();
+            Assert.Equal(polylineLength, bezier.Length());
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
Fixes https://github.com/hypar-io/Elements/issues/462

DESCRIPTION:
When calculating the length of the first segment on the bezier curve, it erroneously used the origin as the start of the curve.  This PR corrects this to use the start point of the bezier curve.

TESTING:
Tests included.
- bezier.Length() should now match polyline.Length() where the number of divisions matches the bezier samples.
  
FUTURE WORK:
- The linear interpolation method is very approximate.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- tests make allowance for the approximate method of calculating length.  This is noted as an inline comment within the test code.
- tests comparing bezier.Length() to polyline.Length() may be brittle to changes in samples constant within Bezier.  This is noted as an inline comment within the test code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/757)
<!-- Reviewable:end -->
