### PR TITLE
Add ModelLines for visualization of line collection what share material

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.9.9
 
 ### Added
+- `ModelLines`
 
 ### Changed
 

--- a/Elements/src/ModelLines.cs
+++ b/Elements/src/ModelLines.cs
@@ -22,9 +22,9 @@ namespace Elements
         private bool _isSelectable = false;
 
         /// <summary>
-        /// Create a model lines. They share Material, Transformation and other parameters.
+        /// Create a collection of lines. They share Material, Transformation and other parameters.
         /// </summary>
-        /// <param name="lines">The lines</param>
+        /// <param name="lines">The lines.</param>
         /// <param name="material">The material. Specular and glossiness components will be ignored.</param>
         /// <param name="transform">The model lines transform.</param>
         /// <param name="isElementDefinition">Is this an element definition?</param>
@@ -48,7 +48,7 @@ namespace Elements
         }
 
         /// <summary>
-        /// Set whether this model curve should be selectable in the web UI.
+        /// Set whether these model lines should be selectable in the web UI.
         /// Lines are not selectable by default.
         /// </summary>
         /// <param name="selectable"></param>

--- a/Elements/src/ModelLines.cs
+++ b/Elements/src/ModelLines.cs
@@ -1,0 +1,81 @@
+﻿using Elements.Geometry;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elements
+{
+    /// <summary>
+    /// A collection of lines which are visible in 3D.
+    /// </summary>
+    /// <example>
+    /// [!code-csharp[Main](../../Elements/test/ModelLinesTest.cs?name=example)]
+    /// </example>
+    public class ModelLines : GeometricElement
+    {
+        /// <summary>
+        /// The lines.
+        /// </summary>
+        public IList<Line> Lines { get; set; }
+
+        private bool _isSelectable = false;
+
+        /// <summary>
+        /// Create a model lines. They share Material, Transformation and other parameters.
+        /// </summary>
+        /// <param name="lines">The lines</param>
+        /// <param name="material">The material. Specular and glossiness components will be ignored.</param>
+        /// <param name="transform">The model lines transform.</param>
+        /// <param name="isElementDefinition">Is this an element definition?</param>
+        /// <param name="id">The id of the model lines.</param>
+        /// <param name="name">The name of the model lines.</param>
+        [JsonConstructor]
+        public ModelLines(IList<Line> lines = null,
+                           Material material = null,
+                           Transform transform = null,
+                           bool isElementDefinition = false,
+                           Guid id = default(Guid),
+                           string name = null) : base(transform != null ? transform : new Transform(),
+                                                      material != null ? material : BuiltInMaterials.Points,
+                                                      null,
+                                                      isElementDefinition,
+                                                      id != default(Guid) ? id : Guid.NewGuid(),
+                                                      name)
+        {
+            this.Lines = lines != null ? lines : new List<Line>();
+            this.Material = material != null ? material : BuiltInMaterials.Edges;
+        }
+
+        /// <summary>
+        /// Set whether this model curve should be selectable in the web UI.
+        /// Lines are not selectable by default.
+        /// </summary>
+        /// <param name="selectable"></param>
+        public void SetSelectable(bool selectable)
+        {
+            _isSelectable = selectable;
+        }
+
+        internal override Boolean TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
+        {
+            if (Lines.Count == 0)
+            {
+                return base.TryToGraphicsBuffers(out graphicsBuffers, out id, out mode);
+            }
+            id = _isSelectable ? $"{this.Id}_lines" : $"unselectable_{this.Id}_lines";
+            mode = glTFLoader.Schema.MeshPrimitive.ModeEnum.LINES;
+            graphicsBuffers = new List<GraphicsBuffers>();
+
+            List<Vector3> points = new List<Vector3>();
+            foreach (var line in Lines)
+            {
+                points.Add(line.Start);
+                points.Add(line.End);
+            }
+
+            graphicsBuffers.Add(points.ToGraphicsBuffers(false));
+            return true;
+        }
+    }
+}

--- a/Elements/src/ModelPoints.cs
+++ b/Elements/src/ModelPoints.cs
@@ -23,10 +23,10 @@ namespace Elements
         /// </summary>
         /// <param name="locations">The locations of the points.</param>
         /// <param name="material">The material. Specular and glossiness components will be ignored.</param>
-        /// <param name="transform">The model curve's transform.</param>
+        /// <param name="transform">The model points transform.</param>
         /// <param name="isElementDefinition">Is this an element definition?</param>
-        /// <param name="id">The id of the model curve.</param>
-        /// <param name="name">The name of the model curve.</param>
+        /// <param name="id">The id of the model points.</param>
+        /// <param name="name">The name of the model points.</param>
         [JsonConstructor]
         public ModelPoints(IList<Vector3> locations = null,
                           Material material = null,

--- a/Elements/test/ModelLinesTests.cs
+++ b/Elements/test/ModelLinesTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Elements.Geometry;
+using Xunit;
+
+namespace Elements.Tests
+{
+    public class ModelLinesTests : ModelTest
+    {
+        public ModelLinesTests()
+        {
+            this.GenerateIfc = false;
+        }
+
+        [Fact, Trait("Category", "Examples")]
+        public void ModelLines()
+        {
+            this.Name = "Elements_ModelCurve";
+
+            // <example>
+            var lines = new List<Line>()
+            {
+                new Line(new Vector3(0, 0), new Vector3(0, 5)),
+                new Line(new Vector3(0, 0), new Vector3(5, 0)),
+                new Line(new Vector3(0, 5), new Vector3(5, 5)),
+                new Line(new Vector3(5, 0), new Vector3(5, 5)),
+                new Line(new Vector3(0, 0), new Vector3(5, 5))
+            };
+
+            var modelLines = new ModelLines(lines, new Material("Yellow", Colors.Yellow));
+            // </exmaple>
+            
+            this.Model.AddElement(modelLines);
+        }
+    }
+}


### PR DESCRIPTION
BACKGROUND:
- I needed visualization AdaptiveGrid edges. For this, I used ModelPoints plus a set of ModelCurve objects. This slowed web view, especially when zoomed out.

DESCRIPTION:
- Added ModelLines specialized in drawing a set of lines that share material from the single buffer. This means that all the lines, if selectable, are selected together, but the drawing is lag free. 

TESTING:
- Added ModelLinesTest.cs to show simple usage example.

REQUIRED:
- [x ] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/760)
<!-- Reviewable:end -->
