### PR TITLE
Added ApproximatelyEquals call as first check to avoid error with acc…

### DIFF
--- a/Elements/src/Search/LeftMostPointComparer.cs
+++ b/Elements/src/Search/LeftMostPointComparer.cs
@@ -58,15 +58,15 @@ namespace Elements.Search
             }
             else
             {
+                if (aLeft.Y.ApproximatelyEquals(bLeft.Y))
+                {
+                    return 0;
+                }
                 if (aLeft.Y > bLeft.Y)
                 {
                     return -1;
                 }
-                else if (aLeft.Y < bLeft.Y)
-                {
-                    return 1;
-                }
-                return 0;
+                return 1;
             }
         }
     }


### PR DESCRIPTION
…uracy;

BACKGROUND:
A new node that is parallel to a parent and has almost the same Y coordinates was added to the tree as left node but during traverse, it was looking as right node 

DESCRIPTION:
The ApproximatelyEquals call is added as first check to avoid error with accuracy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/781)
<!-- Reviewable:end -->
