### PR TITLE
False collinearity of close lines 

### DIFF
--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -999,7 +999,8 @@ namespace Elements.Geometry
         /// <returns></returns>
         public bool IsCollinear(Line line)
         {
-            return Vector3.AreCollinear(Start, End, line.Start) && Vector3.AreCollinear(Start, End, line.End);
+            var vectors = new Vector3[] { Start, End, line.Start, line.End };
+            return vectors.AreCollinear();
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -839,7 +839,7 @@ namespace Elements.Geometry
             ba = ba.Unitized();
             cb = cb.Unitized();
 
-            return Math.Abs(cb.Dot(ba)) > (1 - Vector3.EPSILON);
+            return Math.Abs(cb.Dot(ba)) > (1 - Math.Pow(Vector3.EPSILON, 2));
         }
 
         /// <summary>

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -498,6 +498,10 @@ namespace Elements.Geometry.Tests
             var almostSameLine = new Line(Vector3.Origin, new Vector3(5, 5.00000000001, 5));
             Assert.True(line.IsAlmostEqualTo(almostSameLine, false));
             Assert.True(line.IsCollinear(almostSameLine));
+
+            var longLine = new Line(new Vector3(458.8830, -118.7170, 13.8152), new Vector3(458.8830, -80.4465, 13.8152));
+            var nearlySameLine = new Line(new Vector3(458.9005, 29.6573, 13.7977), new Vector3(458.9005, 33.5632, 13.7977));
+            Assert.False(longLine.IsCollinear(nearlySameLine));
         }
 
         [Fact]

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -427,8 +427,19 @@ namespace Elements.Tests
             Vector3 p2 = new Vector3(20, 20, 20);
             Vector3 p3 = new Vector3(15, 5, 20);
 
+            var p4 = new Vector3(0, -118.7170, 13.8152);
+            var p5 = new Vector3(0, -80.4465, 13.8152);
+            var p6 = new Vector3(0, -118.7170, 13.8173);
+            var p7 = new Vector3(0, 33.5632, 13.8173);
+
+
             Assert.True(Vector3.AreCollinear(p0, p1, p2));
             Assert.False(Vector3.AreCollinear(p0, p1, p3));
+
+            var zeroPlane = new Plane(Vector3.Origin, Vector3.YAxis);
+            Assert.False(p4.Project(zeroPlane).IsAlmostEqualTo(p6.Project(zeroPlane)));
+            Assert.False(Vector3.AreCollinear(p4, p5, p6));
+            Assert.False(Vector3.AreCollinear(p4, p5, p7));
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
I noticed that `Line.IsCollinear()` method returns true for lines which are not collinear and are close to each other. 

Lines which break:
- Start = x: 458.8830, y:-118.7170, z: 13.8152; End = x:458.8830, y:-80.4465, z:13.8152
- Start = x:458.9005, y:29.6573, z:13.7977; End = x:458.9005, y:33.5632, z:13.7977;

DESCRIPTION:
I changed method of checking collinearity inside `Line` class to that which accepts list of `Vectors`. Hopefully it does not break when points are close to each other.
I also fixed `Vector.AreCollinear()` method to return true collinearity checks for Vectors which are not almost the same. 

TESTING:
I added new unit tests with edge cases I noticed. 
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
Currently there are two methods of testing collinearity of `Vectors`. One is in in `Vector3` class and takes 3 Vectors as an argument, second is extension method of list of Vectors. I would suggest to use only one, preferably that one on extension method because it is versatile. 
