### PR TITLE
Fix polygon creation from vertices with sequential duplicates

### DIFF
--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -31,26 +31,26 @@ namespace Elements.Geometry
         [Newtonsoft.Json.JsonConstructor]
         public Polygon(IList<Vector3> @vertices) : base(vertices)
         {
-            if (!Validator.DisableValidationOnConstruction)
+            _plane = Plane();
+        }
+
+        protected override void ValidateVertices()
+        {
+            if (!Vertices.AreCoplanar())
             {
-                if (!vertices.AreCoplanar())
-                {
-                    throw new ArgumentException("The polygon could not be created. The provided vertices are not coplanar.");
-                }
-
-                this.Vertices = Vector3.RemoveSequentialDuplicates(this.Vertices, true);
-                DeleteVerticesForOverlappingEdges(this.Vertices);
-                if (this.Vertices.Count < 3)
-                {
-                    throw new ArgumentException("The polygon could not be created. At least 3 vertices are required.");
-                }
-
-                CheckSegmentLengthAndThrow(Edges());
-                var t = Vertices.ToTransform();
-                CheckSelfIntersectionAndThrow(t, Edges());
+                throw new ArgumentException("The polygon could not be created. The provided vertices are not coplanar.");
             }
 
-            _plane = Plane();
+            this.Vertices = Vector3.RemoveSequentialDuplicates(this.Vertices, true);
+            DeleteVerticesForOverlappingEdges(this.Vertices);
+            if (this.Vertices.Count < 3)
+            {
+                throw new ArgumentException("The polygon could not be created. At least 3 vertices are required.");
+            }
+
+            CheckSegmentLengthAndThrow(Edges());
+            var t = Vertices.ToTransform();
+            CheckSelfIntersectionAndThrow(t, Edges());
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -39,10 +39,15 @@ namespace Elements.Geometry
 
             if (!Validator.DisableValidationOnConstruction)
             {
-                Vertices = Vector3.RemoveSequentialDuplicates(Vertices);
-                CheckSegmentLengthAndThrow(Edges());
+                ValidateVertices();
             }
             _bounds = new BBox3(Vertices);
+        }
+
+        protected virtual void ValidateVertices()
+        {
+            Vertices = Vector3.RemoveSequentialDuplicates(Vertices);
+            CheckSegmentLengthAndThrow(Edges());
         }
 
         /// <summary>

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -1988,5 +1988,19 @@ namespace Elements.Geometry.Tests
             Assert.Equal(2, polys.Where(p => p.Item2 == SetClassification.AOutsideB).Count());
             Assert.Single(polys.Where(p => p.Item2 == SetClassification.AInsideB));
         }
+
+        [Fact]
+        public void ConstructWithSequentialDuplicates()
+        {
+            var polygon = new Polygon(new List<Vector3>()
+            {
+                Vector3.Origin,
+                new Vector3(-6.0, 0.0),
+                new Vector3(-6.0, -6.0),
+                new Vector3(0.0, -6.0),
+                Vector3.Origin,
+            });
+            Assert.True(true);
+        }
     }
 }

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -2000,7 +2000,6 @@ namespace Elements.Geometry.Tests
                 new Vector3(0.0, -6.0),
                 Vector3.Origin,
             });
-            Assert.True(true);
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- It's not possible to create polygon from list of vertices where first and last points are equal. In `Polygon` constructor this case is solved, but in base `Polyline` constructor it's not - duplicated last point is not removed and then overridden method `Edges` returns zero length edge and exception is thrown "A segment of the polyline has zero length".

DESCRIPTION:
- Extract vertices validation to virtual method, so the right validation logic will be used for derived classes

TESTING:
- Add `PolygonTests.ConstructWithSequentialDuplicates` test.
  
REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/777)
<!-- Reviewable:end -->
