### PR TITLE
add support for LineDisplaySettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+`LineDisplaySettings` for materials to control the display of lines in supported viewers (like Hypar.io).
+
 ## 1.0.0
 
 ### Added

--- a/Elements/src/LineDisplaySettings.cs
+++ b/Elements/src/LineDisplaySettings.cs
@@ -1,0 +1,33 @@
+namespace Elements
+{
+    /// <summary>
+    /// Settings for how a curve or line should be displayed. 
+    /// </summary>
+    public class LineDisplaySettings
+    {
+        /// <summary>
+        /// The width of the line. If Mode is set to Screen Units, this will be in pixels (and rounded to the nearest integer). 
+        /// If set to World Units, this will be in meters. 
+        /// </summary>
+        public double Width { get; set; } = 1;
+        /// <summary>
+        /// How the Width should be interpreted. If set to Screen Units, Width is interpreted as a constant pixel width (and rounded to the nearest integer). If set to World Units, Width is interpreted as a constant meter width.
+        /// </summary>
+        public LineDisplayWidthMode Mode { get; set; } = LineDisplayWidthMode.ScreenUnits;
+    }
+
+    /// <summary>
+    /// Different ways to interpret the Width property of a LineDisplaySettings.
+    /// </summary>
+    public enum LineDisplayWidthMode
+    {
+        /// <summary>
+        /// The Width property is interpreted as a constant pixel width (and rounded to the nearest integer).
+        /// </summary>
+        ScreenUnits = 0,
+        /// <summary>
+        /// The Width property is interpreted as a constant meter width.
+        /// </summary>
+        WorldUnits = 1,
+    }
+}

--- a/Elements/src/Material.cs
+++ b/Elements/src/Material.cs
@@ -65,6 +65,11 @@ namespace Elements
         public double EmissiveFactor { get; set; }
 
         /// <summary>
+        /// If provided, this controls how curves and lines will be drawn in the 3D view for supported viewers. This will not affect mesh / solid-based elements.
+        /// </summary>
+        public LineDisplaySettings LineDisplaySettings { get; set; } = null;
+
+        /// <summary>
         /// Construct a material.
         /// </summary>
         public Material()

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -227,6 +227,22 @@ namespace Elements.Serialization.glTF
                     };
                 }
 
+                if (material.LineDisplaySettings != null)
+                {
+                    if (gltfMaterial.Extensions == null)
+                    {
+                        gltfMaterial.Extensions = new Dictionary<string, object>();
+                    }
+                    if (!gltf.ExtensionsUsed.Contains("HYPAR_materials_edgesettings"))
+                    {
+                        gltf.ExtensionsUsed = new List<string>(gltf.ExtensionsUsed) { "HYPAR_materials_edgesettings" }.ToArray();
+                    }
+                    gltfMaterial.Extensions.Add("HYPAR_materials_edgesettings", new Dictionary<string, object>{
+                        {"lineWidth", material.LineDisplaySettings.Width},
+                        {"sizeMode", (int)material.LineDisplaySettings.Mode},
+                    });
+                }
+
                 var textureHasTransparency = false;
 
                 if (material.Texture != null && File.Exists(material.Texture))

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -233,11 +233,11 @@ namespace Elements.Serialization.glTF
                     {
                         gltfMaterial.Extensions = new Dictionary<string, object>();
                     }
-                    if (!gltf.ExtensionsUsed.Contains("HYPAR_materials_edgesettings"))
+                    if (!gltf.ExtensionsUsed.Contains("HYPAR_materials_edge_settings"))
                     {
-                        gltf.ExtensionsUsed = new List<string>(gltf.ExtensionsUsed) { "HYPAR_materials_edgesettings" }.ToArray();
+                        gltf.ExtensionsUsed = new List<string>(gltf.ExtensionsUsed) { "HYPAR_materials_edge_settings" }.ToArray();
                     }
-                    gltfMaterial.Extensions.Add("HYPAR_materials_edgesettings", new Dictionary<string, object>{
+                    gltfMaterial.Extensions.Add("HYPAR_materials_edge_settings", new Dictionary<string, object>{
                         {"lineWidth", material.LineDisplaySettings.Width},
                         {"sizeMode", (int)material.LineDisplaySettings.Mode},
                     });

--- a/Elements/test/ModelCurveTests.cs
+++ b/Elements/test/ModelCurveTests.cs
@@ -47,6 +47,40 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void ModelCurveWithLineWeights()
+        {
+            this.Name = nameof(ModelCurveWithLineWeights);
+
+            // <example>
+            // A line
+            var line = new Line(Vector3.Origin, new Vector3(5, 5, 5));
+
+            // An arc
+            var arc = new Arc(Vector3.Origin, 2.0, 45.0, 135.0);
+
+            // A polygon
+            var pline = Polygon.L(2, 2, 0.5);
+
+            // A Bezier
+            var a = Vector3.Origin;
+            var b = new Vector3(5, 0, 1);
+            var c = new Vector3(5, 5, 2);
+            var d = new Vector3(0, 5, 3);
+            var e = new Vector3(0, 0, 4);
+            var f = new Vector3(5, 0, 5);
+            var ctrlPts = new List<Vector3> { a, b, c, d, e, f };
+            var bezier = new Bezier(ctrlPts);
+
+            var lineModelCurve = new ModelCurve(line, new Material("Red", Colors.Red) { LineDisplaySettings = new LineDisplaySettings { Width = 5 } });
+            var arcModelCurve = new ModelCurve(arc, new Material("Orange", Colors.Orange) { LineDisplaySettings = new LineDisplaySettings { Width = 0.1, Mode = LineDisplayWidthMode.WorldUnits } }, new Transform(5, 0, 0));
+            var plineModelCurve = new ModelCurve(pline, new Material("Purple", Colors.Purple) { LineDisplaySettings = new LineDisplaySettings { Width = 10, Mode = LineDisplayWidthMode.ScreenUnits } }, new Transform(10, 0, 0));
+            var bezierModelCurve = new ModelCurve(bezier, new Material("Green", Colors.Green) { LineDisplaySettings = new LineDisplaySettings { Width = 1, Mode = LineDisplayWidthMode.WorldUnits } }, new Transform(15, 0, 0));
+            // </example>
+
+            this.Model.AddElements(new[] { lineModelCurve, arcModelCurve, plineModelCurve, bezierModelCurve });
+        }
+
+        [Fact]
         public void OffsetModelCurves()
         {
             this.Name = "OffsetModelCurves";
@@ -123,11 +157,12 @@ namespace Elements.Tests
         }
 
         [Fact]
-        public void BBoxToCurves() {
+        public void BBoxToCurves()
+        {
             Name = "BBoxToCurves";
             var star = Polygon.Star(10, 4, 5);
             var flatbbox = new BBox3(star.Vertices);
-            var bbox = new BBox3(new Vector3(4,2,5), new Vector3(10, 8, 14));
+            var bbox = new BBox3(new Vector3(4, 2, 5), new Vector3(10, 8, 14));
             var crvs = bbox.ToModelCurves();
             Model.AddElements(crvs);
             var flatCrvs = flatbbox.ToModelCurves();


### PR DESCRIPTION
BACKGROUND:
- Sometimes, it is useful to render diagrammatic elements in a model with display line-weights. Some elements are strictly conceptual, like structural wireframes, and they may not want to be shown as infinitely-thin curves.

DESCRIPTION:
- Adds support for `LineDisplaySettings` as a property on `Material`, for configuring how curve geometry should be rendered in a supporting 3D viewer. 
```csharp
new ModelCurve(pline, new Material("Purple", Colors.Purple) { 
     LineDisplaySettings = new LineDisplaySettings { 
          Width = 10, 
          Mode = LineDisplayWidthMode.ScreenUnits 
     } 
}, new Transform(10, 0, 0));
```
- Utilizes the pattern of a glTF extension, which we're calling `HYPAR_materials_edge_settings`. (Open to suggestions for a better name! once it's in there, it's in there!)
an example from the generated GLTF:
```json
{
      "name": "f6cc304f-5078-42e9-b6c8-07d271d04f82",
      "extensions": {
        "KHR_materials_pbrSpecularGlossiness": {...},
        "HYPAR_materials_edge_settings": {
          "lineWidth": 5,
          "sizeMode": 0
        }
      }
}
```

`lineWidth` is a number determining the width of the line. `sizeMode` can be either 0 or 1 — if 0, the `lineWidth` is interpreted as a pixel width and rounded to the nearest integer. If 1, the `lineWidth` is interpreted as being in model units (meters), and should scale as the user zooms in and out. 

TESTING:
- This will have no effect anywhere except a viewer that supports this draft extension. A forthcoming hypar PR will demonstrate a first front-end implementation consuming this information to render lines as meshes. 
  
FUTURE WORK:
- We should consider registering `HYPAR` as a glTF vendor prefix. 
- We should consider developing a [formal spec](https://github.com/KhronosGroup/glTF/blob/main/extensions/Template.md) for the extension 
- We could add dash settings to `LineDisplaySettings` (and the extension) as well. 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.
