### PR TITLE
Overlay materials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.0.2
 
+### Added
+- `Material` now supports a `DrawInFront` property.
+
 ### Changed
 
 - `AdaptiveGraphRouting` how recognizes edges as affected by hint line of the same direction if part of it is close enough.

--- a/Elements/src/Material.cs
+++ b/Elements/src/Material.cs
@@ -65,6 +65,12 @@ namespace Elements
         public double EmissiveFactor { get; set; }
 
         /// <summary>
+        /// Should objects with this material be drawn in front of all other objects?
+        /// </summary>
+        [JsonProperty("Draw In Front")]
+        public bool DrawInFront { get; set; } = false;
+
+        /// <summary>
         /// If provided, this controls how curves and lines will be drawn in the 3D view for supported viewers. This will not affect mesh / solid-based elements.
         /// </summary>
         public EdgeDisplaySettings EdgeDisplaySettings { get; set; } = null;

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -86,7 +86,7 @@ namespace Elements.Serialization.glTF
                     if (SaveGlb(model, path, out errors, drawEdges))
                     {
                         return;
-                }
+                    }
                     // Else fall through to produce an empty GLTF.
                 }
                 else
@@ -229,17 +229,16 @@ namespace Elements.Serialization.glTF
 
                 if (material.EdgeDisplaySettings != null)
                 {
-                    if (gltfMaterial.Extensions == null)
-                    {
-                        gltfMaterial.Extensions = new Dictionary<string, object>();
-                    }
-                    if (!gltf.ExtensionsUsed.Contains("HYPAR_materials_edge_settings"))
-                    {
-                        gltf.ExtensionsUsed = new List<string>(gltf.ExtensionsUsed) { "HYPAR_materials_edge_settings" }.ToArray();
-                    }
-                    gltfMaterial.Extensions.Add("HYPAR_materials_edge_settings", new Dictionary<string, object>{
+                    AddExtension(gltf, gltfMaterial, "HYPAR_materials_edge_settings", new Dictionary<string, object>{
                         {"lineWidth", material.EdgeDisplaySettings.LineWidth},
                         {"widthMode", (int)material.EdgeDisplaySettings.WidthMode},
+                    });
+                }
+
+                if (material.DrawInFront)
+                {
+                    AddExtension(gltf, gltfMaterial, "HYPAR_draw_in_front", new Dictionary<string, object>{
+                        {"drawInFront", true},
                     });
                 }
 
@@ -386,6 +385,19 @@ namespace Elements.Serialization.glTF
             }
 
             return materialDict;
+        }
+
+        private static void AddExtension(Gltf gltf, glTFLoader.Schema.Material gltfMaterial, string extensionName, Dictionary<string, object> extensionAttributes)
+        {
+            if (gltfMaterial.Extensions == null)
+            {
+                gltfMaterial.Extensions = new Dictionary<string, object>();
+            }
+            if (!gltf.ExtensionsUsed.Contains(extensionName))
+            {
+                gltf.ExtensionsUsed = new List<string>(gltf.ExtensionsUsed) { extensionName }.ToArray();
+            }
+            gltfMaterial.Extensions.Add(extensionName, extensionAttributes);
         }
 
         private static Image CreateImage(string path, List<BufferView> bufferViews, List<byte> buffer, out bool textureHasTransparency)


### PR DESCRIPTION
BACKGROUND:
- Some applications — specifically image overlays/underlays for tracing — can be tricky to work with if they're fighting with / obscured by other geometry

DESCRIPTION:
- Adds support for gltf extension-formatted metadata on material which tells the hypar web application (and any other client that wants to support it) to draw certain geometry / materials in front of the rest. 

TESTING:
- I tested this on the Image Reference function, along with the corresponding hypar front-end PR. https://github.com/hypar-io/Explore/pull/2258

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.
