### PR TITLE
Cleanup model and add interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `Mesh.Sphere(double radius, int divisions)`
 - `Material.EmissiveTexture`
 - `Material.EmissiveFactor`
+- `Elements.IModel`
 
 ### Changed
 - Remove ``removeCutEdges` from `AdaptiveGrid.SubtractBox` and always remove cut parts of intersected edges.

--- a/Elements/src/IModel.cs
+++ b/Elements/src/IModel.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using Elements.Geometry;
+
+namespace Elements
+{
+    /// <summary>
+    /// The interface for all models.
+    /// </summary>
+    public interface IModel
+    {
+        /// <summary>
+        /// The transform of the model.
+        /// </summary>
+        Transform Transform { get; set; }
+
+        /// <summary>
+        /// Add an element to the model.
+        /// </summary>
+        /// <param name="element">The element to add to the model.</param>
+        /// <param name="gatherSubElements">Should elements be searched recursively for child elements?</param>
+        void AddElement(Element element, bool gatherSubElements = true);
+
+        /// <summary>
+        /// Add elements to the model.
+        /// </summary>
+        /// <param name="elements">A collection of elements to add to the model.</param>
+        /// <param name="gatherSubElements">Should elements be searched recursively for child elements?</param>
+        void AddElements(IEnumerable<Element> elements, bool gatherSubElements = true);
+
+        /// <summary>
+        /// Add elements to the model.
+        /// </summary>
+        /// <param name="elements">Elements to add to the model.</param>
+        void AddElements(params Element[] elements);
+
+        /// <summary>
+        /// Get an element by id from the model.
+        /// </summary>
+        /// <param name="id">The id of the element.</param>
+        /// <typeparam name="T">The type of the element.</typeparam>
+        /// <returns>An element of type T.</returns>
+        T GetElementOfType<T>(Guid id) where T : Element;
+
+        /// <summary>
+        /// Get an element by name from the model.
+        /// </summary>
+        /// <param name="name">The name of the element.</param>
+        /// <typeparam name="T">The type of the element.</typeparam>
+        /// <returns>An element of type T.</returns>
+        T GetElementByName<T>(string name) where T : Element;
+
+        /// <summary>
+        /// Get all elements of type T from the model.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to return.</typeparam>
+        /// <returns>A collection of elements of type T.</returns>
+        IEnumerable<T> AllElementsOfType<T>();
+    }
+}

--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -18,21 +18,21 @@ namespace Elements
     /// <summary>
     /// A container for elements.
     /// </summary>
-    public class Model
+    public class Model : IModel
     {
         /// <summary>The origin of the model.</summary>
-        [Newtonsoft.Json.JsonProperty("Origin", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("Origin", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]
         [Obsolete("Use Transform instead.")]
         public Position Origin { get; set; }
 
         /// <summary>The transform of the model.</summary>
-        [Newtonsoft.Json.JsonProperty("Transform", Required = Newtonsoft.Json.Required.AllowNull)]
+        [JsonProperty("Transform", Required = Required.AllowNull)]
         public Transform Transform { get; set; }
 
-        /// <summary>A collection of Elements keyed by their identifiers.</summary>
-        [Newtonsoft.Json.JsonProperty("Elements", Required = Newtonsoft.Json.Required.Always)]
+        /// <summary>A collection of elements keyed by their identifiers.</summary>
+        [JsonProperty("Elements", Required = Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]
-        public System.Collections.Generic.IDictionary<Guid, Element> Elements { get; set; } = new System.Collections.Generic.Dictionary<Guid, Element>();
+        public IDictionary<Guid, Element> Elements { get; set; } = new Dictionary<Guid, Element>();
 
         /// <summary>
         /// Construct a model.
@@ -40,8 +40,8 @@ namespace Elements
         /// <param name="origin">The origin of the model.</param>
         /// <param name="transform">The transform of the model.</param>
         /// <param name="elements">A collection of elements.</param>
-        [Newtonsoft.Json.JsonConstructor]
-        public Model(Position @origin, Transform @transform, System.Collections.Generic.IDictionary<Guid, Element> @elements)
+        [JsonConstructor]
+        public Model(Position @origin, Transform @transform, IDictionary<Guid, Element> @elements)
         {
             this.Origin = @origin;
             this.Transform = @transform;
@@ -56,12 +56,12 @@ namespace Elements
             this.Transform = new Transform();
         }
 
-        /// <summary>
+        /// <summary>O
         /// Construct a model.
         /// </summary>
         /// <param name="transform">The model's transform.</param>
         /// <param name="elements">The model's elements.</param>
-        public Model(Transform @transform, System.Collections.Generic.IDictionary<Guid, Element> @elements)
+        public Model(Transform @transform, IDictionary<Guid, Element> @elements)
         {
             this.Transform = @transform;
             this.Elements = @elements;
@@ -150,10 +150,10 @@ namespace Elements
         }
 
         /// <summary>
-        /// Get an entity by id from the Model.
+        /// Get an element by id from the Model.
         /// </summary>
         /// <param name="id">The identifier of the element.</param>
-        /// <returns>An entity or null if no entity can be found
+        /// <returns>An element or null if no element can be found
         /// with the provided id.</returns>
         public T GetElementOfType<T>(Guid id) where T : Element
         {
@@ -165,10 +165,10 @@ namespace Elements
         }
 
         /// <summary>
-        /// Get the first entity with the specified name.
+        /// Get the first element with the specified name.
         /// </summary>
         /// <param name="name"></param>
-        /// <returns>An entity or null if no entity can be found
+        /// <returns>An element or null if no element can be found
         /// with the provided name.</returns>
         public T GetElementByName<T>(string name) where T : Element
         {
@@ -181,7 +181,7 @@ namespace Elements
         }
 
         /// <summary>
-        /// Get all entities of the specified Type.
+        /// Get all elements of the specified Type.
         /// </summary>
         /// <typeparam name="T">The Type of element to return.</typeparam>
         /// <returns>A collection of elements of the specified type.</returns>
@@ -437,39 +437,6 @@ namespace Elements
         {
             return typeof(Element).IsAssignableFrom(t)
                    || typeof(SolidOperation).IsAssignableFrom(t);
-        }
-    }
-
-    public static class ModelExtensions
-    {
-        /// <summary>
-        /// Get all elements of a certain type from a specific model name in a dictionary of models.
-        /// </summary>
-        /// <param name="models">Dictionary of models keyed by string.</param>
-        /// <param name="modelName">The name of the model.</param>
-        /// <typeparam name="T">The type of element we want to retrieve.</typeparam>
-        /// <returns></returns>
-        public static List<T> AllElementsOfType<T>(this Dictionary<string, Model> models, string modelName) where T : Element
-        {
-            var elements = new List<T>();
-            models.TryGetValue(modelName, out var model);
-            if (model != null)
-            {
-                elements.AddRange(model.AllElementsOfType<T>());
-            }
-            return elements;
-        }
-
-        /// <summary>
-        /// Get all proxies of a certain type from a specific model name in a dictionary of models.
-        /// </summary>
-        /// <param name="models">Dictionary of models keyed by string</param>
-        /// <param name="modelName">The name of the model</param>
-        /// <typeparam name="T">The type of element we want to retrieve</typeparam>
-        /// <returns></returns>
-        public static List<ElementProxy<T>> AllProxiesOfType<T>(this Dictionary<string, Model> models, string modelName) where T : Element
-        {
-            return models.AllElementsOfType<T>(modelName).Proxies(modelName).ToList();
         }
     }
 }

--- a/Elements/src/ModelExtensions.cs
+++ b/Elements/src/ModelExtensions.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Elements
+{
+    /// <summary>
+    /// Model extension methods.
+    /// </summary>
+    public static class ModelExtensions
+    {
+        /// <summary>
+        /// Get all elements of a certain type from a specific model name in a dictionary of models.
+        /// </summary>
+        /// <param name="models">Dictionary of models keyed by string.</param>
+        /// <param name="modelName">The name of the model.</param>
+        /// <typeparam name="T">The type of element we want to retrieve.</typeparam>
+        /// <returns></returns>
+        public static List<T> AllElementsOfType<T>(this Dictionary<string, Model> models, string modelName) where T : Element
+        {
+            var elements = new List<T>();
+            models.TryGetValue(modelName, out var model);
+            if (model != null)
+            {
+                elements.AddRange(model.AllElementsOfType<T>());
+            }
+            return elements;
+        }
+
+        /// <summary>
+        /// Get all proxies of a certain type from a specific model name in a dictionary of models.
+        /// </summary>
+        /// <param name="models">Dictionary of models keyed by string</param>
+        /// <param name="modelName">The name of the model</param>
+        /// <typeparam name="T">The type of element we want to retrieve</typeparam>
+        /// <returns></returns>
+        public static List<ElementProxy<T>> AllProxiesOfType<T>(this Dictionary<string, Model> models, string modelName) where T : Element
+        {
+            return models.AllElementsOfType<T>(modelName).Proxies(modelName).ToList();
+        }
+    }
+}


### PR DESCRIPTION
BACKGROUND:
Some users of Elements have asked for `Model` to implement an interface (see #694). 

DESCRIPTION:
This PR introduces the `IModel` interface and implements the interface in the existing `Model` class. It also refactors model extension methods into a separate file and cleans up unused namespaces (which will pay dividends in the transition to `System.Text.Json`).

TESTING:
No code was changed.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.
