### PR TITLE
Remove removeCutEdges parameter from AdaptiveGrid.SubstructBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.0
+
+### Added
+
+### Changed
+- Remove ``removeCutEdges` from `AdaptiveGrid.SubtractBox` and always remove cut parts of intersected edges.
+
+### Fixed
+
 ## 0.9.9
 
 ### Added

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -166,8 +166,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// that is inside the box. Note that no new connections are created afterwards.
         /// </summary>
         /// <param name="box">Boding box to subtract</param>
-        /// <param name="removeCutEdges">Should edge be removed or replaced by leftover pieces</param>
-        public void SubtractBox(BBox3 box, bool removeCutEdges = false)
+        public void SubtractBox(BBox3 box)
         {
             List<Edge> edgesToDelete = new List<Edge>();
             foreach (var edge in GetEdges())
@@ -222,46 +221,13 @@ namespace Elements.Spatial.AdaptiveGrid
                     {
                         //Need to find which end is inside the box. 
                         //If none - we just touched the corner
-                        if (startInside)
+                        if (startInside || endInside)
                         {
-                            if (!removeCutEdges)
-                            {
-                                var v = AddVertex(intersections[0]);
-                                if (edge.EndId != v.Id)
-                                {
-                                    AddEdge(v.Id, edge.EndId);
-                                }
-                            }
-                            edgesToDelete.Add(edge);
-                        }
-                        else if (endInside)
-                        {
-                            if (!removeCutEdges)
-                            {
-                                var v = AddVertex(intersections[0]);
-                                if (edge.StartId != v.Id)
-                                {
-                                    AddEdge(edge.StartId, v.Id);
-                                }
-                            }
                             edgesToDelete.Add(edge);
                         }
                     }
                     if (intersections.Count == 2)
                     {
-                        if (!removeCutEdges)
-                        {
-                            var v0 = AddVertex(intersections[0]);
-                            var v1 = AddVertex(intersections[1]);
-                            if (edge.StartId != v0.Id)
-                            {
-                                AddEdge(edge.StartId, v0.Id);
-                            }
-                            if (edge.EndId != v1.Id)
-                            {
-                                AddEdge(v1.Id, edge.EndId);
-                            }
-                        }
                         edgesToDelete.Add(edge);
                     }
                 }

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -206,9 +206,9 @@ namespace Elements.Tests
             var halfTol = adaptiveGrid.Tolerance / 2;
             var modified = vertex.Point + new Vector3(0, 0, halfTol);
             adaptiveGrid.TryGetVertexIndex(new Vector3(10, 0), out var otherId);
-            var newVetex = adaptiveGrid.AddVertex(modified, 
+            var newVertex = adaptiveGrid.AddVertex(modified, 
                 new List<Vertex> { adaptiveGrid.GetVertex(otherId) });
-            Assert.Equal(id, newVetex.Id);
+            Assert.Equal(id, newVertex.Id);
             modified = vertex.Point + new Vector3(-halfTol, -halfTol, -halfTol);
             adaptiveGrid.TryGetVertexIndex(modified, out otherId, adaptiveGrid.Tolerance);
             Assert.Equal(id, otherId);


### PR DESCRIPTION
BACKGROUND:
During creation of documentation for AdaptiveGrid in was discussed that removeCutEdges option was not used and not really needed.
Grid with leftover edges
![Obsticle with edges](https://user-images.githubusercontent.com/22522160/154504901-88f715f8-396d-4c4d-a6cd-a7d5554dd3d5.PNG)
Grid without leftover edges
![Obstacle without edges](https://user-images.githubusercontent.com/22522160/154504906-cafabe8f-ac5a-4f82-9676-cf4b970ea73c.PNG)
Moreover, cut edge code makes function much more complicated.

DESCRIPTION:
- These changes remove extra code needed to support removeCutEdges  = false

TESTING:
- Removed a test for removeCutEdges = true
- Add one test to AdaptiveGridTest not related to the changes
- Add Trait("Category", "Examples") to tests that use model outputs
  
FUTURE WORK:

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/775)
<!-- Reviewable:end -->
