### PR TITLE
Make TryToGraphicsBuffers public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+### Changed
+
+- Simplified `IEnumerable<Vector3>.ToGraphicsBuffers()`
+- `TryToGraphicsBuffers` is now public
+
 ## 1.0.0
 
 ### Added

--- a/Elements/src/GeometricElement.cs
+++ b/Elements/src/GeometricElement.cs
@@ -223,7 +223,7 @@ namespace Elements
         /// True if there is graphicsbuffers data applicable to add, false otherwise.
         /// Out variables should be ignored if the return value is false.
         /// </returns>
-        internal virtual Boolean TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
+        public virtual Boolean TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
         {
             id = null;
             mode = null;

--- a/Elements/src/Geometry/Curve.cs
+++ b/Elements/src/Geometry/Curve.cs
@@ -97,9 +97,9 @@ namespace Elements.Geometry
         /// <param name="c">The curve to convert.</param>
         public static implicit operator ModelCurve(Curve c) => new ModelCurve(c);
 
-        internal GraphicsBuffers ToGraphicsBuffers(bool lineLoop)
+        internal GraphicsBuffers ToGraphicsBuffers()
         {
-            return this.RenderVertices().ToGraphicsBuffers(lineLoop);
+            return this.RenderVertices().ToGraphicsBuffers();
         }
     }
 }

--- a/Elements/src/Geometry/Vector3Extensions.cs
+++ b/Elements/src/Geometry/Vector3Extensions.cs
@@ -182,21 +182,20 @@ namespace Elements.Geometry
             return arr;
         }
 
-        internal static GraphicsBuffers ToGraphicsBuffers(this IList<Vector3> vertices, bool lineLoop)
+        /// <summary>
+        /// Convert a list of vertices to a GraphicsBuffers object.
+        /// </summary>
+        /// <param name="vertices">The vertices to convert.</param>
+        /// <returns></returns>
+        public static GraphicsBuffers ToGraphicsBuffers(this IList<Vector3> vertices)
         {
             var gb = new GraphicsBuffers();
 
             for (var i = 0; i < vertices.Count; i++)
             {
                 var v = vertices[i];
-                gb.AddVertex(v, default(Vector3), default(UV), null);
-
-                var write = lineLoop ? (i < vertices.Count - 1) : (i % 2 == 0 && i < vertices.Count - 1);
-                if (write)
-                {
-                    gb.AddIndex((ushort)i);
-                    gb.AddIndex((ushort)(i + 1));
-                }
+                gb.AddVertex(v, default, default, null);
+                gb.AddIndex((ushort)i);
             }
             return gb;
         }

--- a/Elements/src/GridLine.cs
+++ b/Elements/src/GridLine.cs
@@ -53,7 +53,14 @@ namespace Elements
         /// </summary>
         public double ExtensionEnd = 1;
 
-        internal override Boolean TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
+        /// <summary>
+        /// Get graphics buffers and other metadata required to modify a GLB.
+        /// </summary>
+        /// <returns>
+        /// True if there is graphicsbuffers data applicable to add, false otherwise.
+        /// Out variables should be ignored if the return value is false.
+        /// </returns>
+        public override Boolean TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
         {
             if (this.Curve == null)
             {
@@ -61,7 +68,7 @@ namespace Elements
             }
 
             id = $"{this.Id}_gridline";
-            mode = glTFLoader.Schema.MeshPrimitive.ModeEnum.LINES;
+            mode = glTFLoader.Schema.MeshPrimitive.ModeEnum.LINE_STRIP;
             graphicsBuffers = new List<GraphicsBuffers>();
 
             var renderVertices = new List<Vector3>();
@@ -86,7 +93,7 @@ namespace Elements
                 renderVertices.Add(end.point + end.dir * ExtensionEnd);
             }
 
-            graphicsBuffers.Add(renderVertices.ToGraphicsBuffers(true));
+            graphicsBuffers.Add(renderVertices.ToGraphicsBuffers());
             return true;
         }
 

--- a/Elements/src/ModelArrows.cs
+++ b/Elements/src/ModelArrows.cs
@@ -117,8 +117,14 @@ namespace Elements
 
             return gb;
         }
-
-        internal override Boolean TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
+        /// <summary>
+        /// Get graphics buffers and other metadata required to modify a GLB.
+        /// </summary>
+        /// <returns>
+        /// True if there is graphicsbuffers data applicable to add, false otherwise.
+        /// Out variables should be ignored if the return value is false.
+        /// </returns>
+        public override Boolean TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
         {
             if (this.Vectors.Count < 1)
             {

--- a/Elements/src/ModelCurve.cs
+++ b/Elements/src/ModelCurve.cs
@@ -56,16 +56,23 @@ namespace Elements
             this._isSelectable = selectable;
         }
 
-        internal GraphicsBuffers ToGraphicsBuffers(bool lineLoop)
+        internal GraphicsBuffers ToGraphicsBuffers()
         {
-            return this.Curve.ToGraphicsBuffers(lineLoop);
+            return this.Curve.ToGraphicsBuffers();
         }
 
-        internal override bool TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
+        /// <summary>
+        /// Get graphics buffers and other metadata required to modify a GLB.
+        /// </summary>
+        /// <returns>
+        /// True if there is graphicsbuffers data applicable to add, false otherwise.
+        /// Out variables should be ignored if the return value is false.
+        /// </returns>
+        public override bool TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
         {
             id = this._isSelectable ? $"{this.Id}_curve" : $"unselectable_{this.Id}_curve";
-            mode = glTFLoader.Schema.MeshPrimitive.ModeEnum.LINES;
-            graphicsBuffers = new List<GraphicsBuffers>() { this.ToGraphicsBuffers(true) };
+            mode = glTFLoader.Schema.MeshPrimitive.ModeEnum.LINE_STRIP;
+            graphicsBuffers = new List<GraphicsBuffers>() { this.ToGraphicsBuffers() };
             return true;
         }
     }

--- a/Elements/src/ModelLines.cs
+++ b/Elements/src/ModelLines.cs
@@ -57,7 +57,14 @@ namespace Elements
             _isSelectable = selectable;
         }
 
-        internal override Boolean TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
+        /// <summary>
+        /// Get graphics buffers and other metadata required to modify a GLB.
+        /// </summary>
+        /// <returns>
+        /// True if there is graphicsbuffers data applicable to add, false otherwise.
+        /// Out variables should be ignored if the return value is false.
+        /// </returns>
+        public override Boolean TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
         {
             if (Lines.Count == 0)
             {
@@ -74,7 +81,7 @@ namespace Elements
                 points.Add(line.End);
             }
 
-            graphicsBuffers.Add(points.ToGraphicsBuffers(false));
+            graphicsBuffers.Add(points.ToGraphicsBuffers());
             return true;
         }
     }

--- a/Elements/src/ModelPoints.cs
+++ b/Elements/src/ModelPoints.cs
@@ -57,7 +57,14 @@ namespace Elements
             return gb;
         }
 
-        internal override Boolean TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
+        /// <summary>
+        /// Get graphics buffers and other metadata required to modify a GLB.
+        /// </summary>
+        /// <returns>
+        /// True if there is graphicsbuffers data applicable to add, false otherwise.
+        /// Out variables should be ignored if the return value is false.
+        /// </returns>
+        public override Boolean TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
         {
             if (this.Locations.Count == 0)
             {

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -783,7 +783,7 @@ namespace Elements.Serialization.glTF
             {
                 // Draw standard edges
                 var id = $"{100000}_curve";
-                var gb = vertices.ToArray(vertices.Count).ToGraphicsBuffers(false);
+                var gb = vertices.ToArray(vertices.Count).ToGraphicsBuffers();
                 gltf.AddPointsOrLines(id, buffer, bufferViews, accessors, materials[BuiltInMaterials.Edges.Id.ToString()], new List<GraphicsBuffers>() { gb }, MeshPrimitive.ModeEnum.LINES, meshes, nodes, null);
             }
 
@@ -791,7 +791,7 @@ namespace Elements.Serialization.glTF
             {
                 // Draw highlighted edges
                 var id = $"{100001}_curve";
-                var gb = verticesHighlighted.ToArray(verticesHighlighted.Count).ToGraphicsBuffers(false);
+                var gb = verticesHighlighted.ToArray(verticesHighlighted.Count).ToGraphicsBuffers();
                 gltf.AddPointsOrLines(id, buffer, bufferViews, accessors, materials[BuiltInMaterials.EdgesHighlighted.Id.ToString()], new List<GraphicsBuffers>() { gb }, MeshPrimitive.ModeEnum.LINES, meshes, nodes, null);
             }
 
@@ -991,7 +991,7 @@ namespace Elements.Serialization.glTF
                         continue;
                     }
                     var id = $"{GetNextId()}_edge";
-                    var gb = lineSet.ToGraphicsBuffers(false);
+                    var gb = lineSet.ToGraphicsBuffers();
                     gltf.AddPointsOrLines(id, buffer, bufferViews, accessors, materialIndexMap[BuiltInMaterials.Edges.Id.ToString()], new List<GraphicsBuffers>() { gb }, MeshPrimitive.ModeEnum.LINES, meshes, nodes, null);
                 }
             }

--- a/Elements/test/GeometricElementTests.cs
+++ b/Elements/test/GeometricElementTests.cs
@@ -77,7 +77,7 @@ namespace Elements.Tests
     }
     class CustomGBClass : GeometricElement
     {
-        internal override bool TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
+        public override bool TryToGraphicsBuffers(out List<GraphicsBuffers> graphicsBuffers, out string id, out glTFLoader.Schema.MeshPrimitive.ModeEnum? mode)
         {
             id = $"{this.Id}_customthing";
             mode = glTFLoader.Schema.MeshPrimitive.ModeEnum.TRIANGLE_FAN;
@@ -89,7 +89,7 @@ namespace Elements.Tests
                     (0.5, 1.5,0),
                     (0,1,0),
             };
-            graphicsBuffers = new List<GraphicsBuffers>() { vertices.ToGraphicsBuffers(false) };
+            graphicsBuffers = new List<GraphicsBuffers>() { vertices.ToGraphicsBuffers() };
             return true;
         }
     }


### PR DESCRIPTION
BACKGROUND:
- Users may want to create custom types that specify their own buffer logic. Previously this was only possible for types within Elements.
 
DESCRIPTION:
- Exposes `TryToGraphicsBuffers` and `ToGraphicsBuffers` APIs as public
- simplifies `ToGraphicsBuffers`. It appears it was doing some unnecessary index manipulation to mimic the behavior of  `GL_LINE_LOOP` — but since we exposed setting the Mode (in #704, I think?), this is no longer needed.

TESTING:
- I checked the GLB output of 
  - `GridLine`
  - `ToGLTF()` with `drawEdges`=`true`
  - other `ModelCurve` tests producing both open and closed curves
  - `ModelLines`
 and verified it was visually unchanged
  
FUTURE WORK:
  - `ToGLTF()` with `drawEdges`=`true` appears somewhat broken. It only works right now for element instances. 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/801)
<!-- Reviewable:end -->
