### PR TITLE
fix up warnings, typos

### DIFF
--- a/Elements.Benchmarks/ElementCreation.cs
+++ b/Elements.Benchmarks/ElementCreation.cs
@@ -10,8 +10,6 @@ namespace Elements.Benchmarks
     [MemoryDiagnoser]
     public class ElementCreation
     {
-        Model _model;
-        string _json;
 
         private List<HSSPipeProfile> _hssProfiles;
 

--- a/Elements/src/ContentCatalog.cs
+++ b/Elements/src/ContentCatalog.cs
@@ -37,7 +37,7 @@ namespace Elements
         }
 
         /// <summary>
-        /// Convert the ContentCatalog into it's JSON representation.
+        /// Convert the ContentCatalog into its JSON representation.
         /// </summary>
         public string ToJson()
         {

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -34,6 +34,10 @@ namespace Elements.Geometry
             _plane = Plane();
         }
 
+        /// <summary>
+        /// Validate that this Polygon's vertices are coplanar, clean up any
+        /// duplicate vertices, and fix any overlapping edges.
+        /// </summary>
         protected override void ValidateVertices()
         {
             if (!Vertices.AreCoplanar())
@@ -2201,7 +2205,6 @@ namespace Elements.Geometry
         /// E|_________|B_____A
         /// Vertex A will be deleted
         /// </summary>
-        /// <param name="vertices"></param>
         private void DeleteVerticesForOverlappingEdges()
         {
             if (Vertices.Count < 4)
@@ -2261,7 +2264,7 @@ namespace Elements.Geometry
                         //Loop can possibly be just two points connected forth and back.
                         //Filter it early.
                         vertices.Add(v);
-                        if(vertices.Count > 2)
+                        if (vertices.Count > 2)
                         {
                             polygonPresets.Add(vertices);
                         }

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -44,6 +44,9 @@ namespace Elements.Geometry
             _bounds = new BBox3(Vertices);
         }
 
+        /// <summary>
+        /// Clean up any duplicate vertices, and warn about any vertices that are too close to each other.
+        /// </summary>
         protected virtual void ValidateVertices()
         {
             Vertices = Vector3.RemoveSequentialDuplicates(Vertices);

--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -43,7 +43,10 @@ namespace Elements
         [JsonConstructor]
         public Model(Position @origin, Transform @transform, System.Collections.Generic.IDictionary<Guid, Element> @elements)
         {
+
+#pragma warning disable CS0618
             this.Origin = @origin;
+#pragma warning restore CS0618
             this.Transform = @transform;
             this.Elements = @elements;
         }

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -86,7 +86,7 @@ namespace Elements.Serialization.glTF
                     if (SaveGlb(model, path, out errors, drawEdges))
                     {
                         return;
-                    }
+                }
                     // Else fall through to produce an empty GLTF.
                 }
                 else

--- a/Elements/src/Validators/Validator.cs
+++ b/Elements/src/Validators/Validator.cs
@@ -57,7 +57,7 @@ namespace Elements.Validators
                 return _validator;
             }
         }
-
+#pragma warning disable CS0612
         private Dictionary<Type, IValidator> _validators;
 
         private Validator()
@@ -75,7 +75,7 @@ namespace Elements.Validators
                 _validators.Add(v.ValidatesType, v);
             }
         }
-
+#pragma warning restore CS0612
         /// <summary>
         /// Gets the first validator for the supplied T.
         /// </summary>


### PR DESCRIPTION
BACKGROUND:
- There were some annoying warnings when building —"obsolete" warnings and missing XML comments.

DESCRIPTION:
- Fixes a typo
- adds `#pragma` ignores for valid uses of obsolete apis 
- adds XML descriptions for methods that lacked them

REQUIRED:
- [N/A] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/802)
<!-- Reviewable:end -->
