### PR TITLE
Add Project method to Line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - `EdgeDisplaySettings` for materials to control the display of lines in supported viewers (like Hypar.io).
-- `Line.Project(Plane plane)` create new line projected onto plane
+- `Line.Projected(Plane plane)` create new line projected onto plane
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `EdgeDisplaySettings` for materials to control the display of lines in supported viewers (like Hypar.io).
+- `Line.Project(Plane plane)` create new line projected onto plane
 
 ### Changed
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1046,6 +1046,18 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Projects current line onto a plane
+        /// </summary>
+        /// <param name="plane">Plane to project</param>
+        /// <returns>New line on a plane</returns>
+        public Line Project(Plane plane)
+        {
+            var start = Start.Project(plane);
+            var end = End.Project(plane);
+            return new Line(start, end);
+        }
+
+        /// <summary>
         /// A list of vertices describing the arc for rendering.
         /// </summary>
         internal override IList<Vector3> RenderVertices()

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1050,7 +1050,7 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="plane">Plane to project</param>
         /// <returns>New line on a plane</returns>
-        public Line Project(Plane plane)
+        public Line Projected(Plane plane)
         {
             var start = Start.Project(plane);
             var end = End.Project(plane);

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -542,5 +542,25 @@ namespace Elements.Geometry.Tests
             var secondLineWihNearZeroSum = new Line(new Vector3(-2, 2.00000001, 0), new Vector3(0, 0, 0));
             Assert.True(firstLineWihNearZeroSum.TryGetOverlap(secondLineWihNearZeroSum, out _));
         }
+
+        [Theory]
+        [MemberData(nameof(ProjectData))]
+        public void Project(Line line, Plane plane, Line expectedLine)
+        {
+            var result = line.Project(plane);
+            Assert.Equal(expectedLine, result);
+        }
+
+        public static IEnumerable<object[]> ProjectData()
+        {
+            var line = new Line(Vector3.Origin, new Vector3(5, 5, 5));
+            return new List<object[]>
+            {
+                new object[] {line, new Plane(Vector3.Origin, Vector3.ZAxis), new Line(Vector3.Origin, new Vector3(5, 5, 0))},
+                new object[] {line, new Plane(Vector3.Origin, Vector3.XAxis), new Line(Vector3.Origin, new Vector3(0, 5, 5))},
+                new object[] {line, new Plane(new Vector3(2, 2, 2), Vector3.YAxis), new Line(new Vector3(0, 2, 0), new Vector3(5, 2, 5))},
+                new object[] {new Line(Vector3.Origin, new Vector3(0, 5, 5)), new Plane(Vector3.Origin, Vector3.XAxis), new Line(Vector3.Origin, new Vector3(0, 5, 5))},
+            };
+        }
     }
 }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -544,14 +544,14 @@ namespace Elements.Geometry.Tests
         }
 
         [Theory]
-        [MemberData(nameof(ProjectData))]
-        public void Project(Line line, Plane plane, Line expectedLine)
+        [MemberData(nameof(ProjectedData))]
+        public void Projected(Line line, Plane plane, Line expectedLine)
         {
-            var result = line.Project(plane);
+            var result = line.Projected(plane);
             Assert.Equal(expectedLine, result);
         }
 
-        public static IEnumerable<object[]> ProjectData()
+        public static IEnumerable<object[]> ProjectedData()
         {
             var line = new Line(Vector3.Origin, new Vector3(5, 5, 5));
             return new List<object[]>


### PR DESCRIPTION
BACKGROUND:
I found `Line.Projected(Plane plane)` useful and missing in `Line` class

DESCRIPTION:
Method `Line.Projected(Plane plane)`  projects `Start` and `End` vectors onto `Plane`. After that it creates new `Line` with projected vectors.

TESTING:
Run unit tests 
  
FUTURE WORK:
None 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/811)
<!-- Reviewable:end -->
