### PR TITLE
better support for excluding types from codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,27 @@
 ## 1.0.0
 
 ### Added
+
 - `Mesh.Sphere(double radius, int divisions)`
 - `Model.AllElementsAssignableFromType<T>()`
 - `Material.EmissiveTexture`
 - `Material.EmissiveFactor`
 
 ### Changed
+
 - Remove ``removeCutEdges` from `AdaptiveGrid.SubtractBox` and always remove cut parts of intersected edges.
+- `GenerateUserElementTypeFromUriAsync` now takes an optional `excludedTypes` argument.
 
 ### Fixed
+
 - `Vector3.AreCollinear(Vector3 a, Vector3 b, Vector3 c)` would return `false` if two points are coincident but not exactly.
 - `Line.TryGetOverlap(Line line, out Line overlap)` would return incorrect results due to wrong internal sorting.
 - `Profile.UnionAll, Difference, Intersection, Offset` no longer produce internal loops in `Perimeter` or `Voids`.
+
 ## 0.9.9
 
 ### Added
+
 - `Solid.Union(Solid a, Transform aTransform, Solid b, Transform bTransform)`
 - `Solid.Union(SolidOperation a, SolidOperation b)`
 - `Solid.Difference(Solid a, Transform aTransform, Solid b, Transform bTransform)`
@@ -35,10 +41,12 @@
 - `Line.GetOverlap(Line line)`
 
 ### Changed
+
 - Add parameter `removeCutEdges` to `AdaptiveGrid.SubtractBox` that control if cut parts of intersected edges need to be inserted into the graph.
 - Material colors are now exported to glTF using linear color space. Conversion from sRGB to linear color space happens during glTF export.
 
 ### Fixed
+
 - Under some circumstances `Bezier.Length()` would return incorrect results
 
 ## 0.9.8
@@ -57,6 +65,7 @@
 ## 0.9.7
 
 ### Added
+
 - `GridLine.GetCircleTransform()`
 - `Network.ToModelText(List<Vector3> nodeLocations, Color color)`
 - Content Elements can now use an optional disk cache when running locally for testing purposes, to speed up repeated tests or runs, by setting `GltfExtensions.GltfCachePath`.

--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -155,10 +155,9 @@ namespace Elements.Generate
 
         }
 
-        private static GenerationResult ValidateAndWriteTypeToDisk(JsonSchema schema, string outputBaseDir)
+        private static GenerationResult ValidateAndWriteTypeToDisk(JsonSchema schema, string outputBaseDir, HashSet<string> excludedTypeNames = null)
         {
-            string ns;
-            if (!GetNamespace(schema, out ns))
+            if (!GetNamespace(schema, out string ns))
             {
                 return new GenerationResult
                 {
@@ -168,8 +167,8 @@ namespace Elements.Generate
             }
 
             var typeName = schema.Title;
-            var excludedTypeNames = _coreTypeNames.Where(n => n != typeName).ToArray();
-            return WriteTypeFromSchemaToDisk(schema, outputBaseDir, typeName, ns, excludedTypeNames);
+            var excludedTypes = excludedTypeNames ?? new HashSet<string>(_coreTypeNames);
+            return WriteTypeFromSchemaToDisk(schema, outputBaseDir, typeName, ns, excludedTypes);
         }
 
         /// <summary>
@@ -177,18 +176,22 @@ namespace Elements.Generate
         /// </summary>
         /// <param name="uri">The uri to the schema which defines the type. This can be a url or a relative file path.</param>
         /// <param name="outputBaseDir">The base output directory.</param>
+        /// <param name="excludedTypeNames">An optional collection of type names to exclude from code
+        /// generation. NOTE: this list will be modified by the method, extended with the types
+        /// supplied in the URI list, including nested dependency types, in
+        /// order to prevent duplicate code generation.</param>
         /// <returns>
         /// A GenerationResult object containing info about the success or failure of generation,
         /// the file path of the generated code, and any errors that may have occurred during generation.
         /// </returns>
-        public static async Task<GenerationResult> GenerateUserElementTypeFromUriAsync(string uri, string outputBaseDir)
+        public static async Task<GenerationResult> GenerateUserElementTypeFromUriAsync(string uri, string outputBaseDir, HashSet<string> excludedTypeNames = null)
         {
             DotLiquid.Template.DefaultIsThreadSafe = true;
             DotLiquid.Template.RegisterFilter(typeof(HyparFilters));
 
             var schema = await GetSchemaAsync(uri);
 
-            return ValidateAndWriteTypeToDisk(schema, outputBaseDir);
+            return ValidateAndWriteTypeToDisk(schema, outputBaseDir, excludedTypeNames);
         }
 
         /// <summary>
@@ -196,14 +199,18 @@ namespace Elements.Generate
         /// </summary>
         /// <param name="uris">An array of uris.</param>
         /// <param name="outputBaseDir">The base output directory.</param>
-        public static async Task<GenerationResult[]> GenerateUserElementTypesFromUrisAsync(string[] uris, string outputBaseDir)
+        /// <param name="excludedTypeNames">An optional collection of type names to exclude from code
+        /// generation. NOTE: this list will be modified by the method, extended with the types
+        /// supplied in the URI list, including nested dependency types, in
+        /// order to prevent duplicate code generation.</param>
+        public static async Task<GenerationResult[]> GenerateUserElementTypesFromUrisAsync(string[] uris, string outputBaseDir, HashSet<string> excludedTypeNames = null)
         {
             DotLiquid.Template.DefaultIsThreadSafe = true;
             DotLiquid.Template.RegisterFilter(typeof(HyparFilters));
             var results = new List<Task<GenerationResult>>();
             foreach (var uri in uris)
             {
-                results.Add(GenerateUserElementTypeFromUriAsync(uri, outputBaseDir));
+                results.Add(GenerateUserElementTypeFromUriAsync(uri, outputBaseDir, excludedTypeNames));
             }
             var allResults = await Task.WhenAll(results);
             return allResults;
@@ -400,7 +407,7 @@ namespace Elements.Generate
                 Namespace = ns,
                 ArrayType = "IList",
                 ArrayInstanceType = "List",
-                ExcludedTypeNames = excludedTypes == null ? new string[] { } : excludedTypes,
+                ExcludedTypeNames = excludedTypes ?? (new string[] { }),
                 TemplateDirectory = templates,
                 GenerateJsonMethods = false,
                 ClassStyle = (typeName == "Element" || solidOpTypes.Contains(typeName)) ? CSharpClassStyle.Inpc : CSharpClassStyle.Poco,
@@ -491,13 +498,19 @@ namespace Elements.Generate
             return false;
         }
 
-        private static GenerationResult WriteTypeFromSchemaToDisk(JsonSchema schema, string outDirPath, string typeName, string ns, string[] excludedTypes = null)
+        private static GenerationResult WriteTypeFromSchemaToDisk(JsonSchema schema, string outDirPath, string typeName, string ns, HashSet<string> excludedTypes = null)
         {
             var diagnosticMessages = new List<string>();
 
-            var typeCodeDict = GetCodeForTypesFromSchema(schema, typeName, ns, excludedTypes);
+            var typeCodeDict = GetCodeForTypesFromSchema(schema, typeName, ns, excludedTypes?.ToArray());
             foreach (var kvp in typeCodeDict)
             {
+                // We don't want to generate types we've already generated, so
+                // we add types as we generate them.
+                if (excludedTypes != null)
+                {
+                    excludedTypes.Add(kvp.Key);
+                }
                 var path = Path.Combine(outDirPath, $"{kvp.Key}.g.cs");
 
                 Console.WriteLine($"Generating type {@ns}.{typeName} in {path}...");

--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -167,8 +167,7 @@ namespace Elements.Generate
             }
 
             var typeName = schema.Title;
-            var excludedTypes = excludedTypeNames ?? new HashSet<string>(_coreTypeNames);
-            return WriteTypeFromSchemaToDisk(schema, outputBaseDir, typeName, ns, excludedTypes);
+            return WriteTypeFromSchemaToDisk(schema, outputBaseDir, typeName, ns, excludedTypeNames ?? new HashSet<string>(_coreTypeNames));
         }
 
         /// <summary>
@@ -407,7 +406,7 @@ namespace Elements.Generate
                 Namespace = ns,
                 ArrayType = "IList",
                 ArrayInstanceType = "List",
-                ExcludedTypeNames = excludedTypes ?? (new string[] { }),
+                ExcludedTypeNames = excludedTypes ?? new string[0],
                 TemplateDirectory = templates,
                 GenerateJsonMethods = false,
                 ClassStyle = (typeName == "Element" || solidOpTypes.Contains(typeName)) ? CSharpClassStyle.Inpc : CSharpClassStyle.Poco,

--- a/Elements/src/Floor.cs
+++ b/Elements/src/Floor.cs
@@ -53,15 +53,24 @@ namespace Elements
                      Material material = null,
                      Representation representation = null,
                      bool isElementDefinition = false,
-                     Guid id = default(Guid),
-                     string name = null) : base(transform != null ? transform : new Transform(),
-                                                material != null ? material : BuiltInMaterials.Concrete,
-                                                representation != null ? representation : new Representation(new List<SolidOperation>()),
+                     Guid id = default,
+                     string name = null) : base(transform ?? new Transform(),
+                                                material ?? BuiltInMaterials.Concrete,
+                                                representation ?? new Representation(new List<SolidOperation>()),
                                                 isElementDefinition,
-                                                id != default(Guid) ? id : Guid.NewGuid(),
+                                                id != default ? id : Guid.NewGuid(),
                                                 name)
         {
             SetProperties(profile, thickness);
+        }
+
+        /// <summary>
+        /// Empty constructor for compatibility purposes. It is best to use the
+        /// structured constructor with arguments, to ensure the floor is correctly created.
+        /// </summary>
+        public Floor()
+        {
+
         }
 
         private void SetProperties(Profile profile, double thickness)


### PR DESCRIPTION
BACKGROUND:
- This PR works in tandem with https://github.com/hypar-io/Hypar/pull/465.
- In complex scenarios, code generation would not exclude all types it was expected to. For example:
Type `CirculationSegment`'s schema has it extend `Floor`. We were only checking top-level types from `element_types` against known types, so a `Floor.g.cs` still got created, breaking compilation.
- A function containing within its `element_types` a schema (like `CirculationSegment`) which refers to a type like `ThickenedPolyline` which can ALSO be a input type would result in dual generation of that type: `Elements.ThickenedPolyline` and `Circulation.ThickenedPolyline` in the `Inputs` class, and one could not be converted to the other. 

DESCRIPTION:
- Adds more opportunities to inject a `HashSet` of excluded types, and modifies it on the fly as types are generated. 
- I also added an empty constructor for `Floor`, so that a generated type's empty constructor can call the built-in type's empty constructor. 

TESTING:
- I tested in a modified version of the Circulation function, which has a `ThickenedPolyline` override, as well as a reference to the `CirculationSegment` schema (`https://prod-api.hypar.io/schemas/CirculationSegment`). I verified that it code-genned and built (with the parallel `hypar` CLI PR) correctly.
- I also tested in other function with a complex type scenario: `SpacePlanningZones` from Hypar Space has a mix of extended partial classes, types referenced from external assemblies, types in its `input_schema,` and so on — I verified that it still code-genned correctly and built. 
  
FUTURE WORK:
- We should add empty constructors to all element types that we might inherit from (or be more explicit about prohibiting inheritance in elements)

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- It would be great to test this (and the accompanying CLI PR) against some other complex dependency/codegen scenarios, such as in aliaxis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/792)
<!-- Reviewable:end -->
