### PR TITLE
stop using containsKey because the newtonsoft in revit doesn't have t…

### DIFF
--- a/Elements/src/ContentCatalog.cs
+++ b/Elements/src/ContentCatalog.cs
@@ -53,11 +53,11 @@ namespace Elements
         public static ContentCatalog FromJson(string json)
         {
             var catalogObject = Newtonsoft.Json.JsonConvert.DeserializeObject<JObject>(json);
-            if (catalogObject.ContainsKey("discriminator"))
+            if (catalogObject.TryGetValue("discriminator", out _))
             {
                 return catalogObject.ToObject<ContentCatalog>();
             }
-            else if (catalogObject.ContainsKey("Elements") && catalogObject.ContainsKey("Transform")) // catalog is stored in a model
+            else if (catalogObject.TryGetValue("Elements", out _) && catalogObject.TryGetValue("Transform", out _)) // catalog is stored in a model
             {
                 var model = Model.FromJson(json);
                 return model.AllElementsOfType<ContentCatalog>().First();


### PR DESCRIPTION
…his method

BACKGROUND:
- Catalog deserialization was failing in Revit 2020 due to `JObject.ContainsKey` not existing

DESCRIPTION:
- Uses an older method that seems to exist just fine in Revit.

TESTING:
- save catalogs from revit, they would not recognize old catalogs before this change.
  
FUTURE WORK:
- None

REQUIRED:
- [ ] N/A ~~All changes are up to date in `CHANGELOG.md`.~~

COMMENTS:
- Any other notes.
