### PR TITLE
Line merge collinear line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `EdgeDisplaySettings` for materials to control the display of lines in supported viewers (like Hypar.io).
+- `Line.MergeCollinearLine(Line line)` creates new line containing all four collinear vertices 
 
 ### Changed
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1054,7 +1054,9 @@ namespace Elements.Geometry
         public Line MergedCollinearLine(Line line)
         {
             if (!IsCollinear(line))
+            {
                 throw new ArgumentException("Lines needs to be collinear");
+            }
 
             //order vertices of lines
             var vectors = new List<Vector3>() { Start, End, line.Start, line.End };

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1046,10 +1046,10 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Creates new line with verticies of current and joined line
+        /// Creates new line with vertices of current and joined line
         /// </summary>
         /// <param name="line">Collinear line</param>
-        /// <returns>New line containing verticies of all merged lines</returns>
+        /// <returns>New line containing vertices of all merged lines</returns>
         /// <exception cref="ArgumentException">Throws exception when lines are not collinear</exception>
         public Line MergeCollinearLine(Line line)
         {

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1046,6 +1046,30 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Creates new line with verticies of current and joined line
+        /// </summary>
+        /// <param name="line">Collinear line</param>
+        /// <returns>New line containing verticies of all merged lines</returns>
+        /// <exception cref="ArgumentException">Throws exception when lines are not collinear</exception>
+        public Line MergeCollinearLine(Line line)
+        {
+            if (!IsCollinear(line))
+                throw new ArgumentException("Lines needs to be collinear");
+
+            //order vertices of lines
+            var vectors = new List<Vector3>() { Start, End, line.Start, line.End };
+            var direction = Direction();
+            var orderedVectors = vectors.OrderBy(v => (v - Start).Dot(direction)).ToList();
+
+            var joinedLine = new Line(orderedVectors.First(), orderedVectors.Last());
+
+            //keep the same direction as original line
+            return joinedLine.Direction().IsAlmostEqualTo(Direction())
+                ? joinedLine
+                : joinedLine.Reversed();
+        }
+
+        /// <summary>
         /// A list of vertices describing the arc for rendering.
         /// </summary>
         internal override IList<Vector3> RenderVertices()

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1051,7 +1051,7 @@ namespace Elements.Geometry
         /// <param name="line">Collinear line</param>
         /// <returns>New line containing vertices of all merged lines</returns>
         /// <exception cref="ArgumentException">Throws exception when lines are not collinear</exception>
-        public Line MergeCollinearLine(Line line)
+        public Line MergedCollinearLine(Line line)
         {
             if (!IsCollinear(line))
                 throw new ArgumentException("Lines needs to be collinear");

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -544,15 +544,15 @@ namespace Elements.Geometry.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MergeCollinearLineData))]
-        public void MergeCollinearLine(Line line, Line lineToMerge, Line expectedResult)
+        [MemberData(nameof(MergedCollinearLineData))]
+        public void MergedCollinearLine(Line line, Line lineToMerge, Line expectedResult)
         {
-            var result = line.MergeCollinearLine(lineToMerge);
+            var result = line.MergedCollinearLine(lineToMerge);
             Assert.True(expectedResult.IsAlmostEqualTo(result, true));
             Assert.True(line.Direction().IsAlmostEqualTo(result.Direction()));
         }
 
-        public static IEnumerable<object[]> MergeCollinearLineData()
+        public static IEnumerable<object[]> MergedCollinearLineData()
         {
             var start = Vector3.Origin;
             var end = new Vector3(5, 5, 5);
@@ -571,11 +571,11 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
-        public void MergeCollinearLineThrowsException()
+        public void MergedCollinearLineThrowsException()
         {
             var line = new Line(Vector3.Origin, new Vector3(5, 5, 5));
             var nonCollinearLine = new Line(new Vector3(-5, 5, 5), new Vector3(10, 10, -5));
-            Assert.Throws<ArgumentException>(() => line.MergeCollinearLine(nonCollinearLine));
+            Assert.Throws<ArgumentException>(() => line.MergedCollinearLine(nonCollinearLine));
         }
     }
 }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -542,5 +542,40 @@ namespace Elements.Geometry.Tests
             var secondLineWihNearZeroSum = new Line(new Vector3(-2, 2.00000001, 0), new Vector3(0, 0, 0));
             Assert.True(firstLineWihNearZeroSum.TryGetOverlap(secondLineWihNearZeroSum, out _));
         }
+
+        [Theory]
+        [MemberData(nameof(MergeCollinearLineData))]
+        public void MergeCollinearLine(Line line, Line lineToMerge, Line expectedResult)
+        {
+            var result = line.MergeCollinearLine(lineToMerge);
+            Assert.True(expectedResult.IsAlmostEqualTo(result, true));
+            Assert.True(line.Direction().IsAlmostEqualTo(result.Direction()));
+        }
+
+        public static IEnumerable<object[]> MergeCollinearLineData()
+        {
+            var start = Vector3.Origin;
+            var end = new Vector3(5, 5, 5);
+            var line = new Line(start, end);
+            return new List<object[]>
+            {
+                new object[] {line, new Line(new Vector3(10, 10, 10), end), new Line(start, new Vector3(10, 10, 10))},
+                new object[] {line, new Line(start, new Vector3(-10, -10, -10)), new Line(new Vector3( -10, -10, -10), end)},
+                new object[] {line, new Line(new Vector3(10, 10, 10), new Vector3(20, 20, 20)), new Line(start, new Vector3(20, 20, 20))},
+                new object[] {line, line, line},
+                new object[] {line, new Line(new Vector3(2, 2, 2), new Vector3(-10, -10, -10)), new Line(new Vector3( -10, -10, -10), end)},
+                new object[] {line, new Line(start, new Vector3(5, 5.00000000001, 5)), line},
+                new object[] {line, new Line(new Vector3(2, 2, 2), new Vector3(-10, -10, -10)), new Line(new Vector3( -10, -10, -10), end)},
+                new object[] {new Line(new Vector3(-3, 3, 0), new Vector3(-1, 1.00000002, 0)), new Line(new Vector3(-2, 2.00000001, 0), Vector3.Origin), new Line(new Vector3(-3, 3, 0), Vector3.Origin)}
+            };
+        }
+
+        [Fact]
+        public void MergeCollinearLineThrowsException()
+        {
+            var line = new Line(Vector3.Origin, new Vector3(5, 5, 5));
+            var nonCollinearLine = new Line(new Vector3(-5, 5, 5), new Vector3(10, 10, -5));
+            Assert.Throws<ArgumentException>(() => line.MergeCollinearLine(nonCollinearLine));
+        }
     }
 }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -548,7 +548,6 @@ namespace Elements.Geometry.Tests
         }
 
         [Theory]
-
         [MemberData(nameof(MergedCollinearLineData))]
         public void MergedCollinearLine(Line line, Line lineToMerge, Line expectedResult)
         {
@@ -583,6 +582,7 @@ namespace Elements.Geometry.Tests
             Assert.Throws<ArgumentException>(() => line.MergedCollinearLine(nonCollinearLine));
         }
 
+        [Theory]
         [MemberData(nameof(ProjectedData))]
         public void Projected(Line line, Plane plane, Line expectedLine)
         {


### PR DESCRIPTION
BACKGROUND:
I found `MergeCollinearLine(Line line)` method useful and missing in `Line` class 

DESCRIPTION:
Method `MergeCollinearLine(Line line)` takes all 4 vertices of two lines, sort them and creates line which contains all of them. Finally it keeps direction of original line.

TESTING:
Since there are many similarities to `TryGetOverlap(....)` method I reused unit test cases.  
  
FUTURE WORK:
None

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/810)
<!-- Reviewable:end -->
