### PR TITLE
Fix 770

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - `LocalClassification`
 - `ModelLines`
 - `AdaptiveGrid.AddVertex(Vector3 point, List<Vertex> connections)`
+- `Color.SRGBToLinear(double c)`
+- `Color.LinearToSRGB(double c)`
 
 ### Changed
 - Add parameter `removeCutEdges` to `AdaptiveGrid.SubtractBox` that control if cut parts of intersected edges need to be inserted into the graph.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Changed
 - Add parameter `removeCutEdges` to `AdaptiveGrid.SubtractBox` that control if cut parts of intersected edges need to be inserted into the graph.
+- Material colors are now exported to glTF using linear color space. Conversion from sRGB to linear color space happens during glTF export.
 
 ### Fixed
 - Under some circumstances `Bezier.Length()` would return incorrect results

--- a/Elements/src/Geometry/Color.cs
+++ b/Elements/src/Geometry/Color.cs
@@ -104,8 +104,12 @@ namespace Elements.Geometry
         /// Get the color's components as an array.
         /// </summary>
         /// <returns>An array containing the color's components.</returns>
-        public float[] ToArray()
+        public float[] ToArray(bool convertToLinearColorSpace = false)
         {
+            if (convertToLinearColorSpace)
+            {
+                return new[] { (float)SRGBToLinear(Red), (float)SRGBToLinear(Green), (float)SRGBToLinear(Blue), (float)Alpha };
+            }
             return new[] { (float)Red, (float)Green, (float)Blue, (float)Alpha };
         }
 
@@ -266,6 +270,26 @@ namespace Elements.Geometry
                 throw new ArgumentNullException("Cannot convert null to a Color. Color is a non-nullable type.");
             }
             return new Color(hexOrName);
+        }
+
+        /// <summary>
+        /// Convert a gamma color space component to a linear color space value.
+        /// </summary>
+        /// <param name="c">The gamma color component value.</param>
+        /// <returns>A linear color space component value.</returns>
+        public static double SRGBToLinear(double c)
+        {
+            return (c < 0.04045) ? c * 0.0773993808 : Math.Pow(c * 0.9478672986 + 0.0521327014, 2.4);
+        }
+
+        /// <summary>
+        /// Convert a linear color space component to a gamma color space value.
+        /// </summary>
+        /// <param name="c">The linear color component value.</param>
+        /// <returns>A gamma color space component value.</returns>
+        public static double LinearToSRGB(double c)
+        {
+            return (c < 0.0031308) ? 12.92 * c : (1.055 * Math.Pow(c, 0.41666)) - 0.055;
         }
     }
 }

--- a/Elements/src/Material.cs
+++ b/Elements/src/Material.cs
@@ -9,6 +9,9 @@ namespace Elements
     /// <summary>
     /// A material with red, green, blue, alpha, and metallic factor components.
     /// </summary>
+    /// <example>
+    /// [!code-csharp[Main](../../Elements/test/MaterialTests.cs?name=example)]
+    /// </example>
     public class Material : Element
     {
         /// <summary>The material's color.</summary>

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -217,9 +217,9 @@ namespace Elements.Serialization.glTF
                     m.Extensions = new Dictionary<string, object>{
                         {"KHR_materials_pbrSpecularGlossiness", new Dictionary<string,object>{
                             {"diffuseFactor", new[]{
-                                Geometry.Color.LinearToSRGB(material.Color.Red),
-                                Geometry.Color.LinearToSRGB(material.Color.Green),
-                                Geometry.Color.LinearToSRGB(material.Color.Blue),
+                                Geometry.Color.SRGBToLinear(material.Color.Red),
+                                Geometry.Color.SRGBToLinear(material.Color.Green),
+                                Geometry.Color.SRGBToLinear(material.Color.Blue),
                                 material.Color.Alpha}},
                             {"specularFactor", new[]{material.SpecularFactor, material.SpecularFactor, material.SpecularFactor}},
                             {"glossinessFactor", material.GlossinessFactor}

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -196,9 +196,11 @@ namespace Elements.Serialization.glTF
                 var m = new glTFLoader.Schema.Material();
                 newMaterials.Add(m);
 
-                m.PbrMetallicRoughness = new MaterialPbrMetallicRoughness();
-                m.PbrMetallicRoughness.BaseColorFactor = material.Color.ToArray();
-                m.PbrMetallicRoughness.MetallicFactor = 1.0f;
+                m.PbrMetallicRoughness = new MaterialPbrMetallicRoughness
+                {
+                    BaseColorFactor = material.Color.ToArray(true),
+                    MetallicFactor = 1.0f
+                };
                 m.DoubleSided = material.DoubleSided;
 
                 m.Name = material.Id.ToString();
@@ -211,9 +213,14 @@ namespace Elements.Serialization.glTF
                 }
                 else
                 {
+                    // We convert to a linear color space
                     m.Extensions = new Dictionary<string, object>{
                         {"KHR_materials_pbrSpecularGlossiness", new Dictionary<string,object>{
-                            {"diffuseFactor", new[]{material.Color.Red,material.Color.Green,material.Color.Blue,material.Color.Alpha}},
+                            {"diffuseFactor", new[]{
+                                Geometry.Color.LinearToSRGB(material.Color.Red),
+                                Geometry.Color.LinearToSRGB(material.Color.Green),
+                                Geometry.Color.LinearToSRGB(material.Color.Blue),
+                                material.Color.Alpha}},
                             {"specularFactor", new[]{material.SpecularFactor, material.SpecularFactor, material.SpecularFactor}},
                             {"glossinessFactor", material.GlossinessFactor}
                         }}

--- a/Elements/test/MaterialTests.cs
+++ b/Elements/test/MaterialTests.cs
@@ -8,6 +8,43 @@ namespace Elements.Tests
     public class MaterialTests : ModelTest
     {
         [Fact]
+        public void Example()
+        {
+            this.Name = "Elements_Material";
+
+            // <example>
+            var x = 0.0;
+            var y = 0.0;
+            var z = 0.0;
+            var specularFactor = 0.0;
+            var glossinessFactor = 0.0;
+
+            var rectangle = Polygon.Rectangle(0.5, 0.5);
+
+            for (var r = 0.0; r <= 1.0; r += 0.2)
+            {
+                for (var g = 0.0; g <= 1.0; g += 0.2)
+                {
+                    for (var b = 0.0; b <= 1.0; b += 0.2)
+                    {
+                        var color = new Color(r, g, b, 1.0);
+                        var material = new Material($"{r}_{g}_{b}", color, specularFactor, glossinessFactor);
+                        var mass = new Mass(rectangle, 0.5, material, new Transform(new Vector3(x, y, z)));
+                        this.Model.AddElement(mass);
+                        z += 2.0;
+                    }
+                    z = 0;
+                    y += 2.0;
+                }
+                y = 0;
+                x += 2.0;
+                specularFactor += 0.2;
+                glossinessFactor += 0.2;
+            }
+            // </example>
+        }
+
+        [Fact]
         public void Construct()
         {
             var material = new Material("test", new Color(1.0f, 1.0f, 1.0f, 1.0f), 1.0f, 1.0f);


### PR DESCRIPTION
BACKGROUND:
See #770.

DESCRIPTION:
- This PR adds linear color space conversion during glTF export.
- This PR adds a material example to be included in the docs. (noted missing in #768).

TESTING:
- How should a reviewer observe the behavior desired by this pull request?
 

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

The image below shows masses under normal lighting, and image texture, and CSS colors all matching.
![image](https://user-images.githubusercontent.com/1139788/153686263-15bee2c4-594c-43e1-b831-d1dce336d96b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/771)
<!-- Reviewable:end -->
