### PR TITLE
Mesh sphere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0
 
 ### Added
+- `MeshPrimitives.Sphere(double radius, int divisions)`
 
 ### Changed
 - Remove ``removeCutEdges` from `AdaptiveGrid.SubtractBox` and always remove cut parts of intersected edges.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.0
 
 ### Added
-- `MeshPrimitives.Sphere(double radius, int divisions)`
+- `Mesh.Sphere(double radius, int divisions)`
 
 ### Changed
 - Remove ``removeCutEdges` from `AdaptiveGrid.SubtractBox` and always remove cut parts of intersected edges.

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -91,12 +91,11 @@ namespace Elements.Geometry
         /// </summary>
         public override double Length()
         {
-            var div = 1.0 / _samples;
             Vector3 last = new Vector3();
             double length = 0.0;
-            for (var t = 0.0; t <= 1.0; t += div)
+            for (var t = 0; t <= _samples; t++)
             {
-                var pt = PointAt(t);
+                var pt = PointAt(t * 1.0 / _samples);
                 if (t == 0.0)
                 {
                     last = pt;

--- a/Elements/src/Geometry/Curve.cs
+++ b/Elements/src/Geometry/Curve.cs
@@ -67,10 +67,9 @@ namespace Elements.Geometry
         public virtual Polyline ToPolyline(int divisions = 10)
         {
             var pts = new List<Vector3>(divisions + 1);
-            var div = 1.0 / (double)divisions;
-            for (var t = 0.0; t <= 1.0; t += div)
+            for (var t = 0; t <= divisions; t++)
             {
-                pts.Add(PointAt(t));
+                pts.Add(PointAt(t * 1.0 / divisions));
             }
             return new Polyline(pts);
         }

--- a/Elements/src/Geometry/Mesh.cs
+++ b/Elements/src/Geometry/Mesh.cs
@@ -14,7 +14,7 @@ namespace Elements.Geometry
     /// A triangle mesh.
     /// </summary>
     [JsonConverter(typeof(MeshConverter))]
-    public class Mesh
+    public partial class Mesh
     {
         private PointOctree<Vertex> _octree = new PointOctree<Vertex>(100000, new Octree.Point(0f, 0f, 0f), (float)Vector3.EPSILON);
 

--- a/Elements/src/Geometry/MeshPrimitives.cs
+++ b/Elements/src/Geometry/MeshPrimitives.cs
@@ -1,0 +1,81 @@
+namespace Elements.Geometry
+{
+    /// <summary>
+    /// Create mesh primitives.
+    /// </summary>
+    public static class MeshPrimitives
+    {
+        /// <summary>
+        /// A mesh sphere.
+        /// </summary>
+        /// <param name="radius">The radius of the sphere.</param>
+        /// <param name="divisions">The number of tessellations of the sphere.</param>
+        /// <returns>A mesh.</returns>
+        public static Mesh Sphere(double radius, int divisions = 10)
+        {
+            var arc = new Arc(Vector3.Origin, radius, 0, 180).ToPolyline(divisions);
+            var t = new Transform();
+            var vertices = new Vertex[divisions + 1, divisions + 1];
+            var mesh = new Mesh();
+            var div = 360.0 / divisions;
+
+            for (var u = 0; u <= divisions; u++)
+            {
+                if (u > 0)
+                {
+                    t.Rotate(Vector3.XAxis, div);
+                }
+
+                for (var v = 1; v < divisions; v++)
+                {
+                    var pt = t.OfPoint(arc.Vertices[v]);
+
+                    var vx = new Vertex(pt)
+                    {
+                        UV = new UV((double)v / (double)divisions, (double)u / (double)divisions)
+                    };
+                    vertices[u, v] = vx;
+                    mesh.AddVertex(vx);
+
+                    if (u > 0 && v > 1)
+                    {
+                        var a = vertices[u, v];
+                        var b = vertices[u, v - 1];
+                        var c = vertices[u - 1, v - 1];
+                        var d = vertices[u - 1, v];
+
+                        mesh.AddTriangle(a, b, c);
+                        mesh.AddTriangle(a, c, d);
+                    }
+                }
+            }
+
+            var p1 = new Vertex(arc.Start)
+            {
+                UV = new UV(0, 0)
+            };
+
+            var p2 = new Vertex(arc.End)
+            {
+                UV = new UV(1, 1)
+            };
+            mesh.AddVertex(p1);
+            mesh.AddVertex(p2);
+
+            // Make the end caps separately to manage the singularity 
+            // at the poles. Attempting to do this in the algorithm above
+            // will result in duplicate vertices for every arc section, which
+            // is currently illegal in meshes.
+            // TODO: This causes spiraling of the UV coordinates at the poles.
+            for (var u = 1; u <= divisions; u++)
+            {
+                mesh.AddTriangle(p1, vertices[u - 1, 1], vertices[u, 1]);
+                mesh.AddTriangle(p2, vertices[u, divisions - 1], vertices[u - 1, divisions - 1]);
+            }
+
+            mesh.ComputeNormals();
+
+            return mesh;
+        }
+    }
+}

--- a/Elements/src/Geometry/Meshes.cs
+++ b/Elements/src/Geometry/Meshes.cs
@@ -15,9 +15,9 @@ namespace Elements.Geometry
         /// <returns>A mesh.</returns>
         public static Mesh Sphere(double radius, int divisions = 10)
         {
-            if (divisions < 3)
+            if (divisions < 2)
             {
-                throw new ArgumentException(nameof(divisions), "The number of divisions must be greater than 3.");
+                throw new ArgumentException(nameof(divisions), "The number of divisions must be greater than 2.");
             }
 
             var arc = new Arc(Vector3.Origin, radius, 0, 180).ToPolyline(divisions);

--- a/Elements/src/Geometry/Meshes.cs
+++ b/Elements/src/Geometry/Meshes.cs
@@ -3,7 +3,7 @@ namespace Elements.Geometry
     /// <summary>
     /// Create mesh primitives.
     /// </summary>
-    public static class MeshPrimitives
+    public partial class Mesh
     {
         /// <summary>
         /// A mesh sphere.

--- a/Elements/src/Geometry/Meshes.cs
+++ b/Elements/src/Geometry/Meshes.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Elements.Geometry
 {
     /// <summary>
@@ -13,6 +15,11 @@ namespace Elements.Geometry
         /// <returns>A mesh.</returns>
         public static Mesh Sphere(double radius, int divisions = 10)
         {
+            if (divisions < 3)
+            {
+                throw new ArgumentException(nameof(divisions), "The number of divisions must be greater than 3.");
+            }
+
             var arc = new Arc(Vector3.Origin, radius, 0, 180).ToPolyline(divisions);
             var t = new Transform();
             var vertices = new Vertex[divisions + 1, divisions + 1];

--- a/Elements/test/ArcTests.cs
+++ b/Elements/test/ArcTests.cs
@@ -103,6 +103,8 @@ namespace Hypar.Tests
             var arc = new Arc(Vector3.Origin, 1, 10, 20);
             var p = arc.ToPolyline(10);
             Assert.Equal(10, p.Segments().Length);
+            Assert.Equal(arc.Start, p.Vertices[0]);
+            Assert.Equal(arc.End, p.Vertices[p.Vertices.Count - 1]);
         }
 
         [Fact]
@@ -111,6 +113,8 @@ namespace Hypar.Tests
             var c = new Circle(Vector3.Origin, 1);
             var p = c.ToPolygon(10);
             Assert.Equal(10, p.Segments().Length);
+            Assert.Equal(c.Start, p.Vertices[0]);
+            Assert.Equal(c.End, p.Vertices[0]);
         }
     }
 }

--- a/Elements/test/BezierTests.cs
+++ b/Elements/test/BezierTests.cs
@@ -21,7 +21,7 @@ namespace Hypar.Tests
         public void Bezier()
         {
             this.Name = "Elements_Geometry_Bezier";
-            
+
             // <example>
             var a = Vector3.Origin;
             var b = new Vector3(5, 0, 1);
@@ -29,7 +29,7 @@ namespace Hypar.Tests
             var d = new Vector3(0, 5, 3);
             var e = new Vector3(0, 0, 4);
             var f = new Vector3(5, 0, 5);
-            var ctrlPts = new List<Vector3>{a,b,c,d,e,f};
+            var ctrlPts = new List<Vector3> { a, b, c, d, e, f };
 
             var bezier = new Bezier(ctrlPts);
             // </example>
@@ -43,7 +43,7 @@ namespace Hypar.Tests
             var a = Vector3.Origin;
             var b = Vector3.Origin;
             var c = Vector3.Origin;
-            var ctrlPts = new List<Vector3>{ a, b, c };
+            var ctrlPts = new List<Vector3> { a, b, c };
             var bezier = new Bezier(ctrlPts);
 
             var targetLength = 0;
@@ -58,10 +58,10 @@ namespace Hypar.Tests
             var d = new Vector3(0, 5, 3);
             var e = new Vector3(0, 0, 4);
             var f = new Vector3(5, 0, 5);
-            var ctrlPts = new List<Vector3>{b,c,d,e,f};
+            var ctrlPts = new List<Vector3> { b, c, d, e, f };
             var bezier = new Bezier(ctrlPts);
 
-            var expectedLength = 11.45;  // approximation as the linear interpolation used for calculating length is not hugely accurate
+            var expectedLength = 11.85;  // approximation as the linear interpolation used for calculating length is not hugely accurate
             Assert.Equal(expectedLength, bezier.Length(), 2);
             var divisions = 50; // brittle as it relies on number of samples within Bezier being unchanged
             var polylineLength = bezier.ToPolyline(divisions).Length();

--- a/Elements/test/Grid1dTests.cs
+++ b/Elements/test/Grid1dTests.cs
@@ -198,8 +198,7 @@ namespace Elements.Tests
             var grid = new Grid1d(bezier1);
             grid.DivideByApproximateLength(0.5, EvenDivisionMode.RoundUp);
             var cellGeometry = grid.GetCells().Select(cl => cl.GetCellGeometry());
-            Assert.Equal(25, cellGeometry.Count());
-
+            Assert.Equal(26, cellGeometry.Count());
 
             var r = 2.0;
             var a1 = new Arc(new Vector3(5, 0), r, -90.0, 90.0);

--- a/Elements/test/MeshPrimitivesTests.cs
+++ b/Elements/test/MeshPrimitivesTests.cs
@@ -1,0 +1,19 @@
+using Elements.Geometry;
+using Xunit;
+
+namespace Elements.Tests
+{
+    public class MeshPrimitivesTests : ModelTest
+    {
+        [Fact]
+        public void Sphere()
+        {
+            Name = nameof(Sphere);
+            var m = new Material("Test", Colors.White, unlit: true, texture: "./Textures/UV.jpg");
+            var s = MeshPrimitives.Sphere(3, 20);
+            Assert.Equal(401, s.Vertices.Count);
+            Assert.Equal(760, s.Triangles.Count);
+            Model.AddElement(new MeshElement(s, m));
+        }
+    }
+}

--- a/Elements/test/MeshPrimitivesTests.cs
+++ b/Elements/test/MeshPrimitivesTests.cs
@@ -10,7 +10,7 @@ namespace Elements.Tests
         {
             Name = nameof(Sphere);
             var m = new Material("Test", Colors.White, unlit: true, texture: "./Textures/UV.jpg");
-            var s = MeshPrimitives.Sphere(3, 20);
+            var s = Mesh.Sphere(3, 20);
             Assert.Equal(401, s.Vertices.Count);
             Assert.Equal(760, s.Triangles.Count);
             Model.AddElement(new MeshElement(s, m));


### PR DESCRIPTION
BACKGROUND:
- Having some mesh primitives like spheres and cubes is useful for various tasks.

DESCRIPTION:
- This PR adds the `Mesh.Sphere` method to create a mesh sphere.
- This PR fixes the `ToPolyline` method, which was creating polylines that were one segment short of the end of the curve being converted. It then also fixes all tests where `ToPolyline` is excercised, and adds tests to ensure that polylines created in this way align with the start and end points of curves.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

![image](https://user-images.githubusercontent.com/1139788/157384711-0d83bdf1-f513-4ed0-bf70-98ad225f6329.png)

Use the `divisions` parameter to change the precision.
Example 10
![image](https://user-images.githubusercontent.com/1139788/157387288-5583e64f-51fd-47f1-9b11-1d737c3be3aa.png)

Example 50
![image](https://user-images.githubusercontent.com/1139788/157387341-ab4531d9-b1c2-494d-bd2a-17f2f27b0762.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/778)
<!-- Reviewable:end -->
