### PR TITLE
Add new ceilings

### DIFF
--- a/Elements/src/BaseCeiling.cs
+++ b/Elements/src/BaseCeiling.cs
@@ -1,0 +1,146 @@
+﻿using Elements.Geometry;
+using Elements.Geometry.Solids;
+using Elements.Interfaces;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Elements
+{
+    /// <summary>
+    /// The base class for all ceilings.
+    /// </summary>
+    public abstract class BaseCeiling : GeometricElement
+    {
+        /// <summary>
+        /// The elevation of the ceiling.
+        /// </summary>
+        public double Elevation { get; protected set; }
+
+        /// <summary>
+        /// The perimeter of the ceiling.
+        /// </summary>
+        public Polygon Perimeter { get; protected set; }
+
+        /// <summary>
+        /// Construct a ceiling from perimeter and an elevation.
+        /// </summary>
+        /// <param name="perimeter">The plan profile of the ceiling. It must lie on the XY plane.
+        /// The Z coordinate will be ignored</param>
+        /// <param name="elevation">The elevation of the ceiling.</param>
+        /// <param name="material">The material of the ceiling.</param>
+        /// <param name="transform">An optional transform for the ceiling.</param>
+        /// <param name="representation">The ceiling's representation.</param>
+        /// <param name="isElementDefinition">Is this an element definition?</param>
+        /// <param name="id">The id of the ceiling.</param>
+        /// <param name="name">The name of the ceiling.</param>
+        protected BaseCeiling(Polygon perimeter,
+                      double elevation,
+                      Material material = null,
+                      Transform transform = null,
+                      Representation representation = null,
+                      bool isElementDefinition = false,
+                      Guid id = default(Guid),
+                      string name = null)
+            : base(transform ?? new Transform(),
+                   material ?? BuiltInMaterials.Concrete,
+                   representation ?? new Representation(new List<SolidOperation>()),
+                   isElementDefinition,
+                   id != default(Guid) ? id : Guid.NewGuid(),
+                   name)
+        {
+            if (!perimeter.Normal().IsParallelTo(Vector3.ZAxis))
+            {
+                throw new ArgumentException("The ceiling could not be created. The perimeter polygon must lie on the XY plane");
+            }
+
+            this.Elevation = elevation;
+            this.Perimeter = perimeter.Project(new Plane(Vector3.Origin, Vector3.ZAxis));
+            Transform.Move(Vector3.ZAxis * Elevation);
+        }
+
+        /// <summary>
+        /// Construct a ceiling from perimeter.
+        /// </summary>
+        /// <param name="perimeter">The plan perimeter of the ceiling. It must lie on the XY plane.
+        /// Z coordinate will be used as elevation</param>
+        /// <param name="material">The material of the ceiling.</param>
+        /// <param name="transform">An optional transform for the ceiling.</param>
+        /// <param name="representation">The ceiling's representation.</param>
+        /// <param name="isElementDefinition">Is this an element definition?</param>
+        /// <param name="id">The id of the ceiling.</param>
+        /// <param name="name">The name of the ceiling.</param>
+        protected BaseCeiling(Polygon perimeter,
+                      Material material = null,
+                      Transform transform = null,
+                      Representation representation = null,
+                      bool isElementDefinition = false,
+                      Guid id = default(Guid),
+                      string name = null)
+            : base(transform ?? new Transform(),
+                   material ?? BuiltInMaterials.Concrete,
+                   representation ?? new Representation(new List<SolidOperation>()),
+                   isElementDefinition,
+                   id != default(Guid) ? id : Guid.NewGuid(),
+                   name)
+        {
+            if (!perimeter.Normal().IsParallelTo(Vector3.ZAxis))
+            {
+                throw new ArgumentException("The ceiling could not be created. The perimeter polygon must lie on the XY plane");
+            }
+
+            // we do not need null check cause id there is no vertices it will fail on calculating Normal
+            this.Elevation = perimeter.Vertices.First().Z;
+            this.Perimeter = perimeter.Project(new Plane(Vector3.Origin, Vector3.ZAxis));
+            Transform.Move(Vector3.ZAxis * Elevation);
+        }
+
+        /// <summary>
+        /// Construct a ceiling. It's a private constructor that doesn't add elevation to transform.
+        /// </summary>
+        /// <param name="perimeter">The plan profile of the ceiling. It must lie on the XY plane.
+        /// The Z coordinate will be ignored</param>
+        /// <param name="elevation">The elevation of the ceiling.</param>
+        /// <param name="material">The material of the ceiling.</param>
+        /// <param name="transform">An optional transform for the ceiling.</param>
+        /// <param name="representation">The ceiling's representation.</param>
+        /// <param name="isElementDefinition">Is this an element definition?</param>
+        /// <param name="id">The id of the ceiling.</param>
+        /// <param name="name">The name of the ceiling.</param>
+        [JsonConstructor]
+        protected BaseCeiling(Polygon perimeter,
+                      double elevation,
+                      Guid id = default(Guid),
+                      Material material = null,
+                      Transform transform = null,
+                      Representation representation = null,
+                      bool isElementDefinition = false,
+                      string name = null)
+            : base(transform ?? new Transform(),
+                   material ?? BuiltInMaterials.Concrete,
+                   representation ?? new Representation(new List<SolidOperation>()),
+                   isElementDefinition,
+                   id != default(Guid) ? id : Guid.NewGuid(),
+                   name)
+        {
+            if (!perimeter.Normal().IsParallelTo(Vector3.ZAxis))
+            {
+                throw new ArgumentException("The ceiling could not be created. The perimeter polygon must lie on the XY plane");
+            }
+
+            this.Elevation = elevation;
+            this.Perimeter = perimeter.Project(new Plane(Vector3.Origin, Vector3.ZAxis));
+        }
+
+        private protected BaseCeiling(Transform transform = null, bool isElementDefinition = false)
+            : base(transform ?? new Transform(),
+                   BuiltInMaterials.Default,
+                   new Representation(new List<SolidOperation>()),
+                   isElementDefinition,
+                   Guid.NewGuid(),
+                   null)
+        {
+        }
+    }
+}

--- a/Elements/src/OpenCeiling.cs
+++ b/Elements/src/OpenCeiling.cs
@@ -1,0 +1,84 @@
+﻿using Elements.Geometry;
+using Elements.Geometry.Solids;
+using Newtonsoft.Json;
+using System;
+
+namespace Elements
+{
+    /// <summary>
+    /// A ceiling that has no physical geometry, but still defines a perimeter and an elevation.
+    /// </summary>
+    public class OpenCeiling : BaseCeiling
+    {
+        /// <summary>
+        /// Construct a ceiling from perimeter and an elevation.
+        /// </summary>
+        /// <param name="perimeter">The plan profile of the ceiling. It must lie on the XY plane.
+        /// The Z coordinate will be ignored</param>
+        /// <param name="elevation">The elevation of the ceiling.</param>
+        /// <param name="material">The material of the ceiling.</param>
+        /// <param name="transform">An optional transform for the ceiling.</param>
+        /// <param name="representation">The ceiling's representation.</param>
+        /// <param name="isElementDefinition">Is this an element definition?</param>
+        /// <param name="id">The id of the ceiling.</param>
+        /// <param name="name">The name of the ceiling.</param>
+        public OpenCeiling(Polygon perimeter,
+                      double elevation,
+                      Material material = null,
+                      Transform transform = null,
+                      Representation representation = null,
+                      bool isElementDefinition = false,
+                      Guid id = default(Guid),
+                      string name = null)
+            : base(perimeter, elevation, material, transform, representation, isElementDefinition, id, name)
+        {
+        }
+
+        /// <summary>
+        /// Construct a ceiling from perimeter.
+        /// </summary>
+        /// <param name="perimeter">The plan perimeter of the ceiling. It must lie on the XY plane.
+        /// Z coordinate will be used as elevation</param>
+        /// <param name="material">The material of the ceiling.</param>
+        /// <param name="transform">An optional transform for the ceiling.</param>
+        /// <param name="representation">The ceiling's representation.</param>
+        /// <param name="isElementDefinition">Is this an element definition?</param>
+        /// <param name="id">The id of the ceiling.</param>
+        /// <param name="name">The name of the ceiling.</param>
+        public OpenCeiling(Polygon perimeter,
+                      Material material = null,
+                      Transform transform = null,
+                      Representation representation = null,
+                      bool isElementDefinition = false,
+                      Guid id = default(Guid),
+                      string name = null)
+            : base(perimeter, material, transform, representation, isElementDefinition, id, name)
+        {
+        }
+
+        /// <summary>
+        /// Construct a ceiling. It's a private constructor that doesn't add elevation to transform
+        /// </summary>
+        /// <param name="perimeter">The plan profile of the ceiling. It must lie on the XY plane.
+        /// The Z coordinate will be ignored</param>
+        /// <param name="elevation">The elevation of the ceiling.</param>
+        /// <param name="material">The material of the ceiling.</param>
+        /// <param name="transform">An optional transform for the ceiling.</param>
+        /// <param name="representation">The ceiling's representation.</param>
+        /// <param name="isElementDefinition">Is this an element definition?</param>
+        /// <param name="id">The id of the ceiling.</param>
+        /// <param name="name">The name of the ceiling.</param>
+        [JsonConstructor]
+        protected OpenCeiling(Polygon perimeter,
+                      double elevation,
+                      Guid id = default(Guid),
+                      Material material = null,
+                      Transform transform = null,
+                      Representation representation = null,
+                      bool isElementDefinition = false,
+                      string name = null)
+            : base(perimeter, elevation, id, material, transform, representation, isElementDefinition, name)
+        {
+        }
+    }
+}

--- a/Elements/src/SolidCeiling.cs
+++ b/Elements/src/SolidCeiling.cs
@@ -11,22 +11,12 @@ namespace Elements
     /// <summary>
     /// A ceiling defined by a planar profile extruded to a thickness.
     /// </summary>
-    public class Ceiling : GeometricElement, IHasOpenings
+    public class SolidCeiling : BaseCeiling, IHasOpenings
     {
         /// <summary>
         /// The thickness of the ceiling.
         /// </summary>
         public double Thickness { get; protected set; }
-
-        /// <summary>
-        /// The elevation of the ceiling.
-        /// </summary>
-        public double Elevation { get; protected set; }
-
-        /// <summary>
-        /// The perimeter of the ceiling.
-        /// </summary>
-        public Polygon Perimeter { get; protected set; }
 
         /// <summary>
         /// A collection of openings in the ceiling.
@@ -46,7 +36,7 @@ namespace Elements
         /// <param name="isElementDefinition">Is this an element definition?</param>
         /// <param name="id">The id of the ceiling.</param>
         /// <param name="name">The name of the ceiling.</param>
-        public Ceiling(Polygon perimeter,
+        public SolidCeiling(Polygon perimeter,
                       double thickness,
                       double elevation,
                       Material material = null,
@@ -54,27 +44,15 @@ namespace Elements
                       Representation representation = null,
                       bool isElementDefinition = false,
                       Guid id = default(Guid),
-                      string name = null) : base(transform != null ? transform : new Transform(),
-                                                 material != null ? material : BuiltInMaterials.Concrete,
-                                                 representation != null ? representation : new Representation(new List<SolidOperation>()),
-                                                 isElementDefinition,
-                                                 id != default(Guid) ? id : Guid.NewGuid(),
-                                                 name)
+                      string name = null)
+            : base(perimeter, elevation, material, transform, representation, isElementDefinition, id, name)
         {
             if (thickness <= 0.0)
             {
-                throw new ArgumentOutOfRangeException("The ceiling could not be created. The thickness of the ceiling must be greater than 0.0.");
+                throw new ArgumentOutOfRangeException(nameof(thickness), "The ceiling could not be created. The thickness of the ceiling must be greater than 0.0.");
             }
 
-            if (!perimeter.Normal().IsParallelTo(Vector3.ZAxis))
-            {
-                throw new ArgumentOutOfRangeException("The ceiling could not be created. The perimeter polygon must lie on the XY plane");
-            }
-
-            this.Elevation = elevation;
-            this.Perimeter = perimeter.Project(new Plane(Vector3.Origin, Vector3.ZAxis)); ;
             this.Thickness = thickness;
-            Transform.Move(Vector3.ZAxis * Elevation);
         }
 
         /// <summary>
@@ -89,35 +67,22 @@ namespace Elements
         /// <param name="isElementDefinition">Is this an element definition?</param>
         /// <param name="id">The id of the ceiling.</param>
         /// <param name="name">The name of the ceiling.</param>
-        public Ceiling(Polygon perimeter,
+        public SolidCeiling(Polygon perimeter,
                       double thickness,
                       Material material = null,
                       Transform transform = null,
                       Representation representation = null,
                       bool isElementDefinition = false,
                       Guid id = default(Guid),
-                      string name = null) : base(transform != null ? transform : new Transform(),
-                                                 material != null ? material : BuiltInMaterials.Concrete,
-                                                 representation != null ? representation : new Representation(new List<SolidOperation>()),
-                                                 isElementDefinition,
-                                                 id != default(Guid) ? id : Guid.NewGuid(),
-                                                 name)
+                      string name = null)
+            : base(perimeter, material, transform, representation, isElementDefinition, id, name)
         {
             if (thickness <= 0.0)
             {
-                throw new ArgumentOutOfRangeException("The ceiling could not be created. The thickness of the ceiling must be greater than 0.0.");
+                throw new ArgumentOutOfRangeException(nameof(thickness), "The ceiling could not be created. The thickness of the ceiling must be greater than 0.0.");
             }
 
-            if (!perimeter.Normal().IsParallelTo(Vector3.ZAxis))
-            {
-                throw new ArgumentOutOfRangeException("The ceiling could not be created. The perimeter polygon must lie on the XY plane");
-            }
-
-            // we do not need null check cause id there is no vertices it will fail on calculating Normal
-            this.Elevation = perimeter.Vertices.First().Z;
-            this.Perimeter = perimeter.Project(new Plane(Vector3.Origin, Vector3.ZAxis));
             this.Thickness = thickness;
-            Transform.Move(Vector3.ZAxis * Elevation);
         }
 
         /// <summary>
@@ -134,7 +99,7 @@ namespace Elements
         /// <param name="id">The id of the ceiling.</param>
         /// <param name="name">The name of the ceiling.</param>
         [JsonConstructor]
-        private Ceiling(Polygon perimeter,
+        protected SolidCeiling(Polygon perimeter,
                       double thickness,
                       double elevation,
                       Guid id = default(Guid),
@@ -142,25 +107,14 @@ namespace Elements
                       Transform transform = null,
                       Representation representation = null,
                       bool isElementDefinition = false,
-                      string name = null) : base(transform != null ? transform : new Transform(),
-                                                 material != null ? material : BuiltInMaterials.Concrete,
-                                                 representation != null ? representation : new Representation(new List<SolidOperation>()),
-                                                 isElementDefinition,
-                                                 id != default(Guid) ? id : Guid.NewGuid(),
-                                                 name)
+                      string name = null)
+            : base(perimeter, elevation, id, material, transform, representation, isElementDefinition, name)
         {
             if (thickness <= 0.0)
             {
-                throw new ArgumentOutOfRangeException("The ceiling could not be created. The thickness of the ceiling must be greater than 0.0.");
+                throw new ArgumentOutOfRangeException(nameof(thickness), "The ceiling could not be created. The thickness of the ceiling must be greater than 0.0.");
             }
 
-            if (!perimeter.Normal().IsParallelTo(Vector3.ZAxis))
-            {
-                throw new ArgumentOutOfRangeException("The ceiling could not be created. The perimeter polygon must lie on the XY plane");
-            }
-
-            this.Elevation = elevation;
-            this.Perimeter = perimeter.Project(new Plane(Vector3.Origin, Vector3.ZAxis)); ;
             this.Thickness = thickness;
         }
 
@@ -206,24 +160,15 @@ namespace Elements
         /// <param name="geometry">The geometry of the ceiling.</param>
         /// <param name="transform">The ceiling's Transform.</param>
         /// <param name="isElementDefinition">Is this an element definition?</param>
-        internal Ceiling(Solid geometry,
+        internal SolidCeiling(Solid geometry,
                       Transform transform = null,
-                      bool isElementDefinition = false) : base(transform != null ? transform : new Transform(),
-                                                         BuiltInMaterials.Default,
-                                                         new Representation(new List<SolidOperation>()),
-                                                         isElementDefinition,
-                                                         Guid.NewGuid(),
-                                                         null)
+                      bool isElementDefinition = false) : base(transform, isElementDefinition)
         {
             if (geometry == null)
             {
-                throw new ArgumentOutOfRangeException("You must supply one solid to construct a Ceiling.");
+                throw new ArgumentNullException(nameof(geometry), "You must supply one solid to construct a Ceiling.");
             }
 
-            if (transform != null)
-            {
-                this.Transform = transform;
-            }
             this.Representation.SolidOperations.Add(new ConstructedSolid(geometry));
         }
     }

--- a/Elements/src/TiledCeiling.cs
+++ b/Elements/src/TiledCeiling.cs
@@ -1,0 +1,299 @@
+﻿using Elements.Geometry;
+using Elements.Geometry.Solids;
+using Elements.Interfaces;
+using Elements.Spatial;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+
+namespace Elements
+{
+    /// <summary>
+    /// A tiled ceiling.
+    /// </summary>
+    public class TiledCeiling : BaseCeiling
+    {
+        private const string _tileCellName = "Tile";
+        private const string _spaceCellName = "Spacing";
+        private const double _minDistance = 0.001;
+
+        private Grid2d _grid;
+        private List<Polygon> _tiles;
+
+        /// <summary>
+        /// The tile width.
+        /// </summary>
+        public double TileWidth { get; protected set; }
+
+        /// <summary>
+        /// The tile length.
+        /// </summary>
+        public double TileLength { get; protected set; }
+
+        /// <summary>
+        /// The space between tiles.
+        /// </summary>
+        public double SpaceBetween { get; protected set; }
+
+        /// <summary>
+        /// The grid orientation.
+        /// </summary>
+        public Transform GridOrientation { get; protected set; }
+
+        /// <summary>
+        /// Construct a ceiling from tiles.
+        /// </summary>
+        /// <param name="perimeter">The plan profile of the ceiling. It must lie on the XY plane.
+        /// The Z coordinate will be ignored</param>
+        /// <param name="elevation">The elevation of the ceiling.</param>
+        /// <param name="tileWidth">The tile width.</param>
+        /// <param name="tileLength">The tile length.</param>
+        /// <param name="spaceBetween">The space between tiles.</param>
+        /// <param name="gridOrientation">The grid orientation.</param>
+        /// <param name="material">The material of the ceiling.</param>
+        /// <param name="transform">An optional transform for the ceiling.</param>
+        /// <param name="representation">The ceiling's representation.</param>
+        /// <param name="isElementDefinition">Is this an element definition?</param>
+        /// <param name="id">The id of the ceiling.</param>
+        /// <param name="name">The name of the ceiling.</param>
+        public TiledCeiling(Polygon perimeter,
+                      double elevation,
+                      double tileWidth,
+                      double tileLength,
+                      double spaceBetween,
+                      Transform gridOrientation = null,
+                      Material material = null,
+                      Transform transform = null,
+                      Representation representation = null,
+                      bool isElementDefinition = false,
+                      Guid id = default(Guid),
+                      string name = null)
+            : base(perimeter, elevation, material, transform, representation, isElementDefinition, id, name)
+        {
+            if (tileWidth < _minDistance)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tileWidth), $"The ceiling could not be created. The tile width must be greater than or equal to {_minDistance}.");
+            }
+            if (tileLength < _minDistance)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tileLength), $"The ceiling could not be created. The tile length must be greater than or equal to {_minDistance}.");
+            }
+            if (spaceBetween < _minDistance)
+            {
+                throw new ArgumentOutOfRangeException(nameof(spaceBetween), $"The ceiling could not be created. The space between tiles must be greater than or equal to {_minDistance}.");
+            }
+
+            this.TileWidth = tileWidth;
+            this.TileLength = tileLength;
+            this.SpaceBetween = spaceBetween;
+            this.GridOrientation = gridOrientation;
+        }
+
+        /// <summary>
+        /// Construct a ceiling from tiles.
+        /// </summary>
+        /// <param name="perimeter">The plan perimeter of the ceiling. It must lie on the XY plane.
+        /// Z coordinate will be used as elevation</param>
+        /// <param name="tileWidth">The tile width.</param>
+        /// <param name="tileLength">The tile length.</param>
+        /// <param name="spaceBetween">The space between tiles.</param>
+        /// <param name="gridOrientation">The grid orientation.</param>
+        /// <param name="material">The material of the ceiling.</param>
+        /// <param name="transform">An optional transform for the ceiling.</param>
+        /// <param name="representation">The ceiling's representation.</param>
+        /// <param name="isElementDefinition">Is this an element definition?</param>
+        /// <param name="id">The id of the ceiling.</param>
+        /// <param name="name">The name of the ceiling.</param>
+        public TiledCeiling(Polygon perimeter,
+                      double tileWidth,
+                      double tileLength,
+                      double spaceBetween,
+                      Transform gridOrientation = null,
+                      Material material = null,
+                      Transform transform = null,
+                      Representation representation = null,
+                      bool isElementDefinition = false,
+                      Guid id = default(Guid),
+                      string name = null)
+            : base(perimeter, material, transform, representation, isElementDefinition, id, name)
+        {
+            if (tileWidth < _minDistance)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tileWidth), $"The ceiling could not be created. The tile width must be greater than or equal to {_minDistance}.");
+            }
+            if (tileLength < _minDistance)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tileLength), $"The ceiling could not be created. The tile length must be greater than or equal to {_minDistance}.");
+            }
+            if (spaceBetween < _minDistance)
+            {
+                throw new ArgumentOutOfRangeException(nameof(spaceBetween), $"The ceiling could not be created. The space between tiles must be greater than or equal to {_minDistance}.");
+            }
+
+            this.TileWidth = tileWidth;
+            this.TileLength = tileLength;
+            this.SpaceBetween = spaceBetween;
+            this.GridOrientation = gridOrientation;
+        }
+
+        /// <summary>
+        /// Construct a ceiling from tiles. It's a private constructor that doesn't add elevation to transform
+        /// </summary>
+        /// <param name="perimeter">The plan profile of the ceiling. It must lie on the XY plane.
+        /// The Z coordinate will be ignored</param>
+        /// <param name="elevation">The elevation of the ceiling.</param>
+        /// <param name="tileWidth"></param>
+        /// <param name="tileLength"></param>
+        /// <param name="spaceBetween"></param>
+        /// <param name="gridOrientation"></param>
+        /// <param name="material">The material of the ceiling.</param>
+        /// <param name="transform">An optional transform for the ceiling.</param>
+        /// <param name="representation">The ceiling's representation.</param>
+        /// <param name="isElementDefinition">Is this an element definition?</param>
+        /// <param name="id">The id of the ceiling.</param>
+        /// <param name="name">The name of the ceiling.</param>
+        [JsonConstructor]
+        protected TiledCeiling(Polygon perimeter,
+                      double elevation,
+                      double tileWidth,
+                      double tileLength,
+                      double spaceBetween,
+                      Transform gridOrientation = null,
+                      Guid id = default(Guid),
+                      Material material = null,
+                      Transform transform = null,
+                      Representation representation = null,
+                      bool isElementDefinition = false,
+                      string name = null)
+            : base(perimeter, elevation, id, material, transform, representation, isElementDefinition, name)
+        {
+            if (tileWidth < _minDistance)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tileWidth), $"The ceiling could not be created. The tile width must be greater than or equal to {_minDistance}.");
+            }
+            if (tileLength < _minDistance)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tileLength), $"The ceiling could not be created. The tile length must be greater than or equal to {_minDistance}.");
+            }
+            if (spaceBetween < _minDistance)
+            {
+                throw new ArgumentOutOfRangeException(nameof(spaceBetween), $"The ceiling could not be created. The space between tiles must be greater than or equal to {_minDistance}.");
+            }
+
+            this.TileWidth = tileWidth;
+            this.TileLength = tileLength;
+            this.SpaceBetween = spaceBetween;
+            this.GridOrientation = gridOrientation;
+        }
+
+        /// <summary>
+        /// Update the representations.
+        /// </summary>
+        public override void UpdateRepresentations()
+        {
+            this.Representation.SolidOperations.Clear();
+
+            var tiles = GetTiles();
+            foreach (var tile in tiles)
+            {
+                Representation.SolidOperations.Add(new Lamina(tile));
+            }
+        }
+
+        /// <summary>
+        /// Get tiles.
+        /// </summary>
+        /// <returns>List of tiles.</returns>
+        public List<Polygon> GetTiles()
+        {
+            if (_tiles == null)
+            {
+                _tiles = BuildCeilingTiles();
+            }
+
+            return _tiles;
+        }
+
+        /// <summary>
+        /// Get an underlying grid.
+        /// </summary>
+        /// <returns>An underlying grid.</returns>
+        public Grid2d GetGrid()
+        {
+            if (_grid == null)
+            {
+                _grid = BuildGrid();
+            }
+
+            return _grid;
+        }
+
+        /// <summary>
+        /// Get count of U cells.
+        /// </summary>
+        /// <returns>Count of U cells.</returns>
+        public int GetCountOfUCells()
+        {
+            return GetGrid().U.GetCells().Count(cell => cell.Type?.Contains(_spaceCellName) == false);
+        }
+
+        /// <summary>
+        /// Get count of V cells.
+        /// </summary>
+        /// <returns>Count of v cells.</returns>
+        public int GetCountOfVCells()
+        {
+            return GetGrid().V.GetCells().Count(cell => cell.Type?.Contains(_spaceCellName) == false);
+        }
+
+        private List<Polygon> BuildCeilingTiles()
+        {
+            var cells = GetGrid().GetCells();
+
+            if (cells.Count == 1 && cells[0].IsSingleCell)
+            {
+                return cells[0].GetTrimmedCellGeometry().OfType<Polygon>().ToList();
+            }
+
+            return cells
+                    .Where(c => c.Type?.Contains(_spaceCellName) == false)
+                    .SelectMany(c => c.GetTrimmedCellGeometry())
+                    .OfType<Polygon>()
+                    .ToList();
+        }
+
+        private Grid2d BuildGrid()
+        {
+            var grid = GridOrientation == null ? new Grid2d(Perimeter) : new Grid2d(Perimeter, GridOrientation);
+
+            var patternU = new List<(string typeName, double length)>()
+            {
+                (_tileCellName, TileLength),
+                (_spaceCellName, SpaceBetween)
+            };
+            var patternV = new List<(string typeName, double length)>()
+            {
+                (_tileCellName, TileWidth),
+                (_spaceCellName, SpaceBetween)
+            };
+            grid.U.DivideByPattern(patternU);
+            grid.V.DivideByPattern(patternV);
+
+            var uCells = grid.U.GetCells();
+            for (var i = 0; i < uCells.Count; i++)
+            {
+                uCells[i].Type = patternU[i % patternU.Count].typeName;
+            }
+
+            var vCells = grid.V.GetCells();
+            for (var i = 0; i < vCells.Count; i++)
+            {
+                vCells[i].Type = patternV[i % patternV.Count].typeName;
+            }
+
+            return grid;
+        }
+    }
+}


### PR DESCRIPTION
BACKGROUND:
We need new ceilings types for creating ceilings.

DESCRIPTION:
- Add new classes for ceilings: 
   - BaseCeiling - the base class for all ceilings.
   - OpenCeiling - a ceiling that has no physical geometry, but still defines a perimeter and an elevation
   - TiledCeiling - tiled ceiling, which is defined by tile length, width and space between tiles.
- Rename Ceiling class to SolidCeiling

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/766)
<!-- Reviewable:end -->
