### PR TITLE
 `AdaptiveGraphRouting` how recognizes edges as affected by hint line…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.0.2
+
+### Changed
+
+- `AdaptiveGraphRouting` how recognizes edges as affected by hint line of the same direction if part of it is close enough.
+
+### Fixed
+
+- `Profile.Split` would sometimes fail if the profile being split contained voids.
+
 ## 1.0.1
 
 ### Fixed
@@ -14,7 +24,6 @@
 - `Line.GetUParameter(Vector 3)` - calculate U parameter for point on line
 - `Line.MergeCollinearLine(Line line)` creates new line containing all four collinear vertices
 - `Line.Projected(Plane plane)` create new line projected onto plane
-- `Profile.Split` would sometimes fail if the profile being split contained voids.
 
 ### Changed
 


### PR DESCRIPTION
… of the same direction if part of it is close enough.

BACKGROUND:
- Sometimes hint lines of AdaptiveGraphRouting covers only part of the edge.  It was decided that in this case the edge should be also considered as Affected.

DESCRIPTION:
- Reworked AdaptiveGraphRouting.IsAffected to check if any segment of hint line overlaps an edge.
  
FUTURE WORK:
- Hint line logic may change if support of 3D hint lines is added.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

NOTES:
- Move `Profile.Split` changenote into 1.0.2 section as it was done after 1.0.1 is already released.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/818)
<!-- Reviewable:end -->
