### PR TITLE
Adaptive Grid update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,21 @@
 
 ### Added
 - `Mesh.Sphere(double radius, int divisions)`
-- `Model.AllElementsAssignableFromType<T>()`
 - `Material.EmissiveTexture`
 - `Material.EmissiveFactor`
+- `PriorityQueue`
+- `AdaptiveGraphRouting`
+- `AdaptiveGrid` constructor with no parameters.
+- `AdaptiveGrid.AddVertexStrip(IList<Vector3> points)`
+- `AdaptiveGrid.CutEdge(Edge edge, Vector3 position)`
+- `AdaptiveGrid.ClosestVertex(Vector3 location)` and `AdaptiveGrid.ClosestEdge(Vector3 location)`
+- `AdaptiveGrid.RemoveEdge(Edge edge)`
 
 ### Changed
-- Remove ``removeCutEdges` from `AdaptiveGrid.SubtractBox` and always remove cut parts of intersected edges.
+- Remove `removeCutEdges` from `AdaptiveGrid.SubtractBox` and always remove cut parts of intersected edges.
+- Remove `AdaptiveGrid` reference from `Edge` and `Vertex` Move `Edge.GetVertices` and `Edge.GetLine` to `AdaptiveGrid`.
+- Rename `AdaptiveGrid.DeleteEdge(Edge edge)` into `RemoveEdge` and is not public.
+- `AdaptiveGrid.AddEdge(ulong vertexId1, ulong vertexId2)` is now public.
 
 ### Fixed
 - `Vector3.AreCollinear(Vector3 a, Vector3 b, Vector3 c)` would return `false` if two points are coincident but not exactly.

--- a/Elements/src/PriorityQueue.cs
+++ b/Elements/src/PriorityQueue.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace Elements
 {
     /// <summary>
-    /// PriorityQueue is a collection that allows to retrieve the item with the lowest
+    /// PriorityQueue is a collection that allows you to retrieve the item with the lowest
     /// priority in constant time and be able update priority of an item with log complexity.
     /// Items are unique within the collection but priorities can have duplicate values.
     /// </summary>

--- a/Elements/src/PriorityQueue.cs
+++ b/Elements/src/PriorityQueue.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+
+namespace Elements
+{
+    /// <summary>
+    /// PriorityQueue is a collection that allows to retrieve the item with the lowest
+    /// priority in constant time and be able update priority of an item with log complexity.
+    /// Items are unique within the collection but priorities can have duplicate values.
+    /// </summary>
+    /// <typeparam name="T">Type of the item. Must support hash and comparing.</typeparam>
+    public class PriorityQueue<T> where T : IComparable<T>
+    {
+        private List<(T Id, double Priority)> _priorities;
+        private Dictionary<T, int> _positions;
+
+        /// <summary>
+        /// Creates an empty collection.
+        /// </summary>
+        public PriorityQueue()
+        {
+            _priorities = new List<(T, double)>();
+            _positions = new Dictionary<T, int>();
+        }
+
+        /// <summary>
+        /// Creates collection from input list.
+        /// First item in the list is set to priority 0, others with double.MaxValue.
+        /// </summary>
+        /// <param name="uniqueCollection">List of ids.</param>
+        public PriorityQueue(IEnumerable<T> uniqueCollection)
+        {
+            _priorities = new List<(T, double)>(uniqueCollection.Count());
+            _positions = new Dictionary<T, int>();
+            _priorities.Add((uniqueCollection.First(), 0d));
+            _positions[uniqueCollection.First()] = 0;
+
+            int i = 1;
+            foreach (var item in uniqueCollection.Skip(1))
+            {
+                _priorities.Add((item, double.MaxValue));
+                _positions[item] = i;
+                i++;
+            }
+        }
+
+        /// <summary>
+        /// Returns the lowest priority item from collection.
+        /// Throws an exception if called on an empty collection.
+        /// </summary>
+        /// <returns>Id of the item with lowest priority.</returns>
+        public T PopMin()
+        {
+            var min = _priorities[0];
+            Swap(0, _priorities.Count - 1);
+            _positions.Remove(min.Id);
+            _priorities.RemoveAt(_priorities.Count - 1);
+            ShiftDown(0);
+            return min.Id;
+        }
+
+        /// <summary>
+        /// Adds a new item to the collection.
+        /// If an item with id already exist in collection - it's priority will be updated.
+        /// </summary>
+        /// <param name="id">Id of the item.</param>
+        /// <param name="priority">New priority.</param>
+        public void AddOrUpdate(T id, double priority)
+        {
+            if (_positions.TryGetValue(id, out var index))
+            {
+                Update(index, priority);
+            }
+            else
+            {
+                _priorities.Add((id, priority));
+                _positions[id] = _priorities.Count - 1;
+                ShiftUp(_priorities.Count - 1);
+            }
+        }
+
+        /// <summary>
+        /// Checks if certain Id is in the queue.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public bool Contains(T id)
+        {
+            return _positions.ContainsKey(id);
+        }
+
+        /// <summary>
+        /// Sets priority for the item with given id.
+        /// Does nothing if item is not present in the queue.
+        /// </summary>
+        /// <param name="id">Id of the item.</param>
+        /// <param name="priority">New priority.</param>
+        public void UpdatePriority(T id, double priority)
+        {
+            if (_positions.TryGetValue(id, out var index))
+            {
+                Update(index, priority);
+            }
+        }
+
+        /// <summary>
+        /// Is collection empty.
+        /// </summary>
+        public bool Empty()
+        {
+            return !_priorities.Any();
+        }
+
+        private void Update(int node, double priority)
+        {
+            double oldPriority = _priorities[node].Priority;
+            _priorities[node] = (_priorities[node].Id, priority);
+
+            if (priority < oldPriority)
+            {
+                ShiftUp(node);
+            }
+            else
+            {
+                ShiftDown(node);
+            }
+        }
+
+        private int Parent(int node)
+        {
+            return (node - 1) / 2;
+        }
+
+        private int LeftChild(int node)
+        {
+            return 2 * node + 1;
+        }
+
+        private int RightChild(int node)
+        {
+            return 2 * node + 2;
+        }
+
+        private void Swap(int left, int right)
+        {
+            _positions[_priorities[left].Id] = right;
+            _positions[_priorities[right].Id] = left;
+            (_priorities[left], _priorities[right]) = (_priorities[right], _priorities[left]);
+        }
+
+        private void ShiftUp(int node)
+        {
+            while (node > 0 && _priorities[Parent(node)].Priority > _priorities[node].Priority)
+            {
+                Swap(Parent(node), node);
+                node = Parent(node);
+            }
+        }
+
+        private void ShiftDown(int node)
+        {
+            int min = node;
+            var count = _priorities.Count;
+            int l = LeftChild(node);
+            int r = RightChild(node);
+
+            if (l < count && _priorities[l].Priority < _priorities[min].Priority)
+            {
+                min = l;
+            }
+
+            if (r < count && _priorities[r].Priority < _priorities[min].Priority)
+            {
+                min = r;
+            }
+
+            if (node != min)
+            {
+                Swap(node, min);
+                ShiftDown(min);
+            }
+        }
+    }
+}

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -1,0 +1,1454 @@
+﻿using System;
+using System.Collections.Generic;
+using Elements.Spatial.AdaptiveGrid;
+using Elements.Geometry;
+using System.Linq;
+using Elements.Geometry.Solids;
+
+namespace Elements.Spatial.AdaptiveGrid
+{
+    /// <summary>
+    /// Class for routing through an AdaptiveGrid.
+    /// </summary>
+    public class AdaptiveGraphRouting
+    {
+        private AdaptiveGrid _grid;
+        private RoutingConfiguration _configuration;
+
+        /// <summary>
+        /// Structure that holds information about polylines that are used to guide routing.
+        /// </summary>
+        public struct RoutingHintLine
+        {
+            /// <summary>
+            /// Construct new RoutingHintLine structure.
+            /// </summary>
+            /// <param name="polyline">Geometry of HintLine.</param>
+            /// <param name="factor">Cost multiplier.</param>
+            /// <param name="influence">How far it affects.</param>
+            /// <param name="userDefined">Is user defined.</param>
+            public RoutingHintLine(
+                Polyline polyline, double factor, double influence, bool userDefined)
+            {
+                Polyline = polyline;
+                Factor = factor;
+                InfluenceDistance = influence;
+                UserDefined = userDefined;
+            }
+
+            /// <summary>
+            /// 2D Polyline geometry representation with an influence that is extended on both sides in Z direction.
+            /// </summary>
+            public readonly Polyline Polyline;
+
+            /// <summary>
+            /// Cost multiplier for edges that lie within the Influence distance to the line.
+            /// </summary>
+            public readonly double Factor;
+
+            /// <summary>
+            /// How far away from the line, edge travel cost is affected.
+            /// Both sides of an edge and its middle point should be within influence range.
+            /// </summary>
+            public readonly double InfluenceDistance;
+
+            /// <summary>
+            /// Is line created by the user or from internal parameters?
+            /// User defined lines are preferred for input Vertex connection.
+            /// </summary>
+            public readonly bool UserDefined;
+        }
+
+        /// <summary>
+        /// Structure that holds additional information about inlet vertex
+        /// </summary>
+        public struct RoutingVertex
+        {
+            /// <summary>
+            /// Construct new RoutingVertex structure.
+            /// </summary>
+            /// <param name="id">Id of the vertex in the grid.</param>
+            /// <param name="isolationRadius"> Distance, other sections of the route can't travel near this vertex.</param>
+            /// <param name="guides">Additional vertices this vertex need to travel through.</param>
+            public RoutingVertex(
+                ulong id, double isolationRadius, List<ulong> guides = null)
+            {
+                Id = id;
+                IsolationRadius = isolationRadius;
+                Guides = guides;
+            }
+
+            /// <summary>
+            /// Id of the vertex in the grid.
+            /// </summary>
+            public ulong Id;
+
+            /// <summary>
+            /// Additional vertices this vertex need to travel through
+            /// </summary>
+            public List<ulong> Guides;
+
+            /// <summary>
+            /// Distance closer than which, other sections of the route can't travel near this vertex. 
+            /// Distance is in base plane of the gird, without elevation.
+            /// </summary>
+            public double IsolationRadius;
+        }
+
+        /// <summary>
+        /// Object that holds common parameters that affect routing.
+        /// </summary>
+        public struct RoutingConfiguration
+        {
+            /// <summary>
+            /// Construct new RoutingConfiguration structure.
+            /// </summary>
+            /// <param name="turnCost">Travel cost penalty if route changes it's direction.</param>
+            /// <param name="mainLayer">Elevation at which route prefers to travel.</param>
+            /// <param name="layerPenalty">Penalty if route travels through an elevation different from MainLayer.</param>
+            public RoutingConfiguration(double turnCost, double mainLayer,
+                double layerPenalty)
+            {
+                TurnCost = turnCost;
+                MainLayer = mainLayer;
+                LayerPenalty = layerPenalty;
+            }
+
+            /// <summary>
+            /// Travel cost penalty if route changes it's direction.
+            /// </summary>
+            public readonly double TurnCost;
+
+            /// <summary>
+            /// Elevation at which route prefers to travel.
+            /// </summary>
+            public readonly double MainLayer;
+
+            /// <summary>
+            /// Travel cost penalty if route travels through an elevation different from MainLayer.
+            /// </summary>
+            public readonly double LayerPenalty;
+        }
+
+        /// <summary>
+        /// Enumeration that indicates one of two possible paths in routing.
+        /// There are cases when we need to collect more than one path and
+        /// only after some time we can decide which one is better.
+        /// </summary>
+        public enum BranchSide
+        {
+            /// <summary>
+            /// Indicator that first, "left", path is preferred.
+            /// </summary>
+            Left,
+
+            /// <summary>
+            /// Indicator that second, "right" path is preferred.
+            /// </summary>
+            Right
+        }
+
+        /// <summary>
+        /// Create AdaptiveGraphRouting objects and store core parameters for further use.
+        /// </summary>
+        /// <param name="grid">AdaptiveGrid the algorithm travels through.</param>
+        /// <param name="configuration">Storage for common parameters that affect routing.</param>
+        public AdaptiveGraphRouting(AdaptiveGrid grid, RoutingConfiguration configuration)
+        {
+            //TO DO. The process of using AdaptiveGrid/Routing pair is hard, see AdaptiveGraphRoutingTests.
+            //You need to collect points manually from hint lines, obstacles, then you need to get ids
+            //to pass them to routing still maintaining connection between positions and ids.
+            //Need to consider extra level of abstraction on top, that will do all the work based on
+            //global information line boundaries, points, lines and obstacles.
+            _grid = grid;
+            _configuration = configuration;
+        }
+
+        /// <summary>
+        /// Visualize adaptive graph edges.
+        /// Material depends on elevation and proximity to different hint lines.
+        /// Original split points are not stored in the graph, so they need to be provided.
+        /// </summary>
+        /// <param name="hintLines">List of hint lines.</param>
+        /// <param name="splitPoints">List of split points to visualize</param>
+        /// <returns>List of graphics elements</returns>
+        public IList<Element> RenderElements(IList<RoutingHintLine> hintLines,
+                                             IList<Vector3> splitPoints)
+        {
+            List<Line> normalEdgesMain = new List<Line>();
+            List<Line> hintEdgesMain = new List<Line>();
+            List<Line> offsetEdgesMain = new List<Line>();
+            List<Line> normalEdgesOther = new List<Line>();
+            List<Line> hintEdgesOther = new List<Line>();
+            List<Line> offsetEdgesOther = new List<Line>();
+
+            var hintGroups = hintLines.GroupBy(h => h.UserDefined);
+            var userHints = hintGroups.SingleOrDefault(hg => hg.Key == true);
+            var defaultHints = hintGroups.SingleOrDefault(hg => hg.Key == false);
+
+            foreach (var edge in _grid.GetEdges())
+            {
+                //There is only one edge for vertex pair, if this is changed -
+                //we will need to check edges for uniqueness, 
+                var v0 = _grid.GetVertex(edge.StartId);
+                var v1 = _grid.GetVertex(edge.EndId);
+                Line l = new Line(v0.Point, v1.Point);
+                var mainLayer = OnMainLayer(v0, v1);
+                if (IsAffectedBy(v0.Point, v1.Point, userHints))
+                {
+                    if (mainLayer == true)
+                    {
+                        hintEdgesMain.Add(l);
+                    }
+                    else
+                    {
+                        hintEdgesOther.Add(l);
+                    }
+                }
+                else if (IsAffectedBy(v0.Point, v1.Point, defaultHints))
+                {
+                    if (mainLayer == true)
+                    {
+                        offsetEdgesMain.Add(l);
+                    }
+                    else
+                    {
+                        offsetEdgesOther.Add(l);
+                    }
+                }
+                else
+                {
+                    if (mainLayer == true)
+                    {
+                        normalEdgesMain.Add(l);
+                    }
+                    else
+                    {
+                        normalEdgesOther.Add(l);
+                    }
+                }
+            }
+
+            List<Element> visualizations = new List<Element>();
+            visualizations.Add(VisualizePoints(splitPoints));
+
+            visualizations.Add(new ModelLines(normalEdgesMain, new Material(
+                "Normal Edges Main", Colors.Blue)));
+            visualizations.Add(new ModelLines(normalEdgesOther, new Material(
+                "Normal Edges Other", Colors.Cobalt)));
+            visualizations.Add(new ModelLines(offsetEdgesMain, new Material(
+                "Offset Edges Main", Colors.Orange)));
+            visualizations.Add(new ModelLines(offsetEdgesOther, new Material(
+                "Offset Edges Other", Colors.Yellow)));
+            visualizations.Add(new ModelLines(hintEdgesMain, new Material(
+                "Hint Edges Main", Colors.Green)));
+            visualizations.Add(new ModelLines(hintEdgesOther, new Material(
+                "Hint Edges Other", Colors.Emerald)));
+
+            return visualizations;
+        }
+
+        /// <summary>
+        /// Creates tree of routes between set of input Vertices and the exit Vertex.
+        /// Routes merge together to form a single trunk. Starting from end, point by point,
+        /// vertices are connected to the network using Dijkstra algorithm.
+        /// </summary>
+        /// <param name="leafVertices">Vertices to connect into the system with extra information attached.</param>
+        /// <param name="trunkPathVertices">End vertices, connected in the same order as provided. Exit location goes first.</param>
+        /// <param name="hintLines">Collection of lines that routes are attracted to. At least one hint line is required.</param>
+        /// <returns>Travel routes from inputVertices to the last of tailVertices.</returns>
+        public IDictionary<ulong, ulong?> BuildSpanningTree(
+            IList<RoutingVertex> leafVertices,
+            IList<ulong> trunkPathVertices, IEnumerable<RoutingHintLine> hintLines)
+        {
+            //Excluded vertices includes inlets and vertices in certain distance around these inlets.
+            //Sometimes it's not wanted for routing to go through them.
+            var excludedVertices = ExcludedVertices(leafVertices);
+            var allExcluded = new HashSet<ulong>();
+            foreach (var item in excludedVertices)
+            {
+                item.Value.ForEach(v => allExcluded.Add(v));
+            }
+
+            var weights = CalculateWeights(hintLines, leafVertices);
+
+            var vertexTree = new Dictionary<ulong, ulong?>();
+            vertexTree[trunkPathVertices.First()] = null;
+            foreach (var inlet in leafVertices)
+            {
+                vertexTree[inlet.Id] = null;
+            }
+
+            var hintGroups = hintLines.GroupBy(h => h.UserDefined);
+            var userHints = hintGroups.SingleOrDefault(hg => hg.Key == true);
+            var defaultHints = hintGroups.SingleOrDefault(hg => hg.Key == false);
+            var hintVertices = NearbyVertices(userHints, leafVertices);
+            var offsetVertices = NearbyVertices(defaultHints, leafVertices);
+            //Hint lines can go even through excluded vertices
+            allExcluded.ExceptWith(hintVertices.Select(hv => hv.Id));
+
+            //1. Connect tail points, starting from exit point.
+            //In other instances, algorithm goes towards the end, but here it's calculated backwards
+            //to take into account end direction of previous section in a cheaper way.
+            //Path is still added to tree from start to end.
+            //TO DO: investigate if this can be done through automatic hint lines
+            //TO DO: this section can be moved into `RouteAndAddTailVertices` function 
+            for (int i = 0; i < trunkPathVertices.Count - 1; i++)
+            {
+                var c = ShortestPathDijkstra(trunkPathVertices[i], weights,
+                    out var travelCost, vertexTree[trunkPathVertices[i]], allExcluded);
+                var p = GetPathTo(c, trunkPathVertices[i + 1]);
+                AddPathToTree(trunkPathVertices[i + 1], p, vertexTree);
+            }
+
+            //2. Connect furthest exit point to most efficient point on any of the hint lines.
+            var connections = ShortestPathDijkstra(trunkPathVertices.Last(),
+                                                   weights,
+                                                   out var dropppipeTravelCost,
+                                                   vertexTree[trunkPathVertices.Last()],
+                                                   allExcluded);
+            var droppipeCollectorTerminal = FindConnectionPoint(
+                hintVertices, offsetVertices, dropppipeTravelCost);
+            var droppipePath = GetPathTo(connections, droppipeCollectorTerminal);
+            AddPathToTree(droppipeCollectorTerminal, droppipePath, vertexTree);
+
+            //3. Connect inlets to  most efficient point on hint line.
+            var inletToTrunkPaths = new Dictionary<ulong, List<ulong>>();
+            var inletTouchPoint = new Dictionary<ulong, ulong>();
+            var inletConnections = new Dictionary<ulong, Dictionary<ulong, ulong>>();
+            var inletTravelCosts = new Dictionary<ulong, Dictionary<ulong, double>>();
+            List<ulong> collectorTerminals = new List<ulong>();
+            List<ulong> path = null;
+            foreach (var inlet in leafVertices)
+            {
+                //TO DO: part of this section can be moved into `RouteLeaflVertex` function 
+                var combinedPath = new List<ulong>();
+                ulong? startDirection = null;
+                var otherExcluded = FilteredSet(allExcluded, excludedVertices[inlet.Id]);
+
+                ulong lastInChain = inlet.Id;
+                if (inlet.Guides != null && inlet.Guides.Any() &&
+                    !IsNearby(_grid.GetVertex(inlet.Id).Point, userHints))
+                {
+                    for (int i = 0; i < inlet.Guides.Count(); i++)
+                    {
+                        var c = ShortestPathDijkstra(lastInChain, weights,
+                            out var cost, startDirection, otherExcluded);
+                        var p = GetPathTo(c, inlet.Guides[i]);
+                        CombinePath(combinedPath, p.Take(p.Count - 1).ToList());
+                        inletConnections[lastInChain] = c;
+                        inletTravelCosts[lastInChain] = cost;
+                        lastInChain = inlet.Guides[i];
+                        startDirection = p[p.Count - 2];
+                    }
+                }
+
+                connections = ShortestPathDijkstra(lastInChain, weights,
+                    out var travelCost, startDirection, otherExcluded);
+                inletConnections[lastInChain] = connections;
+                inletTravelCosts[lastInChain] = travelCost;
+                var t1 = FindConnectionPoint(hintVertices, offsetVertices, travelCost);
+                var t2 = FindConnectionPoint(droppipePath, travelCost);
+                if (travelCost[t1] > travelCost[t2])
+                {
+                    path = GetPathTo(connections, t2);
+                }
+                else
+                {
+                    path = GetPathTo(connections, t1);
+                    collectorTerminals.Add(t1);
+
+                }
+                CombinePath(combinedPath, path);
+                inletToTrunkPaths[inlet.Id] = combinedPath;
+                inletTouchPoint[path.Last()] = inlet.Id;
+            }
+
+            //4. Join all individual pieces together. We start from a single connection
+            //path from droppipe and a set of connection points from the previous step.
+            //One at a time we choose the connection point that is cheapest to travel to existing
+            //network and its path is added to the network until all are added.
+            HashSet<ulong> magnetTerminals = new HashSet<ulong>();
+            droppipePath.ForEach(p => magnetTerminals.Add(p));
+
+            var terminalInfo = new Dictionary<ulong, (
+                Dictionary<ulong, ((ulong, BranchSide), (ulong, BranchSide))> Connections,
+                Dictionary<ulong, (double, double)> Costs)>();
+            foreach (var terminal in collectorTerminals)
+            {
+                var inlet = inletTouchPoint[terminal];
+                var excluded = allExcluded;
+                var localExcluded = excludedVertices[inlet];
+                //Allow travel through excluded vertices of inlet only if it not yet left it's zone
+                if (localExcluded.Contains(terminal))
+                {
+                    excluded = FilteredSet(allExcluded, localExcluded);
+                }
+                var pathBefore = inletToTrunkPaths[inlet];
+                var vertexBefore = pathBefore[pathBefore.Count - 2];
+                var branchConns = ShortestBranchesDijkstra(terminal, weights,
+                    out var travelCost, vertexBefore, excluded);
+                terminalInfo[terminal] = (branchConns, travelCost);
+            }
+
+            //Distances are precomputed beforehand to avoid square complexity on Dijkstra algorithm.
+            //When terminal is connected to the trunk - we can choose one of two routing options,
+            //considering also if any of them need extra turn when connected.
+            while (collectorTerminals.Any())
+            {
+                ulong closestTerminal = 0;
+                path = null;
+                double lowestCost = double.MaxValue;
+                foreach (var terminal in collectorTerminals)
+                {
+                    var info = terminalInfo[terminal];
+                    var (localClosest, branchSide) = FindConnectionPoint(
+                        magnetTerminals, info.Costs, info.Connections, vertexTree, weights);
+                    var costs = info.Costs[localClosest];
+                    var bestCost = branchSide == BranchSide.Left ? costs.Item1 : costs.Item2;
+                    if (bestCost < lowestCost)
+                    {
+                        path = GetPathTo(info.Connections, localClosest, branchSide);
+                        closestTerminal = terminal;
+                        lowestCost = bestCost;
+                    }
+                }
+
+                path.ForEach(p => magnetTerminals.Add(p));
+                AddPathToTree(closestTerminal, path, vertexTree);
+                collectorTerminals.Remove(closestTerminal);
+            }
+
+            //5. Inlets are added last. Trunk is already built, check for the best
+            //join point once again, better one might be found.
+            //TO DO: this section can be moved into `RerouteAndAddInletVertices` function 
+            foreach (var inlet in leafVertices)
+            {
+                var key = inlet.Id;
+                var oldPath = inletToTrunkPaths[inlet.Id];
+                if (inlet.Guides != null && inlet.Guides.Any() &&
+                    !IsNearby(_grid.GetVertex(inlet.Id).Point, userHints))
+                {
+                    var index = oldPath.IndexOf(inlet.Guides.Last());
+                    if (index != -1)
+                    {
+                        key = inlet.Guides.Last();
+                        var pathUntilKey = oldPath.Take(index + 1);
+                        AddPathToTree(inlet.Id, pathUntilKey.ToList(), vertexTree);
+                    }
+                }
+
+                //Don't change snapping point is distance is the same as before, as collector
+                //joint point is more preferable than perpendicular connection to the trunk
+                var oldTerminal = oldPath.Last();
+                ulong bestIndex = oldTerminal;
+                var costs = inletTravelCosts[key];
+                double bestCost = costs[bestIndex] - _grid.Tolerance;
+                var t = FindConnectionPoint(magnetTerminals, costs, bestIndex, bestCost);
+                path = GetPathTo(inletConnections[key], t);
+                AddPathToTree(key, path, vertexTree);
+            }
+
+            return vertexTree;
+        }
+
+        /// <summary>
+        /// Creates tree of routes between multiple sections, each having a set of input Vertices,
+        /// hint lines and local end Vertex, and the exit Vertex.
+        /// Route is created by using Dijkstra algorithm locally on different segments.
+        /// Segments are merged together to form a single trunk. Starting from end, point by point,
+        /// segments are connected. Then, Vertices in each segments are connected as well, 
+        /// forming a local trunk, connected with the main one.
+        /// All parameter except "trunkPathVertices" are provided per section in the same order.
+        /// </summary>
+        /// <param name="leafVertices">Vertices to connect into the system with extra information attached.</param>
+        /// <param name="localTails">Anchor points that will form global tree between sections.</param>
+        /// <param name="trunkPathVertices">End vertices, connected in the same order as provided. Exit location goes first.</param>
+        /// <param name="hintLines">Collection of lines that routes are attracted to. At least one hint line per group is required.</param>
+        /// <returns>Travel routes from inputVertices to the last of tailVertices.</returns>
+        public IDictionary<ulong, ulong?> BuildSpanningTree(
+            IList<List<RoutingVertex>> leafVertices, IList<ulong> localTails,
+            IList<ulong> trunkPathVertices, IList<List<RoutingHintLine>> hintLines)
+        {
+            var allLeafs = leafVertices.SelectMany(l => l).ToList();
+            var allHints = hintLines.SelectMany(h => h).ToList();
+
+            //Excluded vertices includes inlets and vertices in certain around inlets
+            //Sometimes it's not wanted for routing to go through them.
+            var excludedVertices = ExcludedVertices(allLeafs);
+            var allExcluded = new HashSet<ulong>();
+            foreach (var item in excludedVertices)
+            {
+                item.Value.ForEach(v => allExcluded.Add(v));
+            }
+
+            var weights = CalculateWeights(allHints, allLeafs);
+            var allUserHints = allHints.Where(h => h.UserDefined == true).ToList();
+            var nearbyHints = NearbyVertices(allUserHints, allLeafs);
+            //Hint lines can go even through excluded vertices
+            allExcluded.ExceptWith(nearbyHints.Select(nh => nh.Id));
+
+            var vertexTree = new Dictionary<ulong, ulong?>();
+            vertexTree[trunkPathVertices.First()] = null;
+            foreach (var inlets in leafVertices)
+            {
+                foreach (var inlet in inlets)
+                {
+                    vertexTree[inlet.Id] = null;
+                }
+            }
+
+            //1. Connect global tail points, starting from exit point.
+            //In other instances, algorithm goes towards the end, but here it's calculated backwards
+            //to take into account end direction of previous section in a cheaper way.
+            //Path is still added to tree from start to end.
+            //TO DO: investigate if this can be done through automatic hint lines
+            //TO DO: this section can be moved into `RouteAndAddTailVertices` function 
+            for (int i = 0; i < trunkPathVertices.Count - 1; i++)
+            {
+                var connections = ShortestPathDijkstra(trunkPathVertices[i], weights,
+                    out var travelCost, vertexTree[trunkPathVertices[i]], allExcluded);
+                var p = GetPathTo(connections, trunkPathVertices[i + 1]);
+                AddPathToTree(trunkPathVertices[i + 1], p, vertexTree);
+            }
+
+            //2. Connect ends of each sections together.
+            //Starting from the trunk created by global tail points.
+            //One at a time we choose the connection point that is cheapest to travel to existing
+            //network and its path is added to the network until all are added.
+            var tailsInfo = new Dictionary<ulong, (Dictionary<ulong, ulong> Connections,
+                                                   Dictionary<ulong, double> Costs)>();
+            for (int i = 0; i < localTails.Count; i++)
+            {
+                //Anchor point can travel through inlets, directly connected to hints.
+                var exceptions = leafVertices[i].Where(
+                    v => IsNearby(_grid.GetVertex(v.Id).Point, allUserHints));
+                var excluded = FilteredSet(
+                    allExcluded,
+                    exceptions.SelectMany(e => excludedVertices[e.Id]));
+                var connections = ShortestPathDijkstra(localTails[i], weights,
+                    out var travelCost, null, excluded);
+                tailsInfo[localTails[i]] = (connections, travelCost);
+            }
+
+            HashSet<ulong> magnetTail = new HashSet<ulong>();
+            magnetTail.Add(trunkPathVertices.Last());
+            var tailsCopy = new List<ulong>(localTails);
+            while (tailsCopy.Any())
+            {
+                List<ulong> path = null;
+                double lowestCost = double.PositiveInfinity;
+                ulong closestTerminal = 0u;
+                foreach (var terminal in tailsCopy)
+                {
+                    var info = tailsInfo[terminal];
+                    var localClosest = FindConnectionPoint(magnetTail, info.Costs);
+                    if (info.Costs[localClosest] < lowestCost)
+                    {
+                        path = GetPathTo(info.Connections, localClosest);
+                        closestTerminal = terminal;
+                        lowestCost = info.Costs[localClosest];
+                    }
+                }
+
+                path.ForEach(p => magnetTail.Add(p));
+                tailsCopy.Remove(closestTerminal);
+                AddPathToTree(closestTerminal, path, vertexTree);
+            }
+
+            //Next steps are repeated independently for each input section
+            for (int i = 0; i < leafVertices.Count; i++)
+            {
+                var hintGroups = hintLines[i].GroupBy(h => h.UserDefined);
+                var userHints = hintGroups.SingleOrDefault(hg => hg.Key == true);
+                var defaultHints = hintGroups.SingleOrDefault(hg => hg.Key == false);
+                var hintVertices = NearbyVertices(userHints, leafVertices[i]);
+                var offsetVertices = NearbyVertices(defaultHints, leafVertices[i]);
+
+                var inletToTrunkPaths = new Dictionary<ulong, List<ulong>>();
+                var inletTouchPoint = new Dictionary<ulong, ulong>();
+                var inletConnections = new Dictionary<ulong, Dictionary<ulong, ulong>>();
+                var inletTravelCosts = new Dictionary<ulong, Dictionary<ulong, double>>();
+                List<ulong> collectorTerminals = new List<ulong>();
+                List<ulong> path = null;
+
+                //3. Connect inlets to  most efficient point on hint line.
+                //User defined hint lines have priority, unless they are too far away.
+                foreach (var inlet in leafVertices[i])
+                {
+                    //TO DO: part of this section can be moved into `RouteLeaflVertex` function 
+                    var combinedPath = new List<ulong>();
+                    ulong? startDirection = null;
+                    var otherExcluded = FilteredSet(allExcluded, excludedVertices[inlet.Id]);
+
+                    ulong lastInChain = inlet.Id;
+                    if (inlet.Guides != null && inlet.Guides.Any() &&
+                        !IsNearby(_grid.GetVertex(inlet.Id).Point, userHints))
+                    {
+                        for (int j = 0; j < inlet.Guides.Count(); j++)
+                        {
+                            var innerCons = ShortestPathDijkstra(lastInChain, weights,
+                                out var innerCosts, startDirection, otherExcluded);
+                            var p = GetPathTo(innerCons, inlet.Guides[j]);
+                            CombinePath(combinedPath, p.Take(p.Count - 1).ToList());
+                            inletConnections[lastInChain] = innerCons;
+                            inletTravelCosts[lastInChain] = innerCosts;
+                            lastInChain = inlet.Guides[j];
+                            startDirection = p[p.Count - 2];
+                        }
+                    }
+
+                    var connections = ShortestPathDijkstra(lastInChain, weights,
+                        out var travelCost, startDirection, otherExcluded);
+                    inletConnections[lastInChain] = connections;
+                    inletTravelCosts[lastInChain] = travelCost;
+                    var t = FindConnectionPoint(hintVertices, offsetVertices, travelCost);
+                    path = GetPathTo(connections, t);
+                    collectorTerminals.Add(t);
+
+                    CombinePath(combinedPath, path);
+                    inletToTrunkPaths[inlet.Id] = combinedPath;
+                    inletTouchPoint[path.Last()] = inlet.Id;
+                }
+
+                //4. Join all individual pieces together. We start from a single connection
+                //path from droppipe and a set of connection points from the previous step.
+                //One at a time we choose the connection point that is cheapest to travel to existing
+                //network and its path is added to the network until all are added.
+                HashSet<ulong> magnetTerminals = new HashSet<ulong>();
+                magnetTerminals.Add(localTails[i]);
+
+                var terminalInfo = new Dictionary<ulong, (
+                    Dictionary<ulong, ((ulong, BranchSide), (ulong, BranchSide))> Connections,
+                    Dictionary<ulong, (double, double)> Costs)>();
+                foreach (var terminal in collectorTerminals)
+                {
+                    var inlet = inletTouchPoint[terminal];
+                    var excluded = allExcluded;
+                    var localExcluded = excludedVertices[inlet];
+                    //Allow travel through excluded vertices of inlet only if it not yet left it's zone
+                    if (localExcluded.Contains(terminal))
+                    {
+                        excluded = FilteredSet(allExcluded, localExcluded);
+                    }
+                    var pathBefore = inletToTrunkPaths[inlet];
+                    var vertexBefore = pathBefore[pathBefore.Count - 2];
+                    var connections = ShortestBranchesDijkstra(terminal, weights,
+                        out var travelCost, vertexBefore, excluded);
+                    terminalInfo[terminal] = (connections, travelCost);
+                }
+
+                //Distances are precomputed beforehand to avoid square complexity on Dijkstra algorithm.
+                //When terminal is connected to the trunk - we can choose one of two routing options,
+                //considering also if any of them need extra turn when connected.
+                while (collectorTerminals.Any())
+                {
+                    ulong closestTerminal = 0;
+                    path = null;
+                    double lowestCost = double.MaxValue;
+                    foreach (var terminal in collectorTerminals)
+                    {
+                        var info = terminalInfo[terminal];
+                        var (localClosest, branch) = FindConnectionPoint(
+                            magnetTerminals, info.Costs, info.Connections, vertexTree, weights);
+                        var costs = info.Costs[localClosest];
+                        var bestCost = branch == BranchSide.Left ? costs.Item1 : costs.Item2;
+                        if (bestCost < lowestCost)
+                        {
+                            path = GetPathTo(info.Connections, localClosest, branch);
+                            closestTerminal = terminal;
+                            lowestCost = bestCost;
+                        }
+                    }
+
+                    path.ForEach(p => magnetTerminals.Add(p));
+                    AddPathToTree(closestTerminal, path, vertexTree);
+                    collectorTerminals.Remove(closestTerminal);
+                }
+
+                foreach (var t in magnetTail)
+                {
+                    magnetTerminals.Add(t);
+                }
+
+                //5. Inlets are added last. Trunk is already built, check for the best
+                //join point once again, better one might be found.
+                //TO DO: this section can be moved into `RerouteAndAddInletVertices` function 
+                foreach (var inlet in leafVertices[i])
+                {
+                    var key = inlet.Id;
+                    var oldPath = inletToTrunkPaths[inlet.Id];
+                    if (inlet.Guides != null && inlet.Guides.Any() &&
+                        !IsNearby(_grid.GetVertex(inlet.Id).Point, userHints))
+                    {
+                        var index = oldPath.IndexOf(inlet.Guides.Last());
+                        if (index != -1)
+                        {
+                            key = inlet.Guides.Last();
+                            var pathUntilKey = oldPath.Take(index + 1);
+                            AddPathToTree(inlet.Id, pathUntilKey.ToList(), vertexTree);
+                        }
+                    }
+
+                    //Don't change snapping point is distance is the same as before, as collector
+                    //joint point is more preferable than perpendicular connection to the trunk
+                    var oldTerminal = oldPath.Last();
+                    ulong bestIndex = oldTerminal;
+                    var costs = inletTravelCosts[key];
+                    double bestCost = costs[bestIndex] - _grid.Tolerance;
+                    var t = FindConnectionPoint(magnetTerminals, costs, bestIndex, bestCost);
+                    path = GetPathTo(inletConnections[key], t);
+                    AddPathToTree(key, path, vertexTree);
+                }
+            }
+
+            return vertexTree;
+        }
+
+        /// <summary>
+        /// Create network of routes between set of input Vertices and set of exit Vertices.
+        /// Each route is most efficient individually, without considering other routes.
+        /// Each route is connected to the network using Dijkstra algorithm.
+        /// </summary>
+        /// <param name="leafVertices">Vertices to connect into the system with extra information attached.</param>
+        /// <param name="exits">Possible exit vertices.</param>
+        /// <param name="hintLines">Collection of lines that routes are attracted to. At least one hint line is required.</param>
+        /// <returns>Travel routes from inputVertices to the last of tailVertices.</returns>
+        public IDictionary<ulong, ulong?> BuildSimpleNetwork(
+            IList<RoutingVertex> leafVertices,
+            IList<ulong> exits,
+            IEnumerable<RoutingHintLine> hintLines)
+        {
+            //Excluded vertices includes inlets and vertices in certain distance around these inlets.
+            //Sometimes it's not wanted for routing to go through them.
+            var excludedVertices = ExcludedVertices(leafVertices);
+            var allExcluded = new HashSet<ulong>();
+            foreach (var item in excludedVertices)
+            {
+                item.Value.ForEach(v => allExcluded.Add(v));
+            }
+
+            var weights = CalculateWeights(hintLines, leafVertices);
+
+            var vertexTree = new Dictionary<ulong, ulong?>();
+            foreach (var trunk in exits)
+            {
+                vertexTree[trunk] = null;
+            }
+
+            foreach (var inlet in leafVertices)
+            {
+                vertexTree[inlet.Id] = null;
+            }
+
+            var hintGroups = hintLines.GroupBy(h => h.UserDefined);
+            var userHints = hintGroups.SingleOrDefault(hg => hg.Key == true);
+            var defaultHints = hintGroups.SingleOrDefault(hg => hg.Key == false);
+            var hintVertices = NearbyVertices(userHints, leafVertices);
+            var offsetVertices = NearbyVertices(defaultHints, leafVertices);
+            //Hint lines can go even through excluded vertices
+            allExcluded.ExceptWith(hintVertices.Select(hv => hv.Id));
+
+
+            foreach (var inlet in leafVertices)
+            {
+                var connections = ShortestPathDijkstra(inlet.Id, weights, out var travelCost);
+                var exit = FindConnectionPoint(exits, travelCost);
+                var path = GetPathTo(connections, exit);
+                AddPathToTree(inlet.Id, path, vertexTree);
+            }
+
+            return vertexTree;
+        }
+
+        /// <summary>
+        /// Calculate weight for each edge in the graph. Information is stored as length
+        /// of edge and extra factor that encourage or discourage traveling trough it.
+        /// Edges that are not on main elevation have bigger factor.
+        /// Edges that are near hint lines have smaller factor.
+        /// Different factors are combined together.
+        /// Also some edges are not allowed at all by setting factor to infinity.
+        /// </summary>
+        /// <param name="hintLines">Lines that affect travel factor for edges</param>
+        /// <param name="inletTerminals">Vertices that are allowed to only travel vertically</param>
+        /// <returns>For each edge - its length and extra traveling factor</returns>
+        private Dictionary<ulong, (double Length, double Factor)> CalculateWeights(
+            IEnumerable<RoutingHintLine> hintLines,
+            IList<RoutingVertex> inletTerminals)
+        {
+            var weights = new Dictionary<ulong, (double Length, double Factor)>();
+            foreach (var e in _grid.GetEdges())
+            {
+                var v0 = _grid.GetVertex(e.StartId);
+                var v1 = _grid.GetVertex(e.EndId);
+
+                double hintFactor = 1;
+                double offsetFactor = 1;
+                double layerFactor = OnMainLayer(v0, v1) ? 1 : _configuration.LayerPenalty;
+                if (hintLines.Any())
+                {
+                    foreach (var l in hintLines)
+                    {
+                        if (IsAffectedBy(v0.Point, v1.Point, l))
+                        {
+                            //If user defined and default hints are overlapped,
+                            //we want path to be aligned with default hints.
+                            //To achieve this to factors are combined.
+                            if (l.UserDefined)
+                            {
+                                hintFactor = Math.Min(l.Factor, hintFactor);
+                            }
+                            else
+                            {
+                                offsetFactor = Math.Min(l.Factor, offsetFactor);
+                            }
+                        }
+                    }
+                }
+
+                var w = (_grid.GetVertex(e.StartId).Point - _grid.GetVertex(e.EndId).Point).Length();
+                weights[e.Id] = (w, hintFactor * offsetFactor * layerFactor);
+            }
+
+            return weights;
+        }
+
+        /// <summary>
+        /// Collect vertices that are less than configured Manhattan distance
+        /// away from given inlets, ignoring Z difference.
+        /// </summary>
+        /// <returns></returns>
+        private Dictionary<ulong, List<ulong>> ExcludedVertices(
+            IList<RoutingVertex> inletTerminals)
+        {
+            var excludedVertices = new Dictionary<ulong, List<ulong>>();
+            foreach (var inlet in inletTerminals)
+            {
+                var adjustedTolerance = inlet.IsolationRadius - Vector3.EPSILON;
+                var ip = _grid.GetVertex(inlet.Id).Point;
+                var set = new List<ulong>();
+                excludedVertices[inlet.Id] = set;
+
+                foreach (var v in _grid.GetVertices())
+                {
+                    var p = v.Point;
+                    var mhDistance2D = Math.Abs(p.X - ip.X) + Math.Abs(p.Y - ip.Y);
+                    if (mhDistance2D < adjustedTolerance)
+                    {
+                        set.Add(v.Id);
+                    }
+                }
+            }
+            return excludedVertices;
+        }
+
+        /// <summary>
+        /// This is a Dijkstra algorithm implementation.
+        /// The algorithm travels from start point to all other points, gathering travel cost.
+        /// Each time route turns - extra penalty is added to the cost.
+        /// Higher level algorithm then decides which one of them to use as an end point.
+        /// </summary>
+        /// <param name="start">Start Vertex</param>
+        /// <param name="edgeWeights">Dictionary of Edge Id to the cost of traveling though it</param>
+        /// <param name="travelCost">Output dictionary where traveling cost is stored per Vertex</param>
+        /// <param name="startDirection">Previous Vertex, if start Vertex is already part of the Route</param>
+        /// <param name="excluded">Vertices that are not allowed to visit</param>
+        /// <param name="pathDirections">Next Vertex dictionary for Vertices that are already part of the route</param>
+        /// <returns>Dictionary that have travel routes from each Vertex back to start Vertex.</returns>
+        public Dictionary<ulong, ulong> ShortestPathDijkstra(
+            ulong start, Dictionary<ulong, (double Length, double Factor)> edgeWeights,
+            out Dictionary<ulong, double> travelCost,
+            ulong? startDirection = null, HashSet<ulong> excluded = null,
+            Dictionary<ulong, ulong?> pathDirections = null)
+        {
+            PriorityQueue<ulong> pq = PreparePriorityQueue(
+                start, out Dictionary<ulong, ulong> path, out travelCost);
+
+            while (!pq.Empty())
+            {
+                //At each step retrieve the vertex with the lowest travel cost and
+                //remove it, so it can't be visited again.
+                ulong u = pq.PopMin();
+                if (excluded != null && excluded.Contains(u))
+                {
+                    continue;
+                }
+
+                var vertex = _grid.GetVertex(u);
+                foreach (var e in vertex.Edges)
+                {
+                    var edgeWeight = edgeWeights[e.Id];
+                    if (edgeWeight.Length < 0)
+                    {
+                        continue;
+                    }
+
+                    var id = e.StartId == u ? e.EndId : e.StartId;
+                    var v = _grid.GetVertex(id);
+
+                    if ((excluded != null && excluded.Contains(id)) || !pq.Contains(id))
+                    {
+                        continue;
+                    }
+
+                    //All vertices that can be reached from start vertex are visited.
+                    //Ignore once only unreachable are left.
+                    var cost = travelCost[u];
+                    if (cost == double.MaxValue)
+                    {
+                        break;
+                    }
+
+                    //Compute cost of each its neighbors as cost of vertex we came from plus cost of edge.
+                    var newWeight = travelCost[u] + edgeWeight.Length * edgeWeight.Factor;
+
+                    //We need as little change of direction as possible. A penalty is added if
+                    //a) We have a turn traveling to the next vertex.
+                    //b) We just started and going in direction different than how we arrived from the previous segment.
+                    //c) We arrived at a vertex that is used in a different path.
+                    if (u == start)
+                    {
+                        if (startDirection.HasValue &&
+                            !AreCollinearInplace(_grid.GetVertex(startDirection.Value).Point, vertex.Point, v.Point))
+                        {
+                            newWeight += CalculateTurnCost(edgeWeight.Factor, vertex, startDirection.Value, edgeWeights);
+                        }
+                    }
+                    else
+                    {
+                        var vertexBefore = _grid.GetVertex(path[u]);
+                        if (!AreCollinearInplace(vertexBefore.Point, vertex.Point, v.Point))
+                        {
+                            newWeight += CalculateTurnCost(edgeWeight.Factor, vertex, vertexBefore.Id, edgeWeights);
+                        }
+                        if (pathDirections != null &&
+                            pathDirections.TryGetValue(v.Id, out var vertexAfter) && vertexAfter.HasValue &&
+                            !AreCollinearInplace(vertex.Point, v.Point, _grid.GetVertex(vertexAfter.Value).Point))
+                        {
+                            newWeight += CalculateTurnCost(edgeWeight.Factor, v, vertexAfter.Value, edgeWeights);
+                        }
+                    }
+
+                    // If a lower travel cost to vertex is discovered update the vertex.
+                    if (newWeight < travelCost[id])
+                    {
+                        travelCost[id] = newWeight;
+                        path[id] = u;
+                        pq.UpdatePriority(id, newWeight);
+                    }
+                }
+            }
+            return path;
+        }
+
+        /// <summary>
+        /// This is a Dijkstra algorithm implementation that stores up to two different paths per vertex.
+        /// The algorithm travels from start point to all other points, gathering travel cost.
+        /// Each time route turns - extra penalty is added to the cost.
+        /// Higher level algorithm then decides which one of them to use as an end point.
+        /// Produced dictionary has "Left/Right" label using which two best routes per vertex can be retried.
+        /// </summary>
+        /// <param name="start">Start Vertex</param>
+        /// <param name="edgeWeights">Dictionary of Edge Id to the cost of traveling though it</param>
+        /// <param name="travelCost">Output dictionary where traveling costs are stored per Vertex for two possible branches</param>
+        /// <param name="startDirection">Previous Vertex, if start Vertex is already part of the Route</param>
+        /// <param name="excluded">Vertices that are not allowed to visit</param>
+        /// <returns>Dictionary that have two travel routes from each Vertex back to start Vertex.</returns>
+        public Dictionary<ulong, ((ulong, BranchSide), (ulong, BranchSide))> ShortestBranchesDijkstra(
+            ulong start, Dictionary<ulong, (double Length, double Factor)> edgeWeights,
+            out Dictionary<ulong, (double, double)> travelCost,
+            ulong? startDirection = null, HashSet<ulong> excluded = null)
+        {
+            PriorityQueue<ulong> pq = PreparePriorityQueue(
+                start, out Dictionary<ulong, ((ulong, BranchSide), (ulong, BranchSide))> path,
+                out travelCost);
+
+            while (!pq.Empty())
+            {
+                //At each step retrieve the vertex with the lowest travel cost and
+                //remove it, so it can't be visited again.
+                ulong u = pq.PopMin();
+                if (excluded != null && excluded.Contains(u))
+                {
+                    continue;
+                }
+
+                var vertex = _grid.GetVertex(u);
+                foreach (var e in vertex.Edges)
+                {
+                    var edgeWeight = edgeWeights[e.Id];
+                    if (edgeWeight.Length < 0)
+                    {
+                        continue;
+                    }
+
+                    var id = e.StartId == u ? e.EndId : e.StartId;
+                    var v = _grid.GetVertex(id);
+
+                    if ((excluded != null && excluded.Contains(id)) || !pq.Contains(id))
+                    {
+                        continue;
+                    }
+
+                    //All vertices that can be reached from start vertex are visited.
+                    //Ignore once only unreachable are left.
+                    var cost = travelCost[u];
+                    if (cost.Item1 == double.MaxValue)
+                    {
+                        break;
+                    }
+
+                    //Compute cost of each its neighbors as cost of vertex we came from plus cost of edge.
+                    var newWeight = edgeWeight.Length * edgeWeight.Factor;
+                    BranchSide bestBranch = BranchSide.Left;
+
+                    //We need as little change of direction as possible. A penalty is added if
+                    //a) We have a turn traveling to the next vertex.
+                    //b) We just started and going in direction different than how we arrived from the previous segment.
+                    //c) We arrived at a vertex that is used in a different path.
+                    if (u == start)
+                    {
+                        if (startDirection.HasValue &&
+                            !AreCollinearInplace(_grid.GetVertex(startDirection.Value).Point, vertex.Point, v.Point))
+                        {
+                            newWeight += CalculateTurnCost(edgeWeight.Factor, vertex, startDirection.Value, edgeWeights);
+                        }
+                    }
+                    else
+                    {
+                        //For each of two stored branches - edges connected to active one.
+                        //Add turn cost if the direction is changed.
+                        var before = path[u];
+                        var leftBefore = _grid.GetVertex(before.Item1.Item1);
+                        var leftCollinear = AreCollinearInplace(leftBefore.Point, vertex.Point, v.Point);
+                        var leftCost = cost.Item1 + newWeight;
+                        if (!leftCollinear)
+                        {
+                            leftCost += CalculateTurnCost(
+                                edgeWeight.Factor, vertex, leftBefore.Id, edgeWeights);
+                        }
+
+                        var rigthCost = Double.MaxValue;
+                        if (before.Item2.Item1 != 0)
+                        {
+                            var rigthBefore = _grid.GetVertex(before.Item2.Item1);
+                            rigthCost = cost.Item2 + newWeight;
+                            if (!AreCollinearInplace(rigthBefore.Point, vertex.Point, v.Point))
+                            {
+                                rigthCost += CalculateTurnCost(
+                                    edgeWeight.Factor, vertex, rigthBefore.Id, edgeWeights);
+                            }
+                        }
+
+                        //Then choose the path that has lower accumulated value.
+                        if (leftCost < rigthCost)
+                        {
+                            newWeight = leftCost;
+                            bestBranch = BranchSide.Left;
+                        }
+                        else
+                        {
+                            newWeight = rigthCost;
+                            bestBranch = BranchSide.Right;
+                        }
+                    }
+
+
+                    var oldCost = travelCost[id];
+                    var oldPath = path[id];
+                    //Cheaper branch is stored first.
+                    //But priority for the Vertex is set by the slower branch.
+                    if (newWeight < oldCost.Item1)
+                    {
+                        travelCost[id] = (newWeight, oldCost.Item1);
+                        path[id] = ((u, bestBranch), oldPath.Item1);
+                        if (oldCost.Item1 == double.MaxValue)
+                        {
+                            //When we first meet the vertex we need to slow it down to allow
+                            //other slightly slower path but with potentially better turn to reach it.
+                            pq.UpdatePriority(id, newWeight + _configuration.TurnCost);
+                        }
+                        else
+                        {
+                            var newPriority = Math.Min(oldCost.Item1, newWeight + _configuration.TurnCost);
+                            pq.UpdatePriority(id, newPriority);
+                        }
+                    }
+                    else if (newWeight < oldCost.Item2)
+                    {
+                        travelCost[id] = (oldCost.Item1, newWeight);
+                        path[id] = (oldPath.Item1, (u, bestBranch));
+                        var newPriority = Math.Min(oldCost.Item1 + _configuration.TurnCost, newWeight);
+                        pq.UpdatePriority(id, newPriority);
+                    }
+                }
+            }
+            return path;
+        }
+
+        /// <summary>
+        /// Calculate turn cost between two edges.
+        /// Turn cost should take into account cost factor of given edges.
+        /// Otherwise hint paths with several turns would be ignored because of extra cost.
+        /// The turn factor is multiplied by minimum of two edges factor.
+        /// </summary>
+        /// <param name="edgeFactor">Edge factor of the first edge</param>
+        /// <param name="sharedVertex">Id of the vertex, common for two edges</param>
+        /// <param name="thirdVertexId">Third vertex Id</param>
+        /// <param name="edgeWeights">Precalculated length and factor for each edge</param>
+        /// <returns></returns>
+        private double CalculateTurnCost(
+            double edgeFactor, Vertex sharedVertex, ulong thirdVertexId,
+            IDictionary<ulong, (double Lenght, double Factor)> edgeWeights)
+        {
+            var otherEdge = sharedVertex.Edges.Where(
+                edge => edge.StartId == thirdVertexId || edge.EndId == thirdVertexId).FirstOrDefault();
+            var otherWeight = edgeWeights[otherEdge.Id];
+            //Minimum factor makes algorithm prefer edges inside of hint lines even if they
+            //have several turns but don't give advantage for the tiny edges that are
+            //fully inside hint line influence area. 
+            return _configuration.TurnCost * Math.Min(edgeFactor, otherWeight.Factor);
+        }
+
+        private PriorityQueue<ulong> PreparePriorityQueue(ulong start,
+            out Dictionary<ulong, ulong> path, out Dictionary<ulong, double> travelCost)
+        {
+            path = new Dictionary<ulong, ulong>();
+            travelCost = new Dictionary<ulong, double>();
+
+            //Travel cost of all vertices are set to infinity, except for the one we start
+            //from for which is set to 0.
+            var vertices = _grid.GetVertices();
+            List<ulong> indices = new List<ulong>() { start };
+            for (int i = 0; i < vertices.Count; i++)
+            {
+                if (vertices[i].Id != start)
+                {
+                    indices.Add(vertices[i].Id);
+                    travelCost[vertices[i].Id] = double.MaxValue;
+                }
+                path[vertices[i].Id] = 0;
+            }
+            travelCost[start] = 0;
+
+            PriorityQueue<ulong> pq = new PriorityQueue<ulong>(indices);
+            return pq;
+        }
+
+        private PriorityQueue<ulong> PreparePriorityQueue(ulong start,
+            out Dictionary<ulong, ((ulong, BranchSide), (ulong, BranchSide))> path,
+            out Dictionary<ulong, (double, double)> travelCost)
+        {
+            path = new Dictionary<ulong, ((ulong, BranchSide), (ulong, BranchSide))>();
+            travelCost = new Dictionary<ulong, (double, double)>();
+
+            //Travel cost of all vertices are set to infinity, except for the one we start
+            //from for which is set to 0.
+            var vertices = _grid.GetVertices();
+            List<ulong> indices = new List<ulong>() { start };
+            for (int i = 0; i < vertices.Count; i++)
+            {
+                if (vertices[i].Id != start)
+                {
+                    indices.Add(vertices[i].Id);
+                    travelCost[vertices[i].Id] = (double.MaxValue, double.MaxValue);
+                }
+                path[vertices[i].Id] = ((0, BranchSide.Left), (0, BranchSide.Left));
+            }
+            travelCost[start] = (0, 0);
+
+            PriorityQueue<ulong> pq = new PriorityQueue<ulong>(indices);
+            return pq;
+        }
+
+        private List<ulong> GetPathTo(Dictionary<ulong, ulong> connections, ulong end)
+        {
+            List<ulong> shortestPath = new List<ulong>();
+            shortestPath.Add(end);
+            var before = connections[end];
+            while (before != 0)
+            {
+                shortestPath.Add(before);
+                before = connections[before];
+            }
+
+            return shortestPath.Reverse<ulong>().ToList();
+        }
+
+        private List<ulong> GetPathTo(
+            Dictionary<ulong, ((ulong, BranchSide), (ulong, BranchSide))> connections,
+            ulong end, BranchSide branch)
+        {
+            List<ulong> shortestPath = new List<ulong>();
+            shortestPath.Add(end);
+            var before = connections[end];
+            var branchBefore = branch == BranchSide.Left ? before.Item1 : before.Item2;
+            while (branchBefore.Item1 != 0)
+            {
+                shortestPath.Add(branchBefore.Item1);
+                before = connections[branchBefore.Item1];
+                branchBefore = branchBefore.Item2 == BranchSide.Left ? before.Item1 : before.Item2;
+            }
+
+            return shortestPath.Reverse<ulong>().ToList();
+        }
+
+        private void AddPathToTree(
+            ulong start, List<ulong> path, Dictionary<ulong, ulong?> tree)
+        {
+            if (path.First() != start)
+            {
+                path.Reverse();
+            }
+
+            for (int i = 1; i < path.Count; i++)
+            {
+                //Path is composed from end to inlets. If tree already has next vertex
+                //from this one recorded, we don't want to override it. This way we join
+                //the flow that is already created, removing unnecessary loops.
+                if (!tree.ContainsKey(path[i - 1]) || tree[path[i - 1]] == null)
+                    tree[path[i - 1]] = path[i];
+            }
+        }
+
+        private List<Vertex> NearbyVertices(
+            IEnumerable<RoutingHintLine> hints,
+            IEnumerable<RoutingVertex> excluded)
+        {
+            if (hints == null || !hints.Any())
+            {
+                return new List<Vertex>();
+            }
+
+            return _grid.GetVertices().Where(
+                v => !excluded.Any(e => e.Id == v.Id) && IsNearby(v.Point, hints)).ToList();
+        }
+
+        private bool IsNearby(Vector3 v, IEnumerable<RoutingHintLine> hints)
+        {
+            return hints != null &&
+                hints.Any(c => new Vector3(v.X, v.Y).DistanceTo(c.Polyline) < c.InfluenceDistance);
+        }
+
+        private bool IsAffectedBy(
+            Vector3 start, Vector3 end, IEnumerable<RoutingHintLine> hints)
+        {
+            return hints != null && hints.Any(h => IsAffectedBy(start, end, h));
+        }
+
+        private bool IsAffectedBy(Vector3 start, Vector3 end, RoutingHintLine hint)
+        {
+            Func<Vector3, RoutingHintLine, bool> check = (Vector3 v, RoutingHintLine hl) =>
+            {
+                return v.DistanceTo(hl.Polyline) < hl.InfluenceDistance;
+            };
+
+            var vs_2d = new Vector3(start.X, start.Y);
+            var ve_2d = new Vector3(end.X, end.Y);
+            //Vertical edges are not affected by hint lines
+            if (!vs_2d.IsAlmostEqualTo(ve_2d, _grid.Tolerance) && Math.Abs(start.Z - end.Z) < _grid.Tolerance)
+            {
+                //Start and End point of edge may be on hint line, but hint line itself
+                //can go around the edge. Need to check middle point additionally.
+                var vm_2d = new Vector3(vs_2d.X + (ve_2d.X - vs_2d.X) / 2.0,
+                                        vs_2d.Y + (ve_2d.Y - vs_2d.Y) / 2.0);
+                return check(vs_2d, hint) && check(ve_2d, hint) && check(vm_2d, hint);
+            }
+            return false;
+        }
+
+        private bool OnMainLayer(Vertex v0, Vertex v1)
+        {
+            return Math.Abs(v0.Point.Z - _configuration.MainLayer) < _grid.Tolerance &&
+                   Math.Abs(v1.Point.Z - _configuration.MainLayer) < _grid.Tolerance;
+        }
+
+        private void Compare(ulong index, IDictionary<ulong, double> travelCost,
+            ref double bestCost, ref ulong bestIndex)
+        {
+            if (travelCost.TryGetValue(index, out var cost))
+            {
+                if (cost < bestCost)
+                {
+                    bestCost = cost;
+                    bestIndex = index;
+                }
+            }
+        }
+
+        private ulong FindConnectionPoint(
+            IEnumerable<Vertex> hintVertices,
+            IEnumerable<Vertex> offsetVertices,
+            IDictionary<ulong, double> travelCost)
+        {
+            ulong bestIndex = 0;
+            double bestCost = double.MaxValue;
+            foreach (var v in hintVertices)
+            {
+                Compare(v.Id, travelCost, ref bestCost, ref bestIndex);
+            }
+            foreach (var v in offsetVertices)
+            {
+                Compare(v.Id, travelCost, ref bestCost, ref bestIndex);
+            }
+            return bestIndex;
+        }
+
+        private (ulong, BranchSide) FindConnectionPoint(
+            IEnumerable<ulong> collection,
+            IDictionary<ulong, (double, double)> travelCost,
+            IDictionary<ulong, ((ulong, BranchSide), (ulong, BranchSide))> connections,
+            IDictionary<ulong, ulong?> tree,
+            IDictionary<ulong, (double Length, double Factor)> weights)
+
+        {
+            ulong bestIndex = 0;
+            double bestCost = double.MaxValue;
+            BranchSide bestBranch = BranchSide.Left;
+            foreach (var index in collection)
+            {
+                if (travelCost.TryGetValue(index, out var costs))
+                {
+                    if (tree.TryGetValue(index, out var next) && next.HasValue)
+                    {
+                        double cost1 = costs.Item1;
+                        double cost2 = costs.Item2;
+                        var activeV = _grid.GetVertex(index);
+                        var nextV = _grid.GetVertex(next.Value);
+
+                        //TO DO: better investigate why they 0 sometimes
+                        var before = connections[index];
+                        var before1 = before.Item1.Item1;
+                        var before2 = before.Item2.Item1;
+                        if (before1 != 0)
+                        {
+                            var beforeV1 = _grid.GetVertex(before.Item1.Item1);
+                            if (!AreCollinearInplace(beforeV1.Point, activeV.Point, nextV.Point))
+                            {
+                                var edge = activeV.Edges.Where(
+                                    e => e.StartId == beforeV1.Id || e.EndId == beforeV1.Id).First();
+                                var edgeWeight = weights[edge.Id];
+                                cost1 += CalculateTurnCost(edgeWeight.Factor, activeV, nextV.Id, weights);
+                            }
+                        }
+
+                        if (before2 != 0)
+                        {
+                            var beforeV2 = _grid.GetVertex(before.Item2.Item1);
+                            if (!AreCollinearInplace(beforeV2.Point, activeV.Point, nextV.Point))
+                            {
+                                var edge = activeV.Edges.Where(
+                                    e => e.StartId == beforeV2.Id || e.EndId == beforeV2.Id).First();
+                                var edgeWeight = weights[edge.Id];
+                                cost2 += CalculateTurnCost(edgeWeight.Factor, activeV, nextV.Id, weights);
+                            }
+
+                        }
+
+                        var bestCandidate = cost1 < cost2 ? (cost1, BranchSide.Left) : (cost2, BranchSide.Right);
+                        if (bestCandidate.Item1 < bestCost)
+                        {
+                            bestCost = bestCandidate.Item1;
+                            bestIndex = index;
+                            bestBranch = bestCandidate.Item2;
+                        }
+                    }
+                    else
+                    {
+                        if (costs.Item1 < bestCost)
+                        {
+                            bestCost = costs.Item1;
+                            bestIndex = index;
+                            bestBranch = BranchSide.Left;
+                        }
+                    }
+                }
+            }
+            return (bestIndex, bestBranch);
+        }
+
+        private ulong FindConnectionPoint(IEnumerable<ulong> collection,
+            IDictionary<ulong, double> travelCost,
+            ulong bestIndex = 0, double bestCost = double.MaxValue)
+        {
+            foreach (var v in collection)
+            {
+                Compare(v, travelCost, ref bestCost, ref bestIndex);
+            }
+            return bestIndex;
+        }
+
+        //This is the same as Vector3.AreCollinear but avoiding all expensive validations.
+        private bool AreCollinearInplace(Vector3 a, Vector3 b, Vector3 c)
+        {
+            var baX = b.X - a.X;
+            var baY = b.Y - a.Y;
+            var baZ = b.Z - a.Z;
+            var baLength = Math.Sqrt(Math.Pow(baX, 2) + Math.Pow(baY, 2) + Math.Pow(baZ, 2));
+            if (baLength < Vector3.EPSILON)
+            {
+                return true;
+            }
+            baX = baX / baLength;
+            baY = baY / baLength;
+            baZ = baZ / baLength;
+
+            var cbX = c.X - b.X;
+            var cbY = c.Y - b.Y;
+            var cbZ = c.Z - b.Z;
+            var cbLength = Math.Sqrt(Math.Pow(cbX, 2) + Math.Pow(cbY, 2) + Math.Pow(cbZ, 2));
+            if (cbLength < Vector3.EPSILON)
+            {
+                return true;
+            }
+            cbX = cbX / cbLength;
+            cbY = cbY / cbLength;
+            cbZ = cbZ / cbLength;
+
+            return Math.Abs(baX * cbX + baY * cbY + baZ * cbZ) > (1 - Vector3.EPSILON);
+        }
+
+        private void CombinePath(List<ulong> mainPath, List<ulong> newPortion)
+        {
+            for (int i = 0; i < mainPath.Count; i++)
+            {
+                var index = newPortion.IndexOf(mainPath[i]);
+                if (index != -1)
+                {
+                    mainPath.RemoveRange(i, mainPath.Count - i);
+                    mainPath.AddRange(newPortion.Skip(index));
+                    return;
+                }
+            }
+            mainPath.AddRange(newPortion);
+        }
+
+        private HashSet<ulong> FilteredSet(HashSet<ulong> hashSet, IEnumerable<ulong> exceptions)
+        {
+            var setCopy = new HashSet<ulong>(hashSet);
+            setCopy.ExceptWith(exceptions);
+            return setCopy;
+        }
+
+        private ModelPoints VisualizePoints(IList<Vector3> points)
+        {
+            List<SolidOperation> so = new List<SolidOperation>();
+            double sideLength = 0.2;
+            var baseRectangle = Polygon.Rectangle(sideLength, sideLength);
+            foreach (var p in points)
+            {
+                var rectangle = baseRectangle.TransformedPolygon(
+                    new Transform(p - new Vector3(0, 0, sideLength / 2)));
+                var extrude = new Extrude(rectangle, sideLength, Vector3.ZAxis, false);
+                so.Add(extrude);
+            }
+
+            var mp = new ModelPoints(points)
+            {
+                Representation = new Representation(so),
+                Material = new Material("Grid Key Points", new Color(0.6, 0.2, 0.8, 0.5)) //Dark Orchid
+            };
+            return mp;
+        }
+    }
+}

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -267,7 +267,7 @@ namespace Elements.Spatial.AdaptiveGrid
             }
 
             //Excluded vertices includes inlets and vertices in certain distance around these inlets.
-            //Sometimes it's not desired for routing to go through them.
+            //Sometimes it's not desirable for routing to go through them.
             var excludedVertices = ExcludedVertices(leafVertices);
             var allExcluded = new HashSet<ulong>();
             foreach (var item in excludedVertices)
@@ -730,7 +730,7 @@ namespace Elements.Spatial.AdaptiveGrid
             IEnumerable<RoutingHintLine> hintLines)
         {
             //Excluded vertices includes inlets and vertices in certain distance around these inlets.
-            //Sometimes it's not desired for routing to go through them.
+            //Sometimes it's not desirable for routing to go through them.
             var excludedVertices = ExcludedVertices(leafVertices);
             var allExcluded = new HashSet<ulong>();
             foreach (var item in excludedVertices)

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -267,7 +267,7 @@ namespace Elements.Spatial.AdaptiveGrid
             }
 
             //Excluded vertices includes inlets and vertices in certain distance around these inlets.
-            //Sometimes it's not wanted for routing to go through them.
+            //Sometimes it's not desired for routing to go through them.
             var excludedVertices = ExcludedVertices(leafVertices);
             var allExcluded = new HashSet<ulong>();
             foreach (var item in excludedVertices)
@@ -289,7 +289,7 @@ namespace Elements.Spatial.AdaptiveGrid
             var defaultHints = hintGroups.SingleOrDefault(hg => hg.Key == false);
             var hintVertices = NearbyVertices(userHints, leafVertices);
             var offsetVertices = NearbyVertices(defaultHints, leafVertices);
-            //Hint lines can go even through excluded vertices
+            //Hint lines can even go through excluded vertices
             allExcluded.ExceptWith(hintVertices.Select(hv => hv.Id));
 
             //1. Connect tail points, starting from exit point.
@@ -722,7 +722,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// </summary>
         /// <param name="leafVertices">Vertices to connect into the system with extra information attached.</param>
         /// <param name="exits">Possible exit vertices.</param>
-        /// <param name="hintLines">Collection of lines that routes are attracted to. At least one hint line is required.</param>
+        /// <param name="hintLines">Collection of lines that routes are attracted to.</param>
         /// <returns>Travel routes from inputVertices to the last of tailVertices.</returns>
         public IDictionary<ulong, ulong?> BuildSimpleNetwork(
             IList<RoutingVertex> leafVertices,
@@ -730,7 +730,7 @@ namespace Elements.Spatial.AdaptiveGrid
             IEnumerable<RoutingHintLine> hintLines)
         {
             //Excluded vertices includes inlets and vertices in certain distance around these inlets.
-            //Sometimes it's not wanted for routing to go through them.
+            //Sometimes it's not desired for routing to go through them.
             var excludedVertices = ExcludedVertices(leafVertices);
             var allExcluded = new HashSet<ulong>();
             foreach (var item in excludedVertices)
@@ -755,8 +755,7 @@ namespace Elements.Spatial.AdaptiveGrid
             var userHints = hintGroups.SingleOrDefault(hg => hg.Key == true);
             var defaultHints = hintGroups.SingleOrDefault(hg => hg.Key == false);
             var hintVertices = NearbyVertices(userHints, leafVertices);
-            var offsetVertices = NearbyVertices(defaultHints, leafVertices);
-            //Hint lines can go even through excluded vertices
+            //Hint lines can even go through excluded vertices
             allExcluded.ExceptWith(hintVertices.Select(hv => hv.Id));
 
 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -261,6 +261,11 @@ namespace Elements.Spatial.AdaptiveGrid
             IList<RoutingVertex> leafVertices,
             IList<ulong> trunkPathVertices, IEnumerable<RoutingHintLine> hintLines)
         {
+            if (!hintLines.Any())
+            {
+                throw new ArgumentException("At least one hint line is required to guide the tree");
+            }
+
             //Excluded vertices includes inlets and vertices in certain distance around these inlets.
             //Sometimes it's not wanted for routing to go through them.
             var excludedVertices = ExcludedVertices(leafVertices);
@@ -470,11 +475,16 @@ namespace Elements.Spatial.AdaptiveGrid
             IList<List<RoutingVertex>> leafVertices, IList<ulong> localTails,
             IList<ulong> trunkPathVertices, IList<List<RoutingHintLine>> hintLines)
         {
+            if (!hintLines.Any() || hintLines.Any(hl => hl == null || !hl.Any()))
+            {
+                throw new ArgumentException("At least one hint line in each group is required to guide the tree");
+            }
+
             var allLeafs = leafVertices.SelectMany(l => l).ToList();
             var allHints = hintLines.SelectMany(h => h).ToList();
 
             //Excluded vertices includes inlets and vertices in certain around inlets
-            //Sometimes it's not wanted for routing to go through them.
+            //Sometimes it's not desirable for routing to go through them.
             var excludedVertices = ExcludedVertices(allLeafs);
             var allExcluded = new HashSet<ulong>();
             foreach (var item in excludedVertices)
@@ -485,7 +495,7 @@ namespace Elements.Spatial.AdaptiveGrid
             var weights = CalculateWeights(allHints, allLeafs);
             var allUserHints = allHints.Where(h => h.UserDefined == true).ToList();
             var nearbyHints = NearbyVertices(allUserHints, allLeafs);
-            //Hint lines can go even through excluded vertices
+            //Hint lines can even go through excluded vertices
             allExcluded.ExceptWith(nearbyHints.Select(nh => nh.Id));
 
             var vertexTree = new Dictionary<ulong, ulong?>();

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -325,13 +325,13 @@ namespace Elements.Spatial.AdaptiveGrid
 
         /// <summary>
         /// Create connected chain of vertices. If chain intersects itself - intersection vertices are created as well.
-        /// New vertices are not connected with other vertices, except the case then one or more added vertices already exist in the grid.
+        /// New vertices are not connected with other vertices, except in the case then one or more added vertices already exist in the grid.
         /// </summary>
-        /// <param name="points">List of point to connect by edges. Must have at least two points.</param>
+        /// <param name="points">List of points to connect by edges. Must have at least two points.</param>
         /// <returns>New vertices in order. Vertices at intersection points are presented more than once.</returns>
         public List<Vertex> AddVertexStrip(IList<Vector3> points)
         {
-            if(points.Count < 2)
+            if (points.Count < 2)
             {
                 throw new ArgumentException("At least two points required");
             }

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -76,7 +76,16 @@ namespace Elements.Spatial.AdaptiveGrid
         #region Constructors
 
         /// <summary>
-        /// Create an AdaptiveGrid.
+        /// Create default AdaptiveGrid
+        /// </summary>
+        /// <returns></returns>
+        public AdaptiveGrid()
+        {
+            Transform = new Transform();
+        }
+
+        /// <summary>
+        /// Create an AdaptiveGrid with custom transformation.
         /// </summary>
         /// <param name="transform">Transformation, grid is aligned with.</param>
         /// <returns></returns>
@@ -212,7 +221,7 @@ namespace Elements.Spatial.AdaptiveGrid
                 }
                 else
                 {
-                    var edgeLine = edge.GetGeometry();
+                    var edgeLine = GetLine(edge);
                     List<Vector3> intersections;
                     edgeLine.Intersects(box, out intersections);
                     // If no intersection found than outside point is exactly within tolerance.
@@ -241,7 +250,7 @@ namespace Elements.Spatial.AdaptiveGrid
 
             foreach (var e in edgesToDelete)
             {
-                DeleteEdge(e);
+                RemoveEdge(e);
             }
         }
 
@@ -298,7 +307,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <param name="point">Position of required Vertex.</param>
         /// <param name="connections">Ids of other vertices to connect new Vertex with.</param>
         /// <returns>New Vertex or existing one if it's within grid tolerance.</returns>
-        public Vertex AddVertex(Vector3 point, List<Vertex> connections)
+        public Vertex AddVertex(Vector3 point, IList<Vertex> connections)
         {
             if (connections == null || !connections.Any())
             {
@@ -314,55 +323,126 @@ namespace Elements.Spatial.AdaptiveGrid
             return v;
         }
 
-        #endregion
-
-        #region Private logic
-
         /// <summary>
-        /// Add a Vertex or return existing one if it's withing grid tolerance.
-        /// Doesn't connect new Vertex to the grid with edges.
+        /// Create connected chain of vertices. If chain intersects itself - intersection vertices are created as well.
+        /// New vertices are not connected with other vertices, except the case then one or more added vertices already exist in the grid.
         /// </summary>
-        /// <param name="point">Position of required vertex</param>
-        /// <returns>New or existing Vertex.</returns>
-        private Vertex AddVertex(Vector3 point)
+        /// <param name="points">List of point to connect by edges. Must have at least two points.</param>
+        /// <returns>New vertices in order. Vertices at intersection points are presented more than once.</returns>
+        public List<Vertex> AddVertexStrip(IList<Vector3> points)
         {
-            if (!TryGetVertexIndex(point, out var id, Tolerance))
+            if(points.Count < 2)
             {
-                var zDict = GetAddressParent(_verticesLookup, point, true, Tolerance);
-                id = this._vertexId;
-                var vertex = new Vertex(this, id, point);
-                zDict[point.Z] = id;
-                _vertices[id] = vertex;
-                this._vertexId++;
+                throw new ArgumentException("At least two points required");
             }
 
-            return GetVertex(id);
+            var vertices = new List<Vertex>();
+            vertices.Add(AddVertex(points[0]));
+            for (int i = 1; i < points.Count; i++)
+            {
+                var tailVertex = AddVertex(points[i], new List<Vertex> { vertices.Last() });
+
+                for (int j = 0; j < vertices.Count - 1; j++)
+                {
+                    if (Line.Intersects(vertices.Last().Point, tailVertex.Point,
+                                        vertices[j].Point, vertices[j + 1].Point,
+                                        out var intersection))
+                    {
+                        var cross = AddVertex(intersection, new List<Vertex> {
+                            tailVertex, vertices.Last(),  vertices[j], vertices[j + 1] });
+                        RemoveEdge(tailVertex.GetEdge(vertices.Last().Id));
+                        RemoveEdge(vertices[j].GetEdge(vertices[j + 1].Id));
+                        vertices.Insert(j + 1, cross);
+                        vertices.Add(cross);
+                        j++;
+                    }
+                }
+                vertices.Add(tailVertex);
+            }
+            return vertices;
         }
 
         /// <summary>
-        /// Remove the Vertex with specified id from the grid.
+        /// Split provided edge by given point. Edge is removed and replaced by two new edges.
+        /// New vertex position is not required to be in the edge line.
         /// </summary>
-        /// <param name="id">Vertex id to delete.</param>
-        private void DeleteVertex(ulong id)
+        /// <param name="edge">Edge to cut.</param>
+        /// <param name="position">Cut position where new Vertex is created.</param>
+        /// <returns>New Vertex at cut position.</returns>
+        public Vertex CutEdge(Edge edge, Vector3 position)
         {
-            var vertex = _vertices[id];
-            _vertices.Remove(id);
-            var zDict = GetAddressParent(_verticesLookup, vertex.Point, tolerance: Tolerance);
-            if (zDict == null)
-            {
-                return;
-            }
-            zDict.Remove(vertex.Point.Z);
+            var startVertex = GetVertex(edge.StartId);
+            var endVertex = GetVertex(edge.EndId);
+            var newVertex = AddVertex(position, new List<Vertex> { startVertex, endVertex });
+            RemoveEdge(edge);
+            return newVertex;
+        }
 
-            TryGetValue(_verticesLookup, vertex.Point.X, out var yzDict, Tolerance);
-            if (zDict.Count == 0)
+        /// <summary>
+        /// Get associated Vertices.
+        /// </summary>
+        /// <returns></returns>
+        public List<Vertex> GetVertices(Edge edge)
+        {
+            return new List<Vertex>() { GetVertex(edge.StartId), GetVertex(edge.EndId) };
+        }
+
+        /// <summary>
+        /// Get the geometry that represents this Edge or DirectedEdge.
+        /// </summary>
+        /// <returns></returns>
+        public Line GetLine(Edge edge)
+        {
+            return new Line(GetVertex(edge.StartId).Point, GetVertex(edge.EndId).Point);
+        }
+
+        /// <summary>
+        /// Find closest Vertex on the grid to given location.
+        /// If several vertices are no the same closest distance - first found is returned.
+        /// </summary>
+        /// <param name="location">Position to which closest Vertex is searched.</param>
+        /// <returns>Closest Vertex</returns>
+        public Vertex ClosestVertex(Vector3 location)
+        {
+            double lowestDist = double.MaxValue;
+            Vertex closest = null;
+            foreach (var v in GetVertices())
             {
-                yzDict.Remove(vertex.Point.Y);
+                double dist = v.Point.DistanceTo(location);
+                if (dist < lowestDist)
+                {
+                    lowestDist = dist;
+                    closest = v;
+                }
             }
-            if (yzDict.Count == 0)
+            return closest;
+        }
+
+        /// <summary>
+        /// Find closest Edge on the grid to given location.
+        /// If several edges are no the same closest distance - first found is returned.
+        /// </summary>
+        /// <param name="location">Position to which closest Vertex is searched.</param>
+        /// <param name="point">Closest point of the found edge line.</param>
+        /// <returns>Closest Edge</returns>
+        public Edge ClosestEdge(Vector3 location, out Vector3 point)
+        {
+            double lowestDist = double.MaxValue;
+            Edge closestEdge = null;
+            point = Vector3.Origin;
+            foreach (var e in GetEdges())
             {
-                _verticesLookup.Remove(vertex.Point.X);
+                var start = GetVertex(e.StartId);
+                var end = GetVertex(e.EndId);
+                double dist = location.DistanceTo((start.Point, end.Point), out var closest);
+                if (dist < lowestDist)
+                {
+                    lowestDist = dist;
+                    closestEdge = e;
+                    point = closest;
+                }
             }
+            return closestEdge;
         }
 
         /// <summary>
@@ -371,7 +451,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <param name="vertexId1">Index of the first Vertex</param>
         /// <param name="vertexId2">Index of the second Vertex</param>
         /// <returns>New or existing Edge.</returns>
-        private Edge AddEdge(ulong vertexId1, ulong vertexId2)
+        public Edge AddEdge(ulong vertexId1, ulong vertexId2)
         {
             if (vertexId1 == vertexId2)
             {
@@ -402,10 +482,32 @@ namespace Elements.Spatial.AdaptiveGrid
         }
 
         /// <summary>
+        /// Remove the Vertex from the grid.
+        /// All it's edges are removed as well, including any neighbor
+        /// vertices that are left without edges.
+        /// </summary>
+        /// <param name="v">Vertex to delete.</param>
+        public void RemoveVertex(Vertex v)
+        {
+            //If there are no edges - delete the vertex manually.
+            if (!v.Edges.Any())
+            {
+                DeleteVertex(v.Id);
+                return;
+            }
+
+            //Otherwise, edges will remove it's orphan vertices.
+            foreach (var edge in v.Edges.ToList())
+            {
+                RemoveEdge(edge);
+            }
+        }
+
+        /// <summary>
         /// Remove the Edge from the grid.
         /// </summary>
         /// <param name="edge">Edge to delete</param>
-        private void DeleteEdge(Edge edge)
+        public void RemoveEdge(Edge edge)
         {
             var hash = Edge.GetHash(new List<ulong> { edge.StartId, edge.EndId });
             this._edgesLookup.Remove(hash);
@@ -422,6 +524,53 @@ namespace Elements.Spatial.AdaptiveGrid
             if (!endVertexEdges.Any())
             {
                 DeleteVertex(edge.EndId);
+            }
+        }
+
+        #endregion
+
+        #region Private logic
+
+        /// <summary>
+        /// Add a Vertex or return existing one if it's withing grid tolerance.
+        /// Doesn't connect new Vertex to the grid with edges.
+        /// </summary>
+        /// <param name="point">Position of required vertex</param>
+        /// <returns>New or existing Vertex.</returns>
+        private Vertex AddVertex(Vector3 point)
+        {
+            if (!TryGetVertexIndex(point, out var id, Tolerance))
+            {
+                var zDict = GetAddressParent(_verticesLookup, point, true, Tolerance);
+                id = this._vertexId;
+                var vertex = new Vertex(id, point);
+                zDict[point.Z] = id;
+                _vertices[id] = vertex;
+                this._vertexId++;
+            }
+
+            return GetVertex(id);
+        }
+
+        private void DeleteVertex(ulong id)
+        {
+            var vertex = _vertices[id];
+            _vertices.Remove(id);
+            var zDict = GetAddressParent(_verticesLookup, vertex.Point, tolerance: Tolerance);
+            if (zDict == null)
+            {
+                return;
+            }
+            zDict.Remove(vertex.Point.Z);
+
+            TryGetValue(_verticesLookup, vertex.Point.X, out var yzDict, Tolerance);
+            if (zDict.Count == 0)
+            {
+                yzDict.Remove(vertex.Point.Y);
+            }
+            if (yzDict.Count == 0)
+            {
+                _verticesLookup.Remove(vertex.Point.X);
             }
         }
 
@@ -445,7 +594,7 @@ namespace Elements.Spatial.AdaptiveGrid
             var intersectionPoints = new List<Vector3>();
             foreach (var edge in edgesToIntersect)
             {
-                if (edge.GetGeometry().Intersects(boundingPolygonPlane, out var intersectionPoint)
+                if (GetLine(edge).Intersects(boundingPolygonPlane, out var intersectionPoint)
                     && boundingPolygon.Contains(intersectionPoint))
                 {
                     intersectionPoints.Add(intersectionPoint);
@@ -501,7 +650,7 @@ namespace Elements.Spatial.AdaptiveGrid
 
         private void AddVerticalEdges(Vector3 extrusionAxis, double height, HashSet<Edge> addedEdges)
         {
-            foreach (var bottomVertex in addedEdges.SelectMany(e => e.GetVertices()).Distinct())
+            foreach (var bottomVertex in addedEdges.SelectMany(e => GetVertices(e)).Distinct())
             {
                 var heightVector = height * extrusionAxis;
                 var topVertex = AddVertex(bottomVertex.Point + heightVector);

--- a/Elements/src/Spatial/AdaptiveGrid/Edge.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/Edge.cs
@@ -23,21 +23,35 @@ namespace Elements.Spatial.AdaptiveGrid
         public ulong EndId;
 
         /// <summary>
-        /// The AdaptiveGrid that this Vertex belongs to.
-        /// </summary>
-        public AdaptiveGrid AdaptiveGrid { get; private set; }
-
-        /// <summary>
         /// ID of this child.
         /// </summary>
         public ulong Id { get; internal set; }
 
         internal Edge(AdaptiveGrid adaptiveGrid, ulong id, ulong vertexId1, ulong vertexId2)
         {
-            AdaptiveGrid = adaptiveGrid;
             Id = id;
-
             this.SetVerticesFromIds(vertexId1, vertexId2);
+        }
+
+        /// <summary>
+        /// ID of other Vertex of this Edge.
+        /// </summary>
+        /// <param name="vertexId">ID of one of edge vertices. Exception is thrown if not present.</param>
+        /// <returns></returns>
+        public ulong OtherVertexId(ulong vertexId)
+        {
+            if (vertexId == StartId)
+            {
+                return EndId;
+            }
+            else if (vertexId == EndId)
+            {
+                return StartId;
+            }
+            else
+            {
+                throw new ArgumentException("Id is not present in the edge");
+            }
         }
 
         /// <summary>
@@ -88,30 +102,6 @@ namespace Elements.Spatial.AdaptiveGrid
                 this.EndId = id1;
                 this.StartId = id2;
             }
-        }
-
-        /// <summary>
-        /// Get associated Vertices.
-        /// </summary>
-        /// <returns></returns>
-        public List<Vertex> GetVertices()
-        {
-            return new List<Vertex>() {
-                this.AdaptiveGrid.GetVertex(this.StartId),
-                this.AdaptiveGrid.GetVertex(this.EndId)
-            };
-        }
-
-        /// <summary>
-        /// Get the geometry that represents this Edge or DirectedEdge.
-        /// </summary>
-        /// <returns></returns>
-        public Line GetGeometry()
-        {
-            return new Line(
-                this.AdaptiveGrid.GetVertex(this.StartId).Point,
-                this.AdaptiveGrid.GetVertex(this.EndId).Point
-            );
         }
     }
 }

--- a/Elements/src/Spatial/AdaptiveGrid/Vertex.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/Vertex.cs
@@ -2,7 +2,7 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 
 namespace Elements.Spatial.AdaptiveGrid
 {
@@ -18,14 +18,19 @@ namespace Elements.Spatial.AdaptiveGrid
         public Vector3 Point { get; set; }
 
         /// <summary>
-        /// The AdaptiveGrid that this Vertex belongs to.
-        /// </summary>
-        public AdaptiveGrid AdaptiveGrid { get; private set; }
-
-        /// <summary>
         /// ID of this Vertex.
         /// </summary>
         public ulong Id { get; internal set; }
+
+        /// <summary>
+        /// Find edge between this Vertex and Vertex with given ID.
+        /// </summary>
+        /// <param name="otherId">Id of other vertex.</param>
+        /// <returns>Edge between this and Vertex with given ID. Null if not found.</returns>
+        public Edge GetEdge(ulong otherId)
+        {
+            return Edges.Where(e => e.StartId == otherId || e.EndId == otherId).FirstOrDefault();
+        }
 
         /// <summary>
         /// All Edges connected to this Vertex.
@@ -33,10 +38,9 @@ namespace Elements.Spatial.AdaptiveGrid
         [JsonIgnore]
         public HashSet<Edge> Edges = new HashSet<Edge>();
 
-        internal Vertex(AdaptiveGrid adaptiveGrid, ulong id, Vector3 point)
+        internal Vertex(ulong id, Vector3 point)
         {
             Id = id;
-            AdaptiveGrid = adaptiveGrid;
             Point = point;
         }
 

--- a/Elements/src/Spatial/AdaptiveGrid/Vertex.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/Vertex.cs
@@ -29,6 +29,10 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <returns>Edge between this and Vertex with given ID. Null if not found.</returns>
         public Edge GetEdge(ulong otherId)
         {
+            if (otherId == this.Id)
+            {
+                return null;
+            }
             return Edges.Where(e => e.StartId == otherId || e.EndId == otherId).FirstOrDefault();
         }
 

--- a/Elements/test/AdaptiveGraphRoutingTests.cs
+++ b/Elements/test/AdaptiveGraphRoutingTests.cs
@@ -1,0 +1,712 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+using Elements;
+using Elements.Geometry;
+using Elements.Spatial.AdaptiveGrid;
+using Xunit;
+using Elements.Serialization.glTF;
+using Vertex = Elements.Spatial.AdaptiveGrid.Vertex;
+using static Elements.Spatial.AdaptiveGrid.AdaptiveGraphRouting;
+
+namespace Elements.Tests
+{
+    public class AdaptiveGraphRoutingTests : ModelTest
+    {
+        [Fact]
+        public void AdaptiveGraphRoutingDijkstraPath()
+        {
+            Polygon region = new Polygon(new List<Vector3>()
+            {
+                new Vector3(0, 0, 0),
+                new Vector3(10, 0, 0),
+                new Vector3(10, 10, 0),
+                new Vector3(0, 10, 0)
+            });
+
+            //Split rectangle into 4 cells.
+            var keyPoints = new List<Vector3>()
+            {
+                new Vector3(5, 4, 0)
+            };
+
+            //Remove center vertex leaving only 8 perimeter vertices
+            AdaptiveGrid grid = new AdaptiveGrid();
+            grid.AddFromPolygon(region, keyPoints);
+            BBox3 obstacle = new BBox3(new Vector3(3, 3, 0), new Vector3(7, 7, 0));
+            grid.SubtractBox(obstacle);
+
+            //Each turn cost 1 additional "meter"
+            var configuration = new AdaptiveGraphRouting.RoutingConfiguration(
+                turnCost: 1, mainLayer: 0, layerPenalty: 1);
+            AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, configuration);
+            grid.TryGetVertexIndex(new Vector3(0, 4, 0), out var inV, grid.Tolerance);
+
+            //Set travel cost for each edge equal to it's length
+            var edgeCosts = new Dictionary<ulong, (double Length, double Factor)>();
+            foreach (var e in grid.GetEdges())
+            {
+                var w = (grid.GetVertex(e.StartId).Point - grid.GetVertex(e.EndId).Point).Length();
+                edgeCosts[e.Id] = (w, 1);
+            }
+
+            //Calculate all path from point (0, 4) to all other accessible points.
+            var paths = alg.ShortestPathDijkstra(inV, edgeCosts, out var travelCosts);
+
+            //Find most efficient path from (0, 4) to (10, 4)
+            grid.TryGetVertexIndex(new Vector3(10, 4, 0), out var outV, grid.Tolerance);
+            List<Vector3> expectedPath = new List<Vector3>()
+            {
+                new Vector3(0, 4, 0),
+                new Vector3(0, 0, 0),
+                new Vector3(5, 0, 0),
+                new Vector3(10, 0, 0),
+                new Vector3(10, 4, 0)
+            };
+
+            //Go from end point (10, 4) backwards 
+            var before = outV;
+            for (int i = expectedPath.Count; i > 0; i--)
+            {
+                Assert.Equal(grid.GetVertex(before).Point, expectedPath[i - 1]);
+                before = paths[before];
+            }
+            //After reaching start point before is pointing to 0 (nothing)
+            Assert.True(before == 0);
+            //Total cost is 4 + 5 + 5 + 4 + 1*2(two turns).
+            Assert.Equal(20, travelCosts[outV]);
+
+            //Find most efficient path from (0, 4) to (5, 10)
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 10, 0), out outV, grid.Tolerance));
+            expectedPath = new List<Vector3>()
+            {
+                new Vector3(0, 4, 0),
+                new Vector3(0, 10, 0),
+                new Vector3(5, 10, 0)
+            };
+
+            before = outV;
+            for (int i = expectedPath.Count; i > 0; i--)
+            {
+                Assert.Equal(grid.GetVertex(before).Point, expectedPath[i - 1]);
+                before = paths[before];
+            }
+            Assert.True(before == 0);
+            //Total cost is 6 + 5 + 1(turn).
+            Assert.Equal(12, travelCosts[outV]);
+        }
+
+        [Fact]
+        public void AdaptiveGraphRoutingDijkstraBranches()
+        {
+            Polygon region = new Polygon(new List<Vector3>()
+            {
+                new Vector3(0, 0, 0),
+                new Vector3(10, 0, 0),
+                new Vector3(10, 3, 0),
+                new Vector3(0, 3, 0)
+            });
+
+            var keyPoints = new List<Vector3>()
+            {
+                new Vector3(2, 1, 0),
+                new Vector3(5, 1, 0),
+                new Vector3(8, 2, 0)
+            };
+
+            AdaptiveGrid grid = new AdaptiveGrid();
+            grid.AddFromPolygon(region, keyPoints);
+
+            var configuration = new RoutingConfiguration(
+                turnCost: 1, mainLayer: 0, layerPenalty: 1);
+            AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, configuration);
+
+            Assert.True(grid.TryGetVertexIndex(new Vector3(2, 2, 0), out var inV, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 2, 0), out var ev0, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(8, 2, 0), out var ev1, grid.Tolerance));
+
+            var edgeCosts = new Dictionary<ulong, (double Length, double Factor)>();
+
+            foreach (var e in grid.GetEdges())
+            {
+                //Set travel cost for each edge equal to it's length.
+                //Except (5, 2) -> (8, 2) for which it's 0.9 of length.
+                var w = (grid.GetVertex(e.StartId).Point - grid.GetVertex(e.EndId).Point).Length();
+                bool startMatch = e.StartId == ev0 || e.StartId == ev1;
+                bool endMatch = e.EndId == ev0 || e.EndId == ev1;
+                var factor = startMatch && endMatch ? 0.9 : 1;
+                edgeCosts[e.Id] = (w, factor);
+            }
+
+            Assert.True(grid.TryGetVertexIndex(new Vector3(2, 3, 0), out var preV, grid.Tolerance));
+            var paths = alg.ShortestBranchesDijkstra(inV, edgeCosts, out var travelCosts, preV);
+
+            //Two paths calculated for (2, 3)->(8, 1) to approach end point from different edges.
+            Assert.True(grid.TryGetVertexIndex(new Vector3(8, 1, 0), out var outV, grid.Tolerance));
+            List<Vector3> expectedLeft = new List<Vector3>()
+            {
+                new Vector3(2, 2, 0),
+                new Vector3(2, 1, 0),
+                new Vector3(5, 1, 0),
+                new Vector3(8, 1, 0),
+            };
+
+            //Go from end point (10, 4) backwards. At each point there are two items: best routes.
+            //They are accompanied with links that says how recursively travel deeper.
+            var before = paths[outV];
+            var leftBranch = before.Item1;
+            for (int i = expectedLeft.Count - 1; i > 0; i--)
+            {
+                Assert.Equal(grid.GetVertex(leftBranch.Item1).Point, expectedLeft[i - 1]);
+                before = paths[leftBranch.Item1];
+                leftBranch = leftBranch.Item2 == BranchSide.Left ? before.Item1 : before.Item2;
+            }
+            Assert.True(leftBranch.Item1 == 0);
+            //Total cost is 1 + 3 + 3 + 1(turn).
+            Assert.Equal(8, travelCosts[outV].Item1);
+
+            List<Vector3> expectedRight = new List<Vector3>()
+            {
+                new Vector3(2, 2, 0),
+                new Vector3(5, 2, 0),
+                new Vector3(8, 2, 0),
+                new Vector3(8, 1, 0),
+            };
+
+            before = paths[outV];
+            var rightBranch = before.Item2;
+            for (int i = expectedRight.Count - 1; i > 0; i--)
+            {
+                Assert.Equal(grid.GetVertex(rightBranch.Item1).Point, expectedRight[i - 1]);
+                before = paths[rightBranch.Item1];
+                rightBranch = rightBranch.Item2 == BranchSide.Left ? before.Item1 : before.Item2;
+            }
+            Assert.True(rightBranch.Item1 == 0);
+            //Total cost is 3 + 2.7 + 1 + 0.9(aligned turn is also discounted).
+            Assert.Equal(8.6, travelCosts[outV].Item2);
+        }
+
+        [Fact]
+        public void AdaptiveGraphRoutingGeneralTest()
+        {
+            Polygon mainRegionBoundary = new Polygon(new List<Vector3>()
+            {
+                new Vector3(0, 0, 1),
+                new Vector3(10, 0, 1),
+                new Vector3(10, 10, 1),
+                new Vector3(0, 10, 1)
+            });
+
+            Polygon auxilaryRegionBoundary = new Polygon(new List<Vector3>()
+            {
+                new Vector3(0, 10, 0),
+                new Vector3(10, 10, 0),
+                new Vector3(10, 10, 3),
+                new Vector3(0, 10, 3)
+            });
+
+            var configuration = new RoutingConfiguration(
+                turnCost: 1, mainLayer: 2, layerPenalty: 2);
+
+            var inputPoints = new List<Vector3>()
+            {
+                new Vector3(5, 2, 3),
+                new Vector3(5, 5, 3),
+                new Vector3(5, 8, 3)
+            };
+
+            var tailPoints = new List<Vector3>()
+            {
+                new Vector3(5, 10, 0),
+                new Vector3(5, 10, 2),
+                new Vector3(6, 10, 2)
+            };
+
+            var keyPoints = new List<Vector3>();
+            keyPoints.AddRange(inputPoints);
+            keyPoints.AddRange(tailPoints);
+
+            var hintPolyline = new Polyline(new List<Vector3>()
+            {
+                new Vector3(6, 6),
+                new Vector3(3, 6),
+                new Vector3(3, 7),
+                new Vector3(6, 7),
+
+            });
+            keyPoints.AddRange(hintPolyline.Vertices.Select(
+                v => new Vector3(v.X, v.Y, configuration.MainLayer)));
+
+            var offsetPolyline = new Polyline(new List<Vector3>()
+            {
+                new Vector3(6, 2),
+                new Vector3(6, 10)
+            });
+            keyPoints.AddRange(offsetPolyline.Vertices.Select(
+                v => new Vector3(v.X, v.Y, configuration.MainLayer)));
+
+            var hints = new List<RoutingHintLine>();
+            hints.Add(new RoutingHintLine(hintPolyline, 0.1, 0.2, true));
+            hints.Add(new RoutingHintLine(offsetPolyline, 0.5, 0.1, false));
+
+            BBox3 obstacle = new BBox3(new Vector3(3, 6, 0), new Vector3(7, 7, 3));
+            keyPoints.AddRange(obstacle.Corners());
+
+            AdaptiveGrid grid = new AdaptiveGrid();
+            grid.AddFromExtrude(mainRegionBoundary, Vector3.ZAxis, 1, keyPoints);
+            grid.AddFromPolygon(auxilaryRegionBoundary, keyPoints);
+            foreach (var input in inputPoints)
+            {
+                var p = new Vector3(input.X, input.Y, configuration.MainLayer);
+                Assert.True(grid.TryGetVertexIndex(p, out ulong down, grid.Tolerance));
+                grid.AddVertex(input, new List<Vertex> { grid.GetVertex(down) });
+            }
+            grid.SubtractBox(obstacle);
+
+            var inputVertices = new List<RoutingVertex>();
+            foreach (var input in inputPoints)
+            {
+                Assert.True(grid.TryGetVertexIndex(input, out ulong id, grid.Tolerance));
+                {
+                    inputVertices.Add(new RoutingVertex(id, 0.5));
+                }
+            }
+            List<ulong> tailVertices = new List<ulong>();
+            foreach (var tail in tailPoints)
+            {
+                Assert.True(grid.TryGetVertexIndex(tail, out ulong id, grid.Tolerance));
+                {
+                    tailVertices.Add(id);
+                }
+            }
+
+            AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, configuration);
+            var tree = alg.BuildSpanningTree(inputVertices, tailVertices, hints);
+
+            List<Vector3> expectedPath = new List<Vector3>()
+            {
+                new Vector3(5, 8, 3),
+                new Vector3(5, 8, 2),
+                new Vector3(5, 7, 2),
+                new Vector3(6, 7, 2),
+                new Vector3(6, 8, 2),
+                new Vector3(6, 10, 2),
+                new Vector3(5, 10, 2),
+                new Vector3(5, 10, 1),
+                new Vector3(5, 10, 0)
+            };
+
+            CheckTree(grid, inputVertices[2].Id, tree, expectedPath);
+
+            expectedPath = new List<Vector3>()
+            {
+                new Vector3(5, 2, 3),
+                new Vector3(5, 2, 2),
+                new Vector3(6, 2, 2),
+                new Vector3(6, 5, 2),
+                new Vector3(6, 6, 2),
+                new Vector3(5, 6, 2),
+                new Vector3(3, 6, 2),
+                new Vector3(3, 7, 2),
+                new Vector3(5, 7, 2),
+                new Vector3(6, 7, 2),
+                new Vector3(6, 8, 2),
+                new Vector3(6, 10, 2),
+                new Vector3(5, 10, 2),
+                new Vector3(5, 10, 1),
+                new Vector3(5, 10, 0),
+            };
+
+            CheckTree(grid, inputVertices[0].Id, tree, expectedPath);
+        }
+
+        [Fact]
+        public void AdaptiveGraphRoutingSimpleTreeExample()
+        {
+            this.Name = "Adaptive_Graph_Routing_Simple";
+            //1. Define boundaries of the grid. 
+            Polygon boundary = new Polygon(new List<Vector3>()
+            {
+                new Vector3(0, 0, 0),
+                new Vector3(20, 0, 0),
+                new Vector3(20, 25, 0),
+                new Vector3(0, 25, 0)
+            });
+
+            //2. Define start points.
+            var inputPoints = new List<Vector3>()
+            {
+                new Vector3(2, 5, 0),
+                new Vector3(2, 10, 0),
+                new Vector3(8, 15, 0),
+                new Vector3(12, 5, 0),
+                new Vector3(9, 8, 0),
+                new Vector3(11, 12, 0),
+            };
+
+            //3. Define end points. Last should go first.
+            var tailPoints = new List<Vector3>()
+            {
+                new Vector3(12, 20, 0),
+                new Vector3(10, 20, 0)
+            };
+
+            //4. All significant points must be added as key points.
+            var keyPoints = new List<Vector3>();
+            keyPoints.AddRange(inputPoints);
+            keyPoints.AddRange(tailPoints);
+
+            //5. Define hint and offset lines.
+            var firstOffsetPolyline = new Polyline(new List<Vector3>(){
+                new Vector3(5, 2),
+                new Vector3(5, 20)
+            });
+            keyPoints.AddRange(firstOffsetPolyline.Vertices);
+
+            var secondOffsetPolyline = new Polyline(new List<Vector3>()
+            {
+                new Vector3(15, 2),
+                new Vector3(15, 20)
+            });
+            keyPoints.AddRange(secondOffsetPolyline.Vertices);
+
+            var hintPolyline = new Polyline(new List<Vector3>()
+            {
+                new Vector3(5, 17),
+                new Vector3(15, 17),
+
+            });
+            keyPoints.AddRange(hintPolyline.Vertices);
+
+            //6. Define obstacles.
+            BBox3 obstacle = new BBox3(new Vector3(11, 14, 0), new Vector3(17, 18, 0));
+            keyPoints.AddRange(obstacle.Corners());
+
+            //7. Create grid.
+            AdaptiveGrid grid = new AdaptiveGrid();
+            grid.AddFromPolygon(boundary, keyPoints);
+            grid.SubtractBox(obstacle);
+
+            //8. Get indices's for start and end vertices
+            var inputVertices = new List<RoutingVertex>();
+            foreach (var input in inputPoints)
+            {
+                Assert.True(grid.TryGetVertexIndex(input, out ulong id, grid.Tolerance));
+                {
+                    inputVertices.Add(new RoutingVertex(id, 0.5));
+                }
+            }
+
+            List<ulong> tailVertices = new List<ulong>();
+            foreach (var tail in tailPoints)
+            {
+                Assert.True(grid.TryGetVertexIndex(tail, out ulong id, grid.Tolerance));
+                {
+                    tailVertices.Add(id);
+                }
+            }
+
+            //9. Set configurations for hint and offset lines.
+            var hint = new RoutingHintLine(hintPolyline, 0.01, 0.1, true);
+            var offset1 = new RoutingHintLine(firstOffsetPolyline, 0.9, 0.1, false);
+            var offset2 = new RoutingHintLine(secondOffsetPolyline, 0.9, 0.1, false);
+            var hints = new List<RoutingHintLine> { hint, offset1, offset2 };
+
+            //10. Run algorithm
+            var config = new RoutingConfiguration(turnCost: 1, mainLayer: 0, layerPenalty: 1);
+            AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, config);
+            var tree = alg.BuildSpanningTree(inputVertices, tailVertices, hints);
+
+            //Results visualization
+            List<Line> lines = new List<Line>();
+            foreach (var input in inputVertices)
+            {
+                var v0 = input.Id;
+                var v1 = tree[v0];
+                while (v1.HasValue && v1 != 0)
+                {
+                    lines.Add(new Line(grid.GetVertex(v0).Point, grid.GetVertex(v1.Value).Point));
+                    v0 = v1.Value;
+                    v1 = tree[v0];
+                }
+            }
+            ModelLines ml = new ModelLines(lines, new Material("", new Color("red")));
+            this.Model.AddElements(alg.RenderElements(hints, keyPoints));
+            this.Model.AddElement(ml);
+        }
+
+        [Fact]
+        public void AdaptiveGraphRoutingGroupedTreeExample()
+        {
+            this.Name = "Adaptive_Graph_Routing_Groups";
+            //1. Define boundaries of the grid. 
+            Polygon boundary = new Polygon(new List<Vector3>()
+            {
+                new Vector3(0, 0, 0),
+                new Vector3(20, 0, 0),
+                new Vector3(20, 25, 0),
+                new Vector3(0, 25, 0)
+            });
+
+            //2. Define start points.
+            var inputPoints = new List<Vector3>()
+            {
+                new Vector3(2, 5, 0),
+                new Vector3(2, 10, 0),
+                new Vector3(8, 15, 0),
+                new Vector3(12, 5, 0),
+                new Vector3(9, 8, 0),
+                new Vector3(11, 12, 0),
+            };
+
+            //3. Define end points. Last should go first.
+            var tailPoints = new List<Vector3>()
+            {
+                new Vector3(12, 20, 0),
+                new Vector3(10, 20, 0)
+            };
+
+            //3a. Define local tail points, one per group
+            var localTailPoints = new List<Vector3>()
+            {
+                new Vector3(5, 16, 0),
+                new Vector3(15, 13, 0)
+            };
+
+            //4. All significant points must be added as key points.
+            var keyPoints = new List<Vector3>();
+            keyPoints.AddRange(inputPoints);
+            keyPoints.AddRange(localTailPoints);
+            keyPoints.AddRange(tailPoints);
+
+            //5. Define hint and offset lines.
+            var firstOffsetPolyline = new Polyline(new List<Vector3>(){
+                new Vector3(5, 2),
+                new Vector3(5, 20)
+            });
+            keyPoints.AddRange(firstOffsetPolyline.Vertices);
+
+            var secondOffsetPolyline = new Polyline(new List<Vector3>()
+            {
+                new Vector3(15, 2),
+                new Vector3(15, 20)
+            });
+            keyPoints.AddRange(secondOffsetPolyline.Vertices);
+
+            var hintPolyline = new Polyline(new List<Vector3>()
+            {
+                new Vector3(5, 17),
+                new Vector3(15, 17),
+
+            });
+            keyPoints.AddRange(hintPolyline.Vertices);
+
+            //6. Define obstacles.
+            BBox3 obstacle = new BBox3(new Vector3(11, 14, 0), new Vector3(17, 18, 0));
+            keyPoints.AddRange(obstacle.Corners());
+
+            //7. Create grid.
+            AdaptiveGrid grid = new AdaptiveGrid();
+            grid.AddFromPolygon(boundary, keyPoints);
+            grid.SubtractBox(obstacle);
+
+            //8. Get indices's for start, end vertices, local tail vertices.
+            //Split input vertices into groups.
+            var inputVertices = new List<List<RoutingVertex>>();
+            inputVertices.Add(new List<RoutingVertex>());
+            foreach (var input in inputPoints.Take(3))
+            {
+                Assert.True(grid.TryGetVertexIndex(input, out ulong id, grid.Tolerance));
+                {
+                    inputVertices[0].Add(new RoutingVertex(id, 0.5));
+                }
+            }
+            inputVertices.Add(new List<RoutingVertex>());
+            foreach (var input in inputPoints.Skip(3))
+            {
+                Assert.True(grid.TryGetVertexIndex(input, out ulong id, grid.Tolerance));
+                {
+                    inputVertices[1].Add(new RoutingVertex(id, 0.5));
+                }
+            }
+
+            List<ulong> localTailVertices = new List<ulong>();
+            foreach (var tail in localTailPoints)
+            {
+                Assert.True(grid.TryGetVertexIndex(tail, out ulong id, grid.Tolerance));
+                {
+                    localTailVertices.Add(id);
+                }
+            }
+
+            List<ulong> tailVertices = new List<ulong>();
+            foreach (var tail in tailPoints)
+            {
+                Assert.True(grid.TryGetVertexIndex(tail, out ulong id, grid.Tolerance));
+                {
+                    tailVertices.Add(id);
+                }
+            }
+
+            //9. Set configurations for hint and offset lines. Split them into groups.
+            var hint = new RoutingHintLine(hintPolyline, 0.01, 0.1, true);
+            var offset1 = new RoutingHintLine(firstOffsetPolyline, 0.9, 0.1, false);
+            var offset2 = new RoutingHintLine(secondOffsetPolyline, 0.9, 0.1, false);
+            var hints = new List<List<RoutingHintLine>>
+            {
+                new List<RoutingHintLine>{ hint, offset1},
+                new List<RoutingHintLine>{ hint, offset2}
+            };
+
+            //10. Run algorithm
+            var config = new RoutingConfiguration(turnCost: 1, mainLayer: 0, layerPenalty: 1);
+            AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, config);
+            var tree = alg.BuildSpanningTree(inputVertices, localTailVertices, tailVertices, hints);
+
+            //Result visualization
+            List<Line> lines = new List<Line>();
+            foreach (var input in inputVertices.SelectMany(iv => iv))
+            {
+                var v0 = input.Id;
+                var v1 = tree[v0];
+                while (v1.HasValue && v1 != 0)
+                {
+                    lines.Add(new Line(grid.GetVertex(v0).Point, grid.GetVertex(v1.Value).Point));
+                    v0 = v1.Value;
+                    v1 = tree[v0];
+                }
+            }
+            ModelLines ml = new ModelLines(lines, new Material("", new Color("red")));
+            this.Model.AddElements(alg.RenderElements(hints.SelectMany(h => h).ToList(), keyPoints));
+            this.Model.AddElement(ml);
+        }
+
+        [Fact]
+        public void AdaptiveGridRoutingSimpleNetwork()
+        {
+            this.Name = "Adaptive_Grid_Routing_Simple_Network";
+
+            //1. Define grid skeleton.
+            //Intersections are not done automatically so lines are aligned manually.
+            var c1 = new List<Vector3> {
+                new Vector3(2, 2, 0),
+                new Vector3(4, 2, 0),
+                new Vector3(8, 2, 0),
+                new Vector3(8, 5, 0),
+                new Vector3(8, 8, 0),
+                new Vector3(6, 8, 0),
+                new Vector3(2, 8, 0),
+                new Vector3(2, 5, 0),
+                new Vector3(2, 2, 0),
+            };
+            var c2 = new List<Vector3> {
+                new Vector3(4, 0, 0),
+                new Vector3(4, 2, 0),
+            };
+            var c3 = new List<Vector3> {
+                new Vector3(6, 8, 0),
+                new Vector3(6, 10, 0),
+            };
+            var c4 = new List<Vector3> {
+                new Vector3(0, 5, 0),
+                new Vector3(2, 5, 0),
+            };
+            var c5 = new List<Vector3> {
+                new Vector3(8, 5, 0),
+                new Vector3(10, 5, 0),
+            };
+
+            //2. Create grid for vertex strips.
+            AdaptiveGrid grid = new AdaptiveGrid();
+            var corridors = new List<List<Vector3>> { c1, c2, c3, c4, c5 };
+            foreach (var c in corridors)
+            {
+                grid.AddVertexStrip(c);
+            }
+
+            //3. Define input vertices.
+            var inputPoints = new List<Vector3>()
+            {
+                new Vector3(4, 0, 0),
+                new Vector3(6, 10, 0)
+            };
+
+            var inputVertices = new List<RoutingVertex>();
+            foreach (var input in inputPoints)
+            {
+                Assert.True(grid.TryGetVertexIndex(input, out ulong id, grid.Tolerance));
+                {
+                    inputVertices.Add(new RoutingVertex(id, 0));
+                }
+            }
+
+            //4. Define exit vertices
+            grid.TryGetVertexIndex(new Vector3(0, 5, 0), out var id1);
+            grid.TryGetVertexIndex(new Vector3(10, 5, 0), out var id2);
+            var exits = new List<ulong> { id1, id2 };
+
+            //5. Run routing without hint lines.
+            var config = new RoutingConfiguration(turnCost: 1, mainLayer: 0, layerPenalty: 1);
+            AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, config);
+            var tree = alg.BuildSimpleNetwork(inputVertices, exits, new List<RoutingHintLine>());
+
+            List<Vector3> expectedPath = new List<Vector3>()
+            {
+                new Vector3(4, 0, 0),
+                new Vector3(4, 2, 0),
+                new Vector3(2, 2, 0),
+                new Vector3(2, 5, 0),
+                new Vector3(0, 5, 0)
+            };
+
+            //Go from input vertex (4, 0) to closest exit vertex (0, 5).
+            CheckTree(grid, inputVertices[0].Id, tree, expectedPath);
+
+            //Find most efficient path from (0, 4) 
+            expectedPath = new List<Vector3>()
+            {
+                new Vector3(6, 10, 0),
+                new Vector3(6, 8, 0),
+                new Vector3(8, 8, 0),
+                new Vector3(8, 5, 0),
+                new Vector3(10, 5, 0)
+            };
+
+            //Go from input vertex (6, 10) to closest exit vertex (10, 5).
+            CheckTree(grid, inputVertices[1].Id, tree, expectedPath);
+
+            //6. Run routing with a hint line.
+            var hint = new RoutingHintLine(
+                new Polyline(new Vector3[]{ new Vector3(2, 2, 0), new Vector3(2, 8, 0) }),
+                0.1, 0.1, false);
+            tree = alg.BuildSimpleNetwork(inputVertices, exits, new List<RoutingHintLine> { hint });
+
+            //Find most efficient path from (0, 4) 
+            expectedPath = new List<Vector3>()
+            {
+                new Vector3(6, 10, 0),
+                new Vector3(6, 8, 0),
+                new Vector3(2, 8, 0),
+                new Vector3(2, 5, 0),
+                new Vector3(0, 5, 0)
+            };
+
+            //Go from input point (6, 10) to now closest exit vertex (0, 5).
+            CheckTree(grid, inputVertices[1].Id, tree, expectedPath);
+        }
+
+        private static void CheckTree(
+            AdaptiveGrid grid, ulong startId, IDictionary<ulong, ulong?> tree, List<Vector3> expectedPath)
+        {
+            ulong? before = startId;
+            for (int i = 0; i < expectedPath.Count; i++)
+            {
+                Assert.Equal(grid.GetVertex(before.Value).Point, expectedPath[i]);
+                before = tree[before.Value];
+            }
+            //After reaching start point before is pointing to 0 (nothing)
+            Assert.False(before.HasValue);
+        }
+    }
+}

--- a/Elements/test/AdaptiveGraphRoutingTests.cs
+++ b/Elements/test/AdaptiveGraphRoutingTests.cs
@@ -418,6 +418,10 @@ namespace Elements.Tests
             AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, config);
             var tree = alg.BuildSpanningTree(inputVertices, tailVertices, hints);
 
+            //Throws if no hint lines
+            Assert.Throws<ArgumentException>(() =>
+                alg.BuildSpanningTree(inputVertices, tailVertices, new List<RoutingHintLine>()));
+
             //Results visualization
             List<Line> lines = new List<Line>();
             foreach (var input in inputVertices)
@@ -564,6 +568,10 @@ namespace Elements.Tests
             AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, config);
             var tree = alg.BuildSpanningTree(inputVertices, localTailVertices, tailVertices, hints);
 
+            //Throws if no hint lines
+            Assert.Throws<ArgumentException>(() =>
+                alg.BuildSpanningTree(inputVertices, localTailVertices, tailVertices, new List<List<RoutingHintLine>>()));
+
             //Result visualization
             List<Line> lines = new List<Line>();
             foreach (var input in inputVertices.SelectMany(iv => iv))
@@ -678,7 +686,7 @@ namespace Elements.Tests
 
             //6. Run routing with a hint line.
             var hint = new RoutingHintLine(
-                new Polyline(new Vector3[]{ new Vector3(2, 2, 0), new Vector3(2, 8, 0) }),
+                new Polyline(new Vector3[] { new Vector3(2, 2, 0), new Vector3(2, 8, 0) }),
                 0.1, 0.1, false);
             tree = alg.BuildSimpleNetwork(inputVertices, exits, new List<RoutingHintLine> { hint });
 

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -20,7 +20,7 @@ namespace Elements.Tests
             // <example>
             var random = new Random();
 
-            var adaptiveGrid = new AdaptiveGrid(new Transform());
+            var adaptiveGrid = new AdaptiveGrid();
             var points = new List<Vector3>()
             {
                 new Vector3(-6, -4),
@@ -34,7 +34,7 @@ namespace Elements.Tests
 
             foreach (var edge in adaptiveGrid.GetEdges())
             {
-                Model.AddElement(new ModelCurve(edge.GetGeometry(), material: random.NextMaterial()));
+                Model.AddElement(new ModelCurve(adaptiveGrid.GetLine(edge), material: random.NextMaterial()));
             }
             // </example>
         }
@@ -46,7 +46,7 @@ namespace Elements.Tests
             // <example2>
             var random = new Random();
 
-            var adaptiveGrid = new AdaptiveGrid(new Transform());
+            var adaptiveGrid = new AdaptiveGrid();
             var points = new List<Vector3>()
             {
                 new Vector3(-6, -4),
@@ -77,7 +77,7 @@ namespace Elements.Tests
 
             foreach (var edge in adaptiveGrid.GetEdges())
             {
-                Model.AddElement(new ModelCurve(edge.GetGeometry(), material: random.NextMaterial()));
+                Model.AddElement(new ModelCurve(adaptiveGrid.GetLine(edge), material: random.NextMaterial()));
             }
             // </example2>
         }
@@ -85,7 +85,7 @@ namespace Elements.Tests
         [Fact]
         public void AdaptiveGridAddVertex()
         {
-            var adaptiveGrid = new AdaptiveGrid(new Transform());
+            var adaptiveGrid = new AdaptiveGrid();
             var points = new List<Vector3>()
             {
                 new Vector3(-6, -4),
@@ -113,7 +113,7 @@ namespace Elements.Tests
         [Fact]
         public void AdaptiveGridSubtractBoxCutEdges()
         {
-            var adaptiveGrid = new AdaptiveGrid(new Transform());
+            var adaptiveGrid = new AdaptiveGrid();
             var polygon = Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10));
 
             var points = new List<Vector3>();
@@ -144,7 +144,7 @@ namespace Elements.Tests
         [Fact]
         public void AdaptiveGridSubtractBoxSmallDifference()
         {
-            var adaptiveGrid = new AdaptiveGrid(new Transform());
+            var adaptiveGrid = new AdaptiveGrid();
             var polygon = Polygon.Rectangle(new Vector3(-41, -51), new Vector3(-39, -49));
 
             var points = new List<Vector3>();
@@ -165,7 +165,7 @@ namespace Elements.Tests
         [Fact]
         public void AdaptiveGridLongSectionDoNowThrow()
         {
-            var adaptiveGrid = new AdaptiveGrid(new Transform());
+            var adaptiveGrid = new AdaptiveGrid();
             var polygon = Polygon.Rectangle(new Vector3(0, 0), new Vector3(200000, 10));
 
             var points = new List<Vector3>();
@@ -178,7 +178,7 @@ namespace Elements.Tests
         [Fact]
         public void AdaptiveGridTwoAlignedSections()
         {
-            var adaptiveGrid = new AdaptiveGrid(new Transform());
+            var adaptiveGrid = new AdaptiveGrid();
             var polygon1 = Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10));
             var polygon2 = Polygon.Rectangle(new Vector3(10, 2), new Vector3(20, 12));
 
@@ -202,7 +202,7 @@ namespace Elements.Tests
         [Fact]
         public void AdaptiveGridDoesntAddTheSameVertex()
         {
-            var adaptiveGrid = new AdaptiveGrid(new Transform());
+            var adaptiveGrid = new AdaptiveGrid();
             var polygon = Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10));
             adaptiveGrid.AddFromPolygon(polygon, new List<Vector3>());
             Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(0, 10), out var id));
@@ -216,6 +216,210 @@ namespace Elements.Tests
             modified = vertex.Point + new Vector3(-halfTol, -halfTol, -halfTol);
             adaptiveGrid.TryGetVertexIndex(modified, out otherId, adaptiveGrid.Tolerance);
             Assert.Equal(id, otherId);
+        }
+
+        [Fact]
+        public void AdaptiveGridAddVertexStrip()
+        {
+            var grid = new AdaptiveGrid();
+            var simpleLine = new Vector3[] { new Vector3(0, 0), new Vector3(5, 0) };
+            var added = grid.AddVertexStrip(simpleLine);
+            Assert.Equal(2, added.Count);
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0), out var id0));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 0), out var id1));
+            var v0 = grid.GetVertex(id0);
+            var v1 = grid.GetVertex(id1);
+            Assert.Single(v0.Edges);
+            Assert.Single(v1.Edges);
+            Assert.Equal(v0.Edges.First().OtherVertexId(v0.Id), v1.Id);
+
+            var singleIntersection = new Vector3[] {
+                new Vector3(0, 5),
+                new Vector3(5, 5),
+                new Vector3(10, 5),
+                new Vector3(10, 10),
+                new Vector3(8, 10),
+                new Vector3(8, 2)
+            };
+            added = grid.AddVertexStrip(singleIntersection);
+            Assert.Equal(8, added.Count); //Single intersection point represented twice.
+            Assert.True(grid.TryGetVertexIndex(new Vector3(8, 5), out var id));
+            var v = grid.GetVertex(id);
+            Assert.Equal(4, v.Edges.Count);
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 5), out id0));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(10, 5), out id1));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(8, 10), out var id2));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(8, 2), out var id3));
+            Assert.Contains(v.Edges, e => e.StartId == id0 || e.EndId == id0);
+            Assert.Contains(v.Edges, e => e.StartId == id1 || e.EndId == id1);
+            Assert.Contains(v.Edges, e => e.StartId == id2 || e.EndId == id2);
+            Assert.Contains(v.Edges, e => e.StartId == id3 || e.EndId == id3);
+
+            var douleIntersection = new Vector3[] {
+                new Vector3(10, 0),
+                new Vector3(20, 0),
+                new Vector3(20, 5),
+                new Vector3(15, 5),
+                new Vector3(15, -5),
+                new Vector3(12, -5),
+                new Vector3(12, 5),
+            };
+            added = grid.AddVertexStrip(douleIntersection);
+            Assert.Equal(11, added.Count); //Two intersection points represented twice.
+            Assert.True(grid.TryGetVertexIndex(new Vector3(15, 0), out id0));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(12, 0), out id1));
+            v0 = grid.GetVertex(id0);
+            v1 = grid.GetVertex(id1);
+            Assert.Equal(4, v0.Edges.Count);
+            Assert.Equal(4, v1.Edges.Count);
+            Assert.Contains(v0.Edges, e => e.StartId == id1 || e.EndId == id1);
+            Assert.True(grid.TryGetVertexIndex(new Vector3(10, 0), out id2));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(20, 0), out id3));
+            var v2 = grid.GetVertex(id2);
+            var v3 = grid.GetVertex(id3);
+            Assert.Single(v2.Edges);
+            Assert.Equal(2, v3.Edges.Count);
+            Assert.Contains(v2.Edges, e => e.StartId == id1 || e.EndId == id1);
+            Assert.Contains(v3.Edges, e => e.StartId == id0 || e.EndId == id0);
+        }
+
+        [Fact]
+        public void AdaptiveGridVertexGetEdgeOtherVertexId()
+        {
+            var grid = SampleGrid();
+            var vertex = grid.GetVertex(2);
+            Assert.Null(vertex.GetEdge(4));
+
+            var edge = vertex.GetEdge(1);
+            Assert.True(edge.OtherVertexId(2) == 1);
+            Assert.Throws<ArgumentException>(() => edge.OtherVertexId(3));
+            var startVertex = grid.GetVertex(edge.StartId);
+            Assert.True(startVertex.Point.IsAlmostEqualTo(new Vector3(0, 0)));
+        }
+
+        [Fact]
+        public void AdaptiveGridClosestVertex()
+        {
+            var grid = SampleGrid();
+            var closest = grid.ClosestVertex(new Vector3(5, 4));
+            Assert.Equal(4u, closest.Id);
+        }
+
+        [Fact]
+        public void AdaptiveGridClosestEdge()
+        {
+            var grid = SampleGrid();
+            var edge = grid.ClosestEdge(new Vector3(9, 3), out var closest);
+            Assert.True(edge.StartId == 3 || edge.StartId == 4);
+            Assert.True(edge.EndId == 3 || edge.EndId == 4);
+            Assert.Equal(new Vector3(8, 2), closest);
+        }
+
+        [Fact]
+        public void AdaptiveGridCutEdge()
+        {
+            var grid = SampleGrid();
+            var vertex = grid.GetVertex(1);
+            var edge = vertex.GetEdge(4);
+            var cut = grid.CutEdge(edge, new Vector3(0, 5));
+            Assert.DoesNotContain(edge, vertex.Edges);
+            Assert.DoesNotContain(edge, grid.GetEdges());
+            Assert.Equal(2, cut.Edges.Count);
+            Assert.Contains(cut.Edges, e => e.OtherVertexId(cut.Id) == 1);
+            Assert.Contains(cut.Edges, e => e.OtherVertexId(cut.Id) == 4);
+        }
+
+        [Fact]
+        public void AdaptiveGridEdgeGetVerticesGetLine()
+        {
+            var grid = SampleGrid();
+            var vertexA = grid.GetVertex(1);
+            var vertexB = grid.GetVertex(4);
+            var edge = vertexA.GetEdge(4);
+            var vertices = grid.GetVertices(edge);
+            Assert.Equal(2, vertices.Count);
+            Assert.Contains(vertices, v => v == vertexA);
+            Assert.Contains(vertices, v => v == vertexB);
+
+            var line = grid.GetLine(edge);
+            Assert.True(line.Start.IsAlmostEqualTo(vertexA.Point) || line.End.IsAlmostEqualTo(vertexA.Point));
+            Assert.True(line.Start.IsAlmostEqualTo(vertexB.Point) || line.End.IsAlmostEqualTo(vertexB.Point));
+        }
+
+        [Fact]
+        public void AdaptiveGridRemoveVertex()
+        {
+            var grid = SampleGrid();
+            var oldVertexCount = grid.GetVertices().Count;
+            var oldEdgeCount = grid.GetEdges().Count;
+            var vertex = grid.GetVertex(1);
+            var edges = vertex.Edges.ToList();
+            var otherVertices = edges.Select(e => grid.GetVertex(e.OtherVertexId(1)));
+            grid.RemoveVertex(vertex);
+            Assert.DoesNotContain(vertex, grid.GetVertices());
+            Assert.Equal(oldVertexCount - 1, grid.GetVertices().Count);
+            Assert.Equal(oldEdgeCount - 2, grid.GetEdges().Count);
+            foreach (var e in edges)
+            {
+                Assert.DoesNotContain(e, grid.GetEdges());
+                Assert.DoesNotContain(otherVertices, v => v.Edges.Contains(e));
+            }
+        }
+
+        [Fact]
+        public void AdaptiveGridAddEdge()
+        {
+            var grid = SampleGrid();
+            var v0 = grid.GetVertex(4);
+            var v0ec = v0.Edges.Count;
+            var v1 = grid.GetVertex(5);
+            var v1ec = v1.Edges.Count;
+            var oldVertexCount = grid.GetVertices().Count;
+            var oldEdgeCount = grid.GetEdges().Count;
+            var newEdge = grid.AddEdge(v0.Id, v1.Id);
+            Assert.Equal(oldVertexCount, grid.GetVertices().Count);
+            Assert.Equal(oldEdgeCount + 1, grid.GetEdges().Count);
+            Assert.Equal(v0ec + 1, v0.Edges.Count);
+            Assert.Equal(v1ec + 1, v1.Edges.Count);
+            Assert.Contains(newEdge, v0.Edges);
+            Assert.Contains(newEdge, v1.Edges);
+            Assert.True(newEdge.StartId == v0.Id);
+            Assert.True(newEdge.EndId == v1.Id);
+        }
+
+        [Fact]
+        public void AdaptiveGridRemoveEdge()
+        {
+            var grid = SampleGrid();
+            var v0 = grid.GetVertex(2);
+            var v1 = grid.GetVertex(5);
+            var v0ec = v0.Edges.Count;
+            var oldVertexCount = grid.GetVertices().Count;
+            var oldEdgeCount = grid.GetEdges().Count;
+            var edge = v0.GetEdge(v1.Id);
+            grid.RemoveEdge(edge);
+            Assert.Equal(oldVertexCount - 1, grid.GetVertices().Count);
+            Assert.Equal(oldEdgeCount - 1, grid.GetEdges().Count);
+
+            Assert.DoesNotContain(edge, grid.GetEdges());
+            Assert.DoesNotContain(v1, grid.GetVertices()); //v1 had only one edge.
+            Assert.Contains(v0, grid.GetVertices()); //v0 had two edges
+            Assert.Equal(v0ec - 1, v0.Edges.Count);
+            Assert.DoesNotContain(edge, v0.Edges);
+        }
+
+        private AdaptiveGrid SampleGrid()
+        {
+            AdaptiveGrid grid = new AdaptiveGrid();
+            var strip = grid.AddVertexStrip(new Vector3[] {
+                new Vector3(0, 0), //1
+                new Vector3(5, 0), //2
+                new Vector3(10, 0) //3
+            });
+
+            grid.AddVertex(new Vector3(5, 5), new Vertex[] { strip[0], strip[2] }); //4
+            grid.AddVertex(new Vector3(5, 2), new Vertex[] { strip[1] }); //5
+            return grid;
         }
     }
 }

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -289,6 +289,7 @@ namespace Elements.Tests
             var grid = SampleGrid();
             var vertex = grid.GetVertex(2);
             Assert.Null(vertex.GetEdge(4));
+            Assert.Null(vertex.GetEdge(2));
 
             var edge = vertex.GetEdge(1);
             Assert.True(edge.OtherVertexId(2) == 1);

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -408,6 +408,15 @@ namespace Elements.Tests
             Assert.DoesNotContain(edge, v0.Edges);
         }
 
+        /*           (4)
+         *          /   \
+         *         /     \
+         *        /       \
+         *       /   (5)   \
+         *      /     |     \
+         *     /      |      \
+         *   (1)-----(2)-----(3)
+         */
         private AdaptiveGrid SampleGrid()
         {
             AdaptiveGrid grid = new AdaptiveGrid();

--- a/Elements/test/PriorityQueueTests.cs
+++ b/Elements/test/PriorityQueueTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Elements;
+using Xunit;
+
+namespace Elements.Tests
+{
+    public class PriorityQueueTests
+    {
+        [Fact]
+        public void ConstructionFromCollection()
+        {
+            List<int> ids = new List<int>() { 10, 2, 4, 6, 3, 5 };
+            PriorityQueue<int> pq = new PriorityQueue<int>(ids);
+            //First in ids is set to 0, others to double.MaxValue 
+            Assert.Equal(10, pq.PopMin());
+            pq.UpdatePriority(4, 10);
+            pq.UpdatePriority(5, 7);
+            pq.UpdatePriority(3, 20);
+            Assert.Equal(5, pq.PopMin());
+            Assert.Equal(4, pq.PopMin());
+            Assert.False(pq.Empty());
+            pq.UpdatePriority(6, 17);
+            pq.UpdatePriority(2, 26);
+            Assert.Equal(6, pq.PopMin());
+            Assert.Equal(3, pq.PopMin());
+            Assert.Equal(2, pq.PopMin());
+            Assert.True(pq.Empty());
+        }
+
+        [Fact]
+        public void ConstructingDynamically()
+        {
+            PriorityQueue<int> pq = new PriorityQueue<int>();
+            pq.AddOrUpdate(1, 10);
+            pq.AddOrUpdate(2, 7);
+            pq.AddOrUpdate(3, 9);
+            pq.AddOrUpdate(4, 13);
+            Assert.Equal(2, pq.PopMin());
+            Assert.Equal(3, pq.PopMin());
+            Assert.False(pq.Empty());
+            pq.AddOrUpdate(5, 10);
+            pq.AddOrUpdate(6, 4);
+            pq.AddOrUpdate(7, 14);
+            Assert.Equal(6, pq.PopMin());
+            //Order is not guaranteed if priority is the same
+            var min = pq.PopMin();
+            Assert.True(min == 5 || min == 1);
+            min = pq.PopMin();
+            Assert.True(min == 5 || min == 1);
+            Assert.False(pq.Empty());
+            Assert.Equal(4, pq.PopMin());
+            Assert.Equal(7, pq.PopMin());
+            Assert.True(pq.Empty());
+        }
+
+        [Fact]
+        public void OverridesDuplicateIds()
+        {
+            PriorityQueue<int> pq = new PriorityQueue<int>();
+            pq.AddOrUpdate(1, 10);
+            pq.AddOrUpdate(2, 7);
+            pq.AddOrUpdate(2, 12);
+            pq.AddOrUpdate(3, 11);
+            Assert.Equal(1, pq.PopMin());
+            Assert.Equal(3, pq.PopMin());
+            Assert.Equal(2, pq.PopMin());
+            Assert.True(pq.Empty());
+        }
+    }
+}


### PR DESCRIPTION
BACKGROUND:
- While working on new function that used AdaptiveGrid I collected all pieces of code related to AdaptiveGrid but located outside Elements. It make sense to place them directly into
- It was decided to move AdaptiveGraph routing and PriorityQueue into Elements as whey had no collections with previous repository.

DESCRIPTION:
- Remove AdaptiveGrid reference from Edge and Vertex to make it independent. Move Edge.GetVertices and Edge.GetLine to AdaptiveGrid.
- Add Vertex.GetEdge, Edge.OtherVertexId.
- Add default constructor to AdaptiveGrid to avoid manual creation of new Transform object.
- Add AdaptiveGrid.AddVertexStrip for adding connected chain of vertices.
- Add AdaptiveGrid.CutEdge for replacing an edge with two new edges that meet at given point.Point.
- Add AdaptiveGrid.ClosestVertex, AdaptiveGrid.ClosestEdge
- Add AdaptiveGrid.RemoveVertex, AdaptiveGrid.AddEdge, AdaptiveGrid.RemoveEdge
- Add PriorityQueue collection into Elements.
- Add AdaptiveGraphRouting into Elements. The only new function it has is BuildSimpleNetwork.

TESTING:
- PriorityQueueTests and AdaptiveGraphRoutingTests were moved together with corresponding files.
- Add a lot of tests to AdaptiveGridTests covering new functions.
  
FUTURE WORK:
- AdaptiveGrid and AdaptiveGraphRouting  are still quite complicated to use. Higher level code is needed to easier handing.
- There are plans to introduce new  features into AdaptiveGrid and AdaptiveGraphRouting

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/794)
<!-- Reviewable:end -->
