### PR TITLE
Fixes for Vector3.AreCollinear and Line.TryGetOverlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Remove ``removeCutEdges` from `AdaptiveGrid.SubtractBox` and always remove cut parts of intersected edges.
 
 ### Fixed
+- `Vector3.AreCollinear(Vector3 a, Vector3 b, Vector3 c)` would return `false` if two points are coincident but not exactly.
+- `Line.TryGetOverlap(Line line, out Line overlap)` would return incorrect results due to wrong internal sorting.
 
 ## 0.9.9
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1019,7 +1019,8 @@ namespace Elements.Geometry
 
             //order vertices of lines
             var vectors = new List<Vector3>() { Start, End, line.Start, line.End };
-            var orderedVectors = vectors.OrderBy(v => v.X + v.Y + v.Z).ToList();
+            var direction = Direction();
+            var orderedVectors = vectors.OrderBy(v => (v - Start).Dot(direction)).ToList();
 
             //check if 2nd point lies on both lines
             if (!PointOnLine(orderedVectors[1], Start, End, true) || !PointOnLine(orderedVectors[1], line.Start, line.End, true))
@@ -1036,7 +1037,7 @@ namespace Elements.Geometry
             var overlappingLine = new Line(orderedVectors[1], orderedVectors[2]);
             
             //keep the same direction as original line
-            overlap = Direction().IsAlmostEqualTo(overlappingLine.Direction()) 
+            overlap = direction.IsAlmostEqualTo(overlappingLine.Direction()) 
                 ? overlappingLine
                 : overlappingLine.Reversed();
 

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -829,11 +829,14 @@ namespace Elements.Geometry
         /// <returns>True if the points are on the same line, false otherwise.</returns>
         public static bool AreCollinear(Vector3 a, Vector3 b, Vector3 c)
         {
-            var ba = (b - a).Unitized();
-            var cb = (c - b).Unitized();
+            var ba = b - a;
+            var cb = c - b;
 
             if (ba.IsZero() || cb.IsZero())
                 return true;
+
+            ba = ba.Unitized();
+            cb = cb.Unitized();
 
             return Math.Abs(cb.Dot(ba)) > (1 - Vector3.EPSILON);
         }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -494,6 +494,10 @@ namespace Elements.Geometry.Tests
             var parallelLine = new Line(new Vector3(3, 3, 0), new Vector3(8, 8, 5));
             Assert.True(line.Direction().IsParallelTo(parallelLine.Direction()));
             Assert.False(line.IsCollinear(parallelLine));
+
+            var almostSameLine = new Line(Vector3.Origin, new Vector3(5, 5.00000000001, 5));
+            Assert.True(line.IsAlmostEqualTo(almostSameLine, false));
+            Assert.True(line.IsCollinear(almostSameLine));
         }
 
         [Fact]

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -532,7 +532,15 @@ namespace Elements.Geometry.Tests
             Assert.NotNull(overlapLine);
             Assert.True(overlapLine.IsAlmostEqualTo(expectedLine, false));
 
+            var almostSameLine = new Line(Vector3.Origin, new Vector3(5, 5.00000000001, 5));
+            Assert.True(line.IsAlmostEqualTo(almostSameLine, false));
+            Assert.True(line.TryGetOverlap(almostSameLine, out Line almostSameOverlap));
+            Assert.True(line.IsAlmostEqualTo(almostSameOverlap, false));
 
+            //This failed in previous iteration when coordinate sum was used for points sorting
+            var firstLineWihNearZeroSum = new Line(new Vector3(-3, 3, 0), new Vector3(-1, 1.00000002, 0));
+            var secondLineWihNearZeroSum = new Line(new Vector3(-2, 2.00000001, 0), new Vector3(0, 0, 0));
+            Assert.True(firstLineWihNearZeroSum.TryGetOverlap(secondLineWihNearZeroSum, out _));
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
When working with walls that belong to several rooms I realized that some wall that were shared between two rooms were not correctly identified. 
I have found two issues in Elements:
- `Vector3.AreCollinear(Vector3 a, Vector3 b, Vector3 c)` was returning `false` if two points are coincident but not exactly.
Checking IsZero after normalizing is not efficient when two points are almost coincident. In this case even slightest variation between two points start to dominate.
- `Line.TryGetOverlap(Line line, out Line overlap)` would return incorrect results due to wrong internal sorting.

DESCRIPTION:
- In `Vector3.AreCollinear` do IsZero check before normalization.
- In `Line.TryGetOverlap`, since it works on collinear lines, use dot product sorting.

TESTING:
- Added extra test cases to `IsCollinear` and `TryGetOverlap` tests.
  
FUTURE WORK:

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/787)
<!-- Reviewable:end -->
