### PR TITLE
Line get overlap extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - `AdaptiveGrid.AddVertex(Vector3 point, List<Vertex> connections)`
 - `Color.SRGBToLinear(double c)`
 - `Color.LinearToSRGB(double c)`
+- `Line.IsCollinear(Line line)`
+- `Line.GetOverlap(Line line)`
 
 ### Changed
 - Add parameter `removeCutEdges` to `AdaptiveGrid.SubtractBox` that control if cut parts of intersected edges need to be inserted into the graph.

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1,3 +1,5 @@
+using System.Net.Sockets;
+using System.Numerics;
 using Elements.Validators;
 using System;
 using System.Collections.Generic;
@@ -996,7 +998,7 @@ namespace Elements.Geometry
         /// <returns></returns>
         public bool IsCollinear(Line line)
         {
-            return line.Direction().IsParallelTo(Direction());
+            return Vector3.AreCollinear(Start, End, line.Start) && Vector3.AreCollinear(Start, End, line.End);
         }
 
         /// <summary>
@@ -1012,7 +1014,7 @@ namespace Elements.Geometry
             if(!IsCollinear(line))
                 return null;
 
-            //order verticies of lines
+            //order vertices of lines
             var vectors = new List<Vector3>() { Start, End, line.Start, line.End };
             var orderedVectors = vectors.OrderBy(v => v.X + v.Y + v.Z).ToList();
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1000,6 +1000,38 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Get overlapping line of this and other line
+        /// </summary>
+        /// <param name="line">Line to check</param>
+        /// <returns>Returns line or null if lines are not collinear or do not overlap</returns>
+        public Line GetOverlap(Line line)
+        {
+            if(line == null)
+                return null;
+
+            if(!IsCollinear(line))
+                return null;
+
+            //order verticies of lines
+            var vectors = new List<Vector3>() { Start, End, line.Start, line.End };
+            var orderedVectors = vectors.OrderBy(v => v.X + v.Y).ToList();
+
+            //check if 2nd point lies on both lines
+            if (!PointOnLine(orderedVectors[1], Start, End, true) || !PointOnLine(orderedVectors[1], line.Start, line.End, true))
+                return null;
+
+            //check if 3rd point lies on both lines
+            if (!PointOnLine(orderedVectors[2], Start, End, true) || !PointOnLine(orderedVectors[2], line.Start, line.End, true))
+                return null;
+
+            //edge case when lines share only point
+            if(orderedVectors[1].IsAlmostEqualTo(orderedVectors[2]))
+                return null;
+
+            return new Line(orderedVectors[1], orderedVectors[2]);
+        }
+
+        /// <summary>
         /// A list of vertices describing the arc for rendering.
         /// </summary>
         internal override IList<Vector3> RenderVertices()

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1014,7 +1014,7 @@ namespace Elements.Geometry
 
             //order verticies of lines
             var vectors = new List<Vector3>() { Start, End, line.Start, line.End };
-            var orderedVectors = vectors.OrderBy(v => v.X + v.Y).ToList();
+            var orderedVectors = vectors.OrderBy(v => v.X + v.Y + v.Z).ToList();
 
             //check if 2nd point lies on both lines
             if (!PointOnLine(orderedVectors[1], Start, End, true) || !PointOnLine(orderedVectors[1], line.Start, line.End, true))

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1028,7 +1028,12 @@ namespace Elements.Geometry
             if(orderedVectors[1].IsAlmostEqualTo(orderedVectors[2]))
                 return null;
 
-            return new Line(orderedVectors[1], orderedVectors[2]);
+            var overlappingLine = new Line(orderedVectors[1], orderedVectors[2]);
+            
+            //keep the same direction as original line
+            return Direction().IsAlmostEqualTo(overlappingLine.Direction()) 
+                ? overlappingLine
+                : overlappingLine.Reversed();
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -990,6 +990,16 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Check if this line is collinear with other line
+        /// </summary>
+        /// <param name="line">Line to check</param>
+        /// <returns></returns>
+        public bool IsCollinear(Line line)
+        {
+            return line.Direction().IsParallelTo(Direction());
+        }
+
+        /// <summary>
         /// A list of vertices describing the arc for rendering.
         /// </summary>
         internal override IList<Vector3> RenderVertices()

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1002,17 +1002,20 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Get overlapping line of this and other line
+        /// Check if line overlap with other line
         /// </summary>
         /// <param name="line">Line to check</param>
-        /// <returns>Returns line or null if lines are not collinear or do not overlap</returns>
-        public Line GetOverlap(Line line)
+        /// <param name="overlap">Overlapping line or null when lines do not overlap</param>
+        /// <returns>Returns true when lines overlap and false when they do not</returns>
+        public bool TryGetOverlap(Line line, out Line overlap)
         {
+            overlap = null;
+
             if(line == null)
-                return null;
+                return false;
 
             if(!IsCollinear(line))
-                return null;
+                return false;
 
             //order vertices of lines
             var vectors = new List<Vector3>() { Start, End, line.Start, line.End };
@@ -1020,22 +1023,24 @@ namespace Elements.Geometry
 
             //check if 2nd point lies on both lines
             if (!PointOnLine(orderedVectors[1], Start, End, true) || !PointOnLine(orderedVectors[1], line.Start, line.End, true))
-                return null;
+                return false;
 
             //check if 3rd point lies on both lines
             if (!PointOnLine(orderedVectors[2], Start, End, true) || !PointOnLine(orderedVectors[2], line.Start, line.End, true))
-                return null;
+                return false;
 
             //edge case when lines share only point
             if(orderedVectors[1].IsAlmostEqualTo(orderedVectors[2]))
-                return null;
+                return false;
 
             var overlappingLine = new Line(orderedVectors[1], orderedVectors[2]);
             
             //keep the same direction as original line
-            return Direction().IsAlmostEqualTo(overlappingLine.Direction()) 
+            overlap = Direction().IsAlmostEqualTo(overlappingLine.Direction()) 
                 ? overlappingLine
                 : overlappingLine.Reversed();
+
+            return true;
         }
 
         /// <summary>

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -491,5 +491,36 @@ namespace Elements.Geometry.Tests
             var sharedEndLine = new Line(new Vector3(-5, 5, 5), new Vector3(5, 5, 5));
             Assert.False(line.IsCollinear(sharedEndLine));
         }
+
+        [Fact]
+        public void GetOverlap()
+        {
+            var line = new Line(Vector3.Origin, new Vector3(5, 5, 5));
+
+            var nonCollinearLine = new Line(new Vector3(-5, 5, 5), new Vector3(10, 10, -5));
+            Assert.Null(line.GetOverlap(nonCollinearLine));
+
+            var sharedEndLine = new Line(new Vector3(10, 10, 10), new Vector3(5, 5, 5));
+            Assert.Null(line.GetOverlap(sharedEndLine));
+
+            var sharedStartLine = new Line(Vector3.Origin, new Vector3(-10, -10, -10));
+            Assert.Null(line.GetOverlap(sharedStartLine));
+
+            var collinearLine = new Line(new Vector3(10, 10, 10), new Vector3(20,20,20));
+            Assert.Null(line.GetOverlap(collinearLine));
+
+            var sameLine = new Line(Vector3.Origin, new Vector3(5, 5, 5));
+            var sameResult = line.GetOverlap(sameLine);
+            Assert.NotNull(sameResult);
+            Assert.True(sameResult.IsAlmostEqualTo(line, false));
+
+            var ovelappingLine = new Line(new Vector3(2, 2, 2), new Vector3(-10, -10, -10));
+            var expectedLine = new Line(Vector3.Origin, new Vector3(2, 2, 2));
+            var overlapResult = line.GetOverlap(ovelappingLine);
+            Assert.NotNull(overlapResult);
+            Assert.True(overlapResult.IsAlmostEqualTo(expectedLine, false));
+
+
+        }
     }
 }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -464,5 +464,32 @@ namespace Elements.Geometry.Tests
             );
             Assert.False(points1.AreCollinear());
         }
+
+        [Fact]
+        public void IsCollinear()
+        {
+            var line = new Line(Vector3.Origin, new Vector3(5, 5, 5));
+
+            var collinearLine = new Line(new Vector3(10, 10, 10), new Vector3(20, 20, 20));
+            Assert.True(line.IsCollinear(collinearLine));
+
+            var nonCollinearLine = new Line(new Vector3(-5, 5, 5), new Vector3(10, 10, -5));
+            Assert.False(line.IsCollinear(nonCollinearLine));
+
+            var reversedLine = new Line(new Vector3(5, 5, 5), Vector3.Origin);
+            Assert.True(line.IsCollinear(reversedLine));
+
+            var sameLine = new Line(Vector3.Origin, new Vector3(5, 5, 5));
+            Assert.True(line.IsCollinear(sameLine));
+
+            var ovelappingLine = new Line(new Vector3(2, 2, 2), new Vector3(-10, -10, -10));
+            Assert.True(line.IsCollinear(ovelappingLine));
+
+            var sharedStartLine = new Line(Vector3.Origin, new Vector3(10, 10, -5));
+            Assert.False(line.IsCollinear(sharedStartLine));
+
+            var sharedEndLine = new Line(new Vector3(-5, 5, 5), new Vector3(5, 5, 5));
+            Assert.False(line.IsCollinear(sharedEndLine));
+        }
     }
 }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -491,38 +491,42 @@ namespace Elements.Geometry.Tests
             var sharedEndLine = new Line(new Vector3(-5, 5, 5), new Vector3(5, 5, 5));
             Assert.False(line.IsCollinear(sharedEndLine));
 
-            //var parallelLine = new Line(new Vector3(3, 3, 0), new Vector3(8, 8, 5));
-            //Assert.True(line.Direction().IsParallelTo(parallelLine.Direction()));
-            //Assert.False(line.IsCollinear(parallelLine));
+            var parallelLine = new Line(new Vector3(3, 3, 0), new Vector3(8, 8, 5));
+            Assert.True(line.Direction().IsParallelTo(parallelLine.Direction()));
+            Assert.False(line.IsCollinear(parallelLine));
         }
 
         [Fact]
-        public void GetOverlap()
+        public void TryGetOverlap()
         {
             var line = new Line(Vector3.Origin, new Vector3(5, 5, 5));
 
             var nonCollinearLine = new Line(new Vector3(-5, 5, 5), new Vector3(10, 10, -5));
-            Assert.Null(line.GetOverlap(nonCollinearLine));
+            Assert.False(line.TryGetOverlap(nonCollinearLine, out Line nonCollinearOverlap));
+            Assert.Null(nonCollinearOverlap);
 
             var sharedEndLine = new Line(new Vector3(10, 10, 10), new Vector3(5, 5, 5));
-            Assert.Null(line.GetOverlap(sharedEndLine));
+            Assert.False(line.TryGetOverlap(sharedEndLine, out Line sharedEndOverlap));
+            Assert.Null(sharedEndOverlap);
 
             var sharedStartLine = new Line(Vector3.Origin, new Vector3(-10, -10, -10));
-            Assert.Null(line.GetOverlap(sharedStartLine));
+            Assert.False(line.TryGetOverlap(sharedStartLine, out Line sharedStartOverlap));
+            Assert.Null(sharedStartOverlap);
 
-            var collinearLine = new Line(new Vector3(10, 10, 10), new Vector3(20,20,20));
-            Assert.Null(line.GetOverlap(collinearLine));
+            var collinearLine = new Line(new Vector3(10, 10, 10), new Vector3(20, 20, 20));
+            Assert.False(line.TryGetOverlap(collinearLine, out Line collinearOverlap));
+            Assert.Null(collinearOverlap);
 
             var sameLine = new Line(Vector3.Origin, new Vector3(5, 5, 5));
-            var sameResult = line.GetOverlap(sameLine);
-            Assert.NotNull(sameResult);
-            Assert.True(sameResult.IsAlmostEqualTo(line, false));
+            Assert.True(line.TryGetOverlap(sameLine, out Line sameLineOverlap));
+            Assert.NotNull(sameLineOverlap);
+            Assert.True(sameLineOverlap.IsAlmostEqualTo(line, false));
 
             var ovelappingLine = new Line(new Vector3(2, 2, 2), new Vector3(-10, -10, -10));
             var expectedLine = new Line(Vector3.Origin, new Vector3(2, 2, 2));
-            var overlapResult = line.GetOverlap(ovelappingLine);
-            Assert.NotNull(overlapResult);
-            Assert.True(overlapResult.IsAlmostEqualTo(expectedLine, false));
+            Assert.True(line.TryGetOverlap(ovelappingLine, out Line overlapLine));
+            Assert.NotNull(overlapLine);
+            Assert.True(overlapLine.IsAlmostEqualTo(expectedLine, false));
 
 
         }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -490,6 +490,10 @@ namespace Elements.Geometry.Tests
 
             var sharedEndLine = new Line(new Vector3(-5, 5, 5), new Vector3(5, 5, 5));
             Assert.False(line.IsCollinear(sharedEndLine));
+
+            //var parallelLine = new Line(new Vector3(3, 3, 0), new Vector3(8, 8, 5));
+            //Assert.True(line.Direction().IsParallelTo(parallelLine.Direction()));
+            //Assert.False(line.IsCollinear(parallelLine));
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
- I found two missing methods in Line API:
  - `IsCollinear(Line line)` will check if line is collinear with base line
  - `GetOverlap(Line line)` will return line which is a part of both lines, base and line
  
![image](https://user-images.githubusercontent.com/97615778/154447403-cfd4c84a-401f-4e16-bd79-80bbb5f07314.png)

DESCRIPTION:
- `IsCollinear(Line line)` methods checks if `Direction` vectors are parallel
- `GetOverlap(Line line)` method checks if lines are collinear, then it takes all line ends and order them by sum of their coordinates. When 2nd and 3rd vector lies on both lines they are ends of overlapping line. 

TESTING:
- Run `IsCollinear` and `GetOverlap` unit tests 
  
FUTURE WORK:
- There is no future work needed 

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/774)
<!-- Reviewable:end -->
