### PR TITLE
fix for string enum codegen

### DIFF
--- a/Elements.CodeGeneration/src/Templates/Class.liquid
+++ b/Elements.CodeGeneration/src/Templates/Class.liquid
@@ -30,7 +30,7 @@
 {%   if property.HasDescription -%}
     /// <summary>{{ property.Description | csharpdocs }}</summary>
 {%   endif -%}
-    [JsonProperty("{{ property.Name }}", Required = {{ property.JsonPropertyRequiredCode }}{% if property.IsStringEnumArray %}, ItemConverterType = typeof(Converters.StringEnumConverter){% endif %})]
+    [JsonProperty("{{ property.Name }}", Required = {{ property.JsonPropertyRequiredCode }}{% if property.IsStringEnumArray %}, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter){% endif %})]
 {%   if property.RenderRequiredAttribute -%}
     [System.ComponentModel.DataAnnotations.Required{% if property.AllowEmptyStrings %}(AllowEmptyStrings = true){% endif %}]
 {%   endif -%}
@@ -50,7 +50,7 @@
     [System.ComponentModel.DataAnnotations.RegularExpression(@"{{ property.RegularExpressionValue }}")]
 {%   endif -%}
 {%   if property.IsStringEnum -%}
-    [JsonConverter(typeof(Converters.StringEnumConverter))]
+    [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
 {%   endif -%}
 {%   if property.IsDate and UseDateFormatConverter -%}
     [JsonConverter(typeof(DateFormatConverter))]


### PR DESCRIPTION
BACKGROUND:
- CodeGen of enums would sometimes result in invalid C# code. Even though we have `using Newtonsoft.Json` in the class template, because we didn't have `using Newtonsoft.Json.Converters`, this would not build.

DESCRIPTION:
- fully qualifies `Newtonsoft.Json.Converters.StringEnumConverter`

TESTING:
- I tested this with a local build of the Hypar CLI which references this version of elements, and verified that string enums no longer generated invalid code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/807)
<!-- Reviewable:end -->
