### PR TITLE
Added additional check to DeleteVerticesForOverlappingEdges

### DIFF
--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -2219,6 +2219,11 @@ namespace Elements.Geometry
                 {
                     vertices.Remove(b);
                     i--;
+
+                    if (a.IsAlmostEqualTo(c))
+                    {
+                        vertices.Remove(c);
+                    }
                 }
             }
         }


### PR DESCRIPTION
BACKGROUND:
Some models exported from Revit couldn't be opened in JSON to Model function. It happens when polyline contains three points A, B and C: 
AB == BC

DESCRIPTION:
This PR contains additional check: if point AB overlapping BC and C==A, delete B and C;

TESTING:
I can provide json model. JSON to Model function is already published to dev

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/780)
<!-- Reviewable:end -->
