### PR TITLE
add a more default model.tojson

### DIFF
--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -201,11 +201,20 @@ namespace Elements
         }
 
         /// <summary>
-        /// Serialize the model to JSON using default arguments
+        /// Serialize the model to JSON using default arguments.
         /// </summary>
         public string ToJson()
         {
             return ToJson();
+        }
+
+        /// <summary>
+        /// Serialize the model to JSON to match default arguments.
+        /// TODO this method can be removed after Hypar.Functions release 0.9.11 occurs.
+        /// </summary>
+        public string ToJson(bool indent = false)
+        {
+            return ToJson(false);
         }
 
         /// <summary>

--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -205,7 +205,8 @@ namespace Elements
         /// </summary>
         public string ToJson()
         {
-            return ToJson();
+            // The arguments here are meant to match the default arguments of the ToJson(bool, bool) method above.
+            return ToJson(false, true);
         }
 
         /// <summary>
@@ -214,7 +215,7 @@ namespace Elements
         /// </summary>
         public string ToJson(bool indent = false)
         {
-            return ToJson(false);
+            return ToJson(indent, true);
         }
 
         /// <summary>

--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -201,6 +201,14 @@ namespace Elements
         }
 
         /// <summary>
+        /// Serialize the model to JSON using default arguments
+        /// </summary>
+        public string ToJson()
+        {
+            return ToJson();
+        }
+
+        /// <summary>
         /// Serialize the model to a JSON file.
         /// </summary>
         /// <param name="path">The path of the file on disk.</param>
@@ -274,7 +282,7 @@ namespace Elements
 
         private List<Element> RecursiveGatherSubElements(object obj)
         {
-            // A dictionary created for the purpose of caching properties 
+            // A dictionary created for the purpose of caching properties
             // that we need to recurse, for types that we've seen before.
             var props = new Dictionary<Type, List<PropertyInfo>>();
 
@@ -316,7 +324,7 @@ namespace Elements
             }
             else
             {
-                // This query had a nice little speed boost when we filtered for 
+                // This query had a nice little speed boost when we filtered for
                 // valid types first then filtered for custom attributes.
                 constrainedProps = t.GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(p => IsValidForRecursiveAddition(p.PropertyType) && p.GetCustomAttribute<JsonIgnoreAttribute>() == null).ToList();
                 properties.Add(t, constrainedProps);


### PR DESCRIPTION
BACKGROUND:
- Functions published with latest alphas broke because the function signature of ToJson changed.
  - ![image](https://user-images.githubusercontent.com/5872187/151428724-408b193c-0b46-40da-9b0d-83451b1c8870.png)
- the Hypar repo was not updated appropriately 
- Breakage occurred even though signature introduced only arguments with defaults, which should be optional, and the only place it is used used passes no arguments.

DESCRIPTION:
- Add an explicit `ToJson()` method that has no arguments for future compatibility.

TESTING:
- publishing a function with latest alphas will result in error during function execution.
  - `dotnet add package Hypar.Elements --version 0.9.9-alpha.7`
  - `dotnet add package Hypar.Functions --version 0.9.11-alpha.3`
  
FUTURE WORK:
- We will update the Hypar.Functions project to reference the latest alpha regardless of the effect of this fix.

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/764)
<!-- Reviewable:end -->
