### PR TITLE
Add parameter `removeCutEdges` to `AdaptiveGrid.SubstructBox`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `ModelLines`
 
 ### Changed
+- Add parameter `removeCutEdges` to `AdaptiveGrid.SubtructBox` that control if cut parts of intersected edges need to be inserted into the graph.
 
 ### Fixed
 - Under some circumstances `Bezier.Length()` would return incorrect results
@@ -50,7 +51,6 @@
 
 - Support non-linear gridlines by deprecating `GridLine.Line` and replacing it with `GridLine.Curve`.
 - Add use new CSG library and test it's effectiveness
-- Add parameter `removeCutEdges` to `AdaptiveGrid.SubstructBox` that control if cut parts of intersected edges need to be inserted into the graph.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 - Support non-linear gridlines by deprecating `GridLine.Line` and replacing it with `GridLine.Curve`.
 - Add use new CSG library and test it's effectiveness
+- Add parameter `removeCutEdges` to `AdaptiveGrid.SubstructBox` that control if cut parts of intersected edges need to be inserted into the graph.
 
 ### Fixed
 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -166,7 +166,8 @@ namespace Elements.Spatial.AdaptiveGrid
         /// that is inside the box. Note that no new connections are created afterwards.
         /// </summary>
         /// <param name="box">Boding box to subtract</param>
-        public void SubtractBox(BBox3 box)
+        /// <param name="removeCutEdges">Should edge be removed or replaced by leftover pieces</param>
+        public void SubtractBox(BBox3 box, bool removeCutEdges = false)
         {
             List<Edge> edgesToDelete = new List<Edge>();
             foreach (var edge in GetEdges())
@@ -223,34 +224,43 @@ namespace Elements.Spatial.AdaptiveGrid
                         //If none - we just touched the corner
                         if (startInside)
                         {
-                            var v = AddVertex(intersections[0]);
-                            if (edge.EndId != v.Id)
+                            if (!removeCutEdges)
                             {
-                                AddEdge(v.Id, edge.EndId);
+                                var v = AddVertex(intersections[0]);
+                                if (edge.EndId != v.Id)
+                                {
+                                    AddEdge(v.Id, edge.EndId);
+                                }
                             }
                             edgesToDelete.Add(edge);
                         }
                         else if (endInside)
                         {
-                            var v = AddVertex(intersections[0]);
-                            if (edge.StartId != v.Id)
+                            if (!removeCutEdges)
                             {
-                                AddEdge(edge.StartId, v.Id);
+                                var v = AddVertex(intersections[0]);
+                                if (edge.StartId != v.Id)
+                                {
+                                    AddEdge(edge.StartId, v.Id);
+                                }
                             }
                             edgesToDelete.Add(edge);
                         }
                     }
                     if (intersections.Count == 2)
                     {
-                        var v0 = AddVertex(intersections[0]);
-                        var v1 = AddVertex(intersections[1]);
-                        if (edge.StartId != v0.Id)
+                        if (!removeCutEdges)
                         {
-                            AddEdge(edge.StartId, v0.Id);
-                        }
-                        if (edge.EndId != v1.Id)
-                        {
-                            AddEdge(v1.Id, edge.EndId);
+                            var v0 = AddVertex(intersections[0]);
+                            var v1 = AddVertex(intersections[1]);
+                            if (edge.StartId != v0.Id)
+                            {
+                                AddEdge(edge.StartId, v0.Id);
+                            }
+                            if (edge.EndId != v1.Id)
+                            {
+                                AddEdge(v1.Id, edge.EndId);
+                            }
                         }
                         edgesToDelete.Add(edge);
                     }

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -79,7 +79,7 @@ namespace Elements.Tests
         }
 
         [Fact]
-        public void AdaptiveGridSubtractBox()
+        public void AdaptiveGridSubtractBoxKeepEdges()
         {
             var adaptiveGrid = new AdaptiveGrid(new Transform());
             var polygon = Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10));
@@ -90,13 +90,52 @@ namespace Elements.Tests
                 points.Add(new Vector3(i, i, 1));
             }
             adaptiveGrid.AddFromExtrude(polygon, Vector3.ZAxis, 2, points);
-            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(5, 5), out _));
-            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(5, 4.9), out _));
+            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(5, 5, 1), out _));
+            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(5, 4.9, 1), out _));
+            var numVertices = adaptiveGrid.GetVertices().Count;
 
             var box = new BBox3(new Vector3(4.9, 4.9, 0), new Vector3(5.1, 5.1, 2));
-            adaptiveGrid.SubtractBox(box);
+            adaptiveGrid.SubtractBox(box, false);
             Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(5, 5, 1), out _));
-            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(5, 4.9, 1), out _));
+            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(5, 4.9, 1), out var cutEdgeId));
+
+            var v = adaptiveGrid.GetVertex(cutEdgeId);
+            Assert.Single(v.Edges);
+            adaptiveGrid.TryGetVertexIndex(new Vector3(5, 4, 1), out var borderId);
+            Assert.True(v.Edges.First().StartId == borderId || v.Edges.First().EndId == borderId);
+            //On each elevation one vertex is removed but 4 added
+            Assert.Equal(numVertices + (3 * (4 - 1)), adaptiveGrid.GetVertices().Count);
+        }
+
+        [Fact]
+        public void AdaptiveGridSubtractBoxCutEdges()
+        {
+            var adaptiveGrid = new AdaptiveGrid(new Transform());
+            var polygon = Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10));
+
+            var points = new List<Vector3>();
+            for (int i = 1; i < 10; i++)
+            {
+                points.Add(new Vector3(i, i, 1));
+            }
+
+            adaptiveGrid.AddFromExtrude(polygon, Vector3.ZAxis, 2, points);
+            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(5, 5, 1), out _));
+            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(5, 4.9, 1), out _));
+
+            adaptiveGrid.TryGetVertexIndex(new Vector3(5, 4, 1), out var borderId);
+            var borderV = adaptiveGrid.GetVertex(borderId);
+            var numEdges = borderV.Edges.Count;
+            var numVertices = adaptiveGrid.GetVertices().Count;
+
+            var box = new BBox3(new Vector3(4.9, 4.9, 0), new Vector3(5.1, 5.1, 2));
+            adaptiveGrid.SubtractBox(box, true);
+            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(5, 5, 1), out _));
+            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(5, 4.9, 1), out _));
+
+            Assert.Equal(numEdges - 1, borderV.Edges.Count);
+            //On each elevation one vertex is removed and no added
+            Assert.Equal(numVertices - (3 * 1), adaptiveGrid.GetVertices().Count);
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
- When AdaptiveGrid is intersected by a box, all intersected edges were cut and leftover portions were inserted back into the grid. This is not always wanted as "dead end" edges were creating routing issues in some conditions. 

DESCRIPTION:
- Added parameter `removeCutEdges` to `AdaptiveGrid.SubstructBox` that control if cut parts of intersected edges need to be inserted into the graph. The parameter is set to false (old behavior) by default.

TESTING:
- Added test AdaptiveGridSubtractBoxCutEdges and changed test AdaptiveGridSubtractBox (now AdaptiveGridSubtractBoxKeepEdges)
  
FUTURE WORK:
- In future we might need function that cut space not using global coordinate space but coordinate space of the grid.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/763)
<!-- Reviewable:end -->
