### PR TITLE
Loaded types

### DIFF
--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -238,7 +238,7 @@ namespace Elements.Generate
                 try
                 {
                     var schema = await GetSchemaAsync(uri);
-                    var csharpFileContents = GenerateCSharpCodeForSchema(schema);
+                    var csharpFileContents = GenerateCSharpCodeForSchemaExcludingLoadedTypes(schema);
                     foreach (var csharp in csharpFileContents)
                     {
                         if (code.ContainsKey(csharp.Key))
@@ -303,7 +303,7 @@ namespace Elements.Generate
                 try
                 {
                     var schema = await GetSchemaAsync(uri);
-                    var csharpFileContents = GenerateCSharpCodeForSchema(schema);
+                    var csharpFileContents = GenerateCSharpCodeForSchemaExcludingLoadedTypes(schema);
                     foreach (var csharp in csharpFileContents)
                     {
                         if (code.ContainsKey(csharp.Key))
@@ -584,7 +584,7 @@ namespace Elements.Generate
         /// <returns>Returns true if the dll was generated successfully, otherwise false.</returns>
         public static bool GenerateAndSaveDllForSchema(JsonSchema schema, string dllPath, out string[] diagnosticResults, bool frameworkBuild = false)
         {
-            var csharpFileContents = GenerateCSharpCodeForSchema(schema);
+            var csharpFileContents = GenerateCSharpCodeForSchemaExcludingLoadedTypes(schema);
             if (csharpFileContents == null)
             {
                 diagnosticResults = new string[] { };
@@ -594,7 +594,7 @@ namespace Elements.Generate
             return TryEmitAndSave(compilation, dllPath, out diagnosticResults);
         }
 
-        private static Dictionary<string, string> GenerateCSharpCodeForSchema(JsonSchema schema)
+        private static Dictionary<string, string> GenerateCSharpCodeForSchemaExcludingLoadedTypes(JsonSchema schema)
         {
             string ns;
             if (!GetNamespace(schema, out ns))

--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -608,7 +608,7 @@ namespace Elements.Generate
             {
                 return new Dictionary<string, string>();
             }
-            var localExcludes = _coreTypeNames.Where(n => n != typeName).ToArray();
+            var localExcludes = loadedTypes.Union(_coreTypeNames).Distinct().Where(n => n != typeName).ToArray();
 
             return GetCodeForTypesFromSchema(schema, typeName, ns, localExcludes);
         }

--- a/Elements.Serialization.IFC/src/Serialization/IFC/IFCElementExtensions.cs
+++ b/Elements.Serialization.IFC/src/Serialization/IFC/IFCElementExtensions.cs
@@ -17,7 +17,8 @@ namespace Elements.Serialization.IFC
         internal static List<IfcProduct> ToIfcProducts(this Element e,
                                                        IfcRepresentationContext context,
                                                        Document doc,
-                                                       Dictionary<Guid, List<IfcStyleAssignmentSelect>> styleAssignments)
+                                                       Dictionary<Guid, List<IfcStyleAssignmentSelect>> styleAssignments,
+                                                       bool updateElementRepresentation = true)
         {
             var products = new List<IfcProduct>();
 
@@ -44,7 +45,10 @@ namespace Elements.Serialization.IFC
                 trans = geoElement.Transform;
             }
 
-            geoElement.UpdateRepresentations();
+            if (updateElementRepresentation)
+            {
+                geoElement.UpdateRepresentations();
+            }
 
             var localPlacement = trans.ToIfcLocalPlacement(doc);
             doc.AddEntity(localPlacement);

--- a/Elements.Serialization.IFC/src/Serialization/IFC/IFCModelExtensions.cs
+++ b/Elements.Serialization.IFC/src/Serialization/IFC/IFCModelExtensions.cs
@@ -147,7 +147,8 @@ namespace Elements.Serialization.IFC
         /// </summary>
         /// <param name="model"></param>
         /// <param name="path">The path to the generated IFC STEP file.</param>
-        public static void ToIFC(this Model model, string path)
+        /// <param name="updateElementsRepresentation">Indicates whether UpdateRepresentation should be called for all elements.</param>
+        public static void ToIFC(this Model model, string path, bool updateElementsRepresentation = true)
         {
             var ifc = new Document("Elements", "Elements", Environment.UserName,
                                     null, null, null, "Elements", null, null,
@@ -258,7 +259,7 @@ namespace Elements.Serialization.IFC
             {
                 try
                 {
-                    products.AddRange(e.ToIfcProducts(context, ifc, styleAssignments));
+                    products.AddRange(e.ToIfcProducts(context, ifc, styleAssignments, updateElementsRepresentation));
                 }
                 catch (Exception ex)
                 {

--- a/Elements/src/Floor.cs
+++ b/Elements/src/Floor.cs
@@ -115,10 +115,8 @@ namespace Elements
         /// </summary>
         public override void UpdateRepresentations()
         {
-            if (this.Representation.SolidOperations.Count == 0)
-            {
-                this.Representation.SolidOperations.Add(new Extrude(this.Profile, this.Thickness, Vector3.ZAxis, false));
-            }
+            this.Representation.SolidOperations.Clear();
+            this.Representation.SolidOperations.Add(new Extrude(this.Profile, this.Thickness, Vector3.ZAxis, false));
         }
 
         /// <summary>

--- a/Elements/src/Floor.cs
+++ b/Elements/src/Floor.cs
@@ -115,8 +115,10 @@ namespace Elements
         /// </summary>
         public override void UpdateRepresentations()
         {
-            this.Representation.SolidOperations.Clear();
-            this.Representation.SolidOperations.Add(new Extrude(this.Profile, this.Thickness, Vector3.ZAxis, false));
+            if (this.Representation.SolidOperations.Count == 0)
+            {
+                this.Representation.SolidOperations.Add(new Extrude(this.Profile, this.Thickness, Vector3.ZAxis, false));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
BACKGROUND:
New types that are inherited from Floor or some other types are exported to the IFC as Objects and are not recognized as Floor or Beam elements. The issue is that during json deserialization inside Exporter class, Exporter generates new classes from schema (e.g. FloorPanal) without inheritance from the Floor class 

DESCRIPTION:
- This PR includes all locally loaded types to the CSharpGeneratorSettings.ExcludedTypeNames. That allows to create proper inheritance. 

TESTING:
I tried:
 - generate IFC
 - CLI init command

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/815)
<!-- Reviewable:end -->
