### PR TITLE
Line GetUValue for point on line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `EdgeDisplaySettings` for materials to control the display of lines in supported viewers (like Hypar.io).
+- `Line.GetUParameter(Vector 3)` - calculate U parameter for point on line
 
 ### Changed
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1050,7 +1050,7 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="point"></param>
         /// <returns>Returns U parameter for point on line</returns>
-        public double GetUValue(Vector3 point)
+        public double GetUParameter(Vector3 point)
         { 
             if (!PointOnLine(point, true))
                 return -1;

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1075,17 +1075,18 @@ namespace Elements.Geometry
                 return -1;
             }
 
-            if(point.IsAlmostEqualTo(start))
+            if (point.IsAlmostEqualTo(start))
             {
                 return 0;
             }
 
-            if(point.IsAlmostEqualTo(end))
+            if (point.IsAlmostEqualTo(end))
             {
                 return 1;
             }
 
             return (point - start).Length() / (end - start).Length();
+        }
 
         /// Projects current line onto a plane
         /// </summary>

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1050,7 +1050,7 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="point"></param>
         /// <returns>Returns U parameter for point on line</returns>
-        public double GetUParameter(Vector3 point)
+        public double GetParameterAt(Vector3 point)
         { 
             if (!PointOnLine(point, true))
                 return -1;

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1048,16 +1048,43 @@ namespace Elements.Geometry
         /// <summary>
         /// Calculate U parameter for point on line
         /// </summary>
-        /// <param name="point"></param>
+        /// <param name="point">Point on line</param>
         /// <returns>Returns U parameter for point on line</returns>
         public double GetParameterAt(Vector3 point)
-        { 
+        {
             if (!PointOnLine(point, true))
+            {
                 return -1;
+            }
 
-            var distance = Start.DistanceTo(point);
+            return GetParameterAt(point, Start, End);
+        }
 
-            return distance / Length();
+        /// <summary>
+        /// Calculate U parameter for point between two other points
+        /// </summary>
+        /// <param name="point">Point for which parameter is calculated</param>
+        /// <param name="start">First point</param>
+        /// <param name="end">Second point</param>
+        /// <returns>Returns U parameter for point between two other points</returns>
+        public static double GetParameterAt(Vector3 point, Vector3 start, Vector3 end)
+        {
+            if (!PointOnLine(point, start, end, true))
+            {
+                return -1;
+            }
+
+            if(point.IsAlmostEqualTo(start))
+            {
+                return 0;
+            }
+
+            if(point.IsAlmostEqualTo(end))
+            {
+                return 1;
+            }
+
+            return (point - start).Length() / (end - start).Length();
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1053,11 +1053,6 @@ namespace Elements.Geometry
         /// <returns>Returns U parameter for point on line</returns>
         public double GetParameterAt(Vector3 point)
         {
-            if (!PointOnLine(point, true))
-            {
-                return -1;
-            }
-
             return GetParameterAt(point, Start, End);
         }
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1046,6 +1046,21 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Calculate U parameter for point on line
+        /// </summary>
+        /// <param name="point"></param>
+        /// <returns>Returns U parameter for point on line</returns>
+        public double GetUValue(Vector3 point)
+        { 
+            if (!PointOnLine(point, true))
+                return -1;
+
+            var distance = Start.DistanceTo(point);
+
+            return distance / Length();
+        }
+
+        /// <summary>
         /// A list of vertices describing the arc for rendering.
         /// </summary>
         internal override IList<Vector3> RenderVertices()

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -601,3 +601,4 @@ namespace Elements.Geometry.Tests
             };
         }
     }
+}

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -542,5 +542,30 @@ namespace Elements.Geometry.Tests
             var secondLineWihNearZeroSum = new Line(new Vector3(-2, 2.00000001, 0), new Vector3(0, 0, 0));
             Assert.True(firstLineWihNearZeroSum.TryGetOverlap(secondLineWihNearZeroSum, out _));
         }
+
+        [Fact]
+        public void GetUValue()
+        {
+            var end = new Vector3(5, 5, 5);
+            var line = new Line(Vector3.Origin, end);
+
+            var start = Vector3.Origin;
+            Assert.Equal(0, line.GetUValue(start));
+
+            Assert.Equal(1, line.GetUValue(end));
+
+            var vectorOutsideLine = new Vector3(1, 2, 3);
+            Assert.False(line.PointOnLine(vectorOutsideLine, true));
+            Assert.Equal(-1, line.GetUValue(vectorOutsideLine));
+
+            var middle = new Vector3(2.5, 2.5, 2.5);
+            Assert.Equal(0.5, line.GetUValue(middle));
+
+            var vector = new Vector3(3.2, 3.2, 3.2);
+            var uValue = line.GetUValue(vector);
+            var expectedVector = line.PointAt(uValue);
+            Assert.InRange(uValue, 0, 1);
+            Assert.True(vector.IsAlmostEqualTo(expectedVector));
+        }
     }
 }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -550,19 +550,19 @@ namespace Elements.Geometry.Tests
             var line = new Line(Vector3.Origin, end);
 
             var start = Vector3.Origin;
-            Assert.Equal(0, line.GetUValue(start));
+            Assert.Equal(0, line.GetUParameter(start));
 
-            Assert.Equal(1, line.GetUValue(end));
+            Assert.Equal(1, line.GetUParameter(end));
 
             var vectorOutsideLine = new Vector3(1, 2, 3);
             Assert.False(line.PointOnLine(vectorOutsideLine, true));
-            Assert.Equal(-1, line.GetUValue(vectorOutsideLine));
+            Assert.Equal(-1, line.GetUParameter(vectorOutsideLine));
 
             var middle = new Vector3(2.5, 2.5, 2.5);
-            Assert.Equal(0.5, line.GetUValue(middle));
+            Assert.Equal(0.5, line.GetUParameter(middle));
 
             var vector = new Vector3(3.2, 3.2, 3.2);
-            var uValue = line.GetUValue(vector);
+            var uValue = line.GetUParameter(vector);
             var expectedVector = line.PointAt(uValue);
             Assert.InRange(uValue, 0, 1);
             Assert.True(vector.IsAlmostEqualTo(expectedVector));

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -544,25 +544,25 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
-        public void GetUValue()
+        public void GetParameterAt()
         {
             var end = new Vector3(5, 5, 5);
             var line = new Line(Vector3.Origin, end);
 
             var start = Vector3.Origin;
-            Assert.Equal(0, line.GetUParameter(start));
+            Assert.Equal(0, line.GetParameterAt(start));
 
-            Assert.Equal(1, line.GetUParameter(end));
+            Assert.Equal(1, line.GetParameterAt(end));
 
             var vectorOutsideLine = new Vector3(1, 2, 3);
             Assert.False(line.PointOnLine(vectorOutsideLine, true));
-            Assert.Equal(-1, line.GetUParameter(vectorOutsideLine));
+            Assert.Equal(-1, line.GetParameterAt(vectorOutsideLine));
 
             var middle = new Vector3(2.5, 2.5, 2.5);
-            Assert.Equal(0.5, line.GetUParameter(middle));
+            Assert.Equal(0.5, line.GetParameterAt(middle));
 
             var vector = new Vector3(3.2, 3.2, 3.2);
-            var uValue = line.GetUParameter(vector);
+            var uValue = line.GetParameterAt(vector);
             var expectedVector = line.PointAt(uValue);
             Assert.InRange(uValue, 0, 1);
             Assert.True(vector.IsAlmostEqualTo(expectedVector));

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -546,13 +546,21 @@ namespace Elements.Geometry.Tests
         [Fact]
         public void GetParameterAt()
         {
-            var end = new Vector3(5, 5, 5);
-            var line = new Line(Vector3.Origin, end);
-
             var start = Vector3.Origin;
+            var end = new Vector3(5, 5, 5);
+            var line = new Line(start, end);
+
             Assert.Equal(0, line.GetParameterAt(start));
 
+            var almostEqualStart = new Vector3(0.000001, 0.000005, 0);
+            Assert.True(start.IsAlmostEqualTo(almostEqualStart));
+            Assert.Equal(0, line.GetParameterAt(almostEqualStart));
+
             Assert.Equal(1, line.GetParameterAt(end));
+
+            var almostEqualEnd = new Vector3(5.0000005, 5.000001, 5);
+            Assert.True(end.IsAlmostEqualTo(almostEqualEnd));
+            Assert.Equal(1, line.GetParameterAt(almostEqualEnd));
 
             var vectorOutsideLine = new Vector3(1, 2, 3);
             Assert.False(line.PointOnLine(vectorOutsideLine, true));


### PR DESCRIPTION
BACKGROUND:
I found `GetUParameter()` method useful and missing in `Line` class. 

DESCRIPTION:
`GetuUParameter` checks if point is on line. If not it returns -1, otherwise it returns U parameter.

TESTING:
Run unit tests 
  
FUTURE WORK:
None

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/809)
<!-- Reviewable:end -->
