### PR TITLE
More fast AreCollinear from private section of AdaptiveGridRouting. Add infinite to Line.Trim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 
 - `AdaptiveGraphRouting` how recognizes edges as affected by hint line of the same direction if part of it is close enough.
+- `Vector3.AreCollinear` are renamed into `Vector3.AreCollinearByDistance` and added `tolerance` parameter.
+- `Line.Trim` - added `infinite` for the cases when line needs to be treated as infinite.
 
 ### Fixed
 
@@ -17,6 +19,8 @@
 - `LinearDimension`
 - `AlignedDimension`
 - `ContinuousDimension`
+- `Vector3.AreCollinearByAngle(Vector3 a, Vector3 b, Vector3 c, double tolerance)`
+
 
 ### Fixed
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -838,7 +838,7 @@ namespace Elements.Geometry
         /// <param name="polygon">The polygon to trim with.</param>
         /// <param name="outsideSegments">A list of the segment(s) of the line outside of the supplied polygon.</param>
         /// <param name="includeCoincidenceAtEdge">Include coincidence at edge as inner segment.</param>
-        /// <param name="infinite"></param>
+        /// <param name="infinite">Treat the line as infinite?</param>
         /// <returns>A list of the segment(s) of the line within the supplied polygon.</returns>
         public List<Line> Trim(Polygon polygon, out List<Line> outsideSegments, bool includeCoincidenceAtEdge = false, bool infinite = false)
         {

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -1955,16 +1955,16 @@ namespace Elements.Geometry
             int count = this.Vertices.Count;
             var unique = new List<Vector3>(count);
 
-            if (!Vector3.AreCollinear(Vertices[count - 1], Vertices[0], Vertices[1]))
+            if (!Vector3.AreCollinearByDistance(Vertices[count - 1], Vertices[0], Vertices[1]))
                 unique.Add(Vertices[0]);
 
             for (int i = 1; i < count - 1; i++)
             {
-                if (!Vector3.AreCollinear(Vertices[i - 1], Vertices[i], Vertices[i + 1]))
+                if (!Vector3.AreCollinearByDistance(Vertices[i - 1], Vertices[i], Vertices[i + 1]))
                     unique.Add(Vertices[i]);
             }
 
-            if (!Vector3.AreCollinear(Vertices[count - 2], Vertices[count - 1], Vertices[0]))
+            if (!Vector3.AreCollinearByDistance(Vertices[count - 2], Vertices[count - 1], Vertices[0]))
                 unique.Add(Vertices[count - 1]);
 
             return new Polygon(unique);

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -294,7 +294,7 @@ namespace Elements.Geometry
 
             // At the first point, use either the next non-collinear edge or a cardinal direction to choose a normal.
             var previousDirection = new Vector3();
-            if (Vector3Extensions.AreCollinear(this.Vertices))
+            if (Vector3Extensions.AreCollinearByDistance(this.Vertices))
             {
                 // If the polyline is collinear, use whichever cardinal direction isn't collinear with it.
                 if (Math.Abs(nextDirection.Dot(Vector3.YAxis)) < 1 - Vector3.EPSILON)

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -819,14 +819,14 @@ namespace Elements.Geometry
         /// <param name="a">The first point.</param>
         /// <param name="b">The second point.</param>
         /// <param name="c">The third point.</param>
-        /// <returns>Greater than 0 if the points are CCW, less than 0 if they are CW, and 0 if they are colinear.</returns>
+        /// <returns>Greater than 0 if the points are CCW, less than 0 if they are CW, and 0 if they are collinear.</returns>
         public static double CCW(Vector3 a, Vector3 b, Vector3 c)
         {
             return (b.X - a.X) * (c.Y - a.Y) - (c.X - a.X) * (b.Y - a.Y);
         }
 
         /// <summary>
-        /// Check whether three points are on the same line withing certain distance.
+        /// Check whether three points are on the same line within certain distance.
         /// </summary>
         /// <param name="a">The first point.</param>
         /// <param name="b">The second point.</param>
@@ -840,7 +840,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Check whether three points are on the same line withing certain angle.
+        /// Check whether three points are on the same line within certain angle.
         /// Order is important since unsigned abc angle is checked.
         /// This function is much faster than AreCollinearByDistance but angle deviation 
         /// accumulates distance deviation and, if points are far away, position differences are noticeable.

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -15,6 +15,11 @@ namespace Elements.Geometry
         /// </summary>
         public const double EPSILON = 1e-5;
 
+        /// <summary>
+        /// A tolerance for angle comparison operation of cos of 0.001 degrees.
+        /// </summary>
+        public const double COS_ANGLE_EPSILON = 0.99999999984769128;
+
         private static Vector3 _xAxis = new Vector3(1, 0, 0);
         private static Vector3 _yAxis = new Vector3(0, 1, 0);
         private static Vector3 _zAxis = new Vector3(0, 0, 1);
@@ -821,16 +826,57 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Check whether three points are on the same line.
+        /// Check whether three points are on the same line withing certain distance.
         /// </summary>
         /// <param name="a">The first point.</param>
         /// <param name="b">The second point.</param>
         /// <param name="c">The third point.</param>
+        /// <param name="tolerance">Distance tolerance.</param>
         /// <returns>True if the points are on the same line, false otherwise.</returns>
-        public static bool AreCollinear(Vector3 a, Vector3 b, Vector3 c)
+        public static bool AreCollinearByDistance(Vector3 a, Vector3 b, Vector3 c, double tolerance = Vector3.EPSILON) 
         {
             var vectorList = new List<Vector3> { a, b, c };
-            return vectorList.AreCollinear();
+            return vectorList.AreCollinearByDistance(tolerance);
+        }
+
+        /// <summary>
+        /// Check whether three points are on the same line withing certain angle.
+        /// Order is important since unsigned abc angle is checked.
+        /// This function is much faster than AreCollinearByDistance but angle deviation 
+        /// accumulates distance deviation and, if points are far away, position differences are noticeable.
+        /// </summary>
+        /// <param name="a">The first point.</param>
+        /// <param name="b">The second point.</param>
+        /// <param name="c">The third point.</param>
+        /// <param name="tolerance">Angle tolerance as cos.</param>
+        /// <returns></returns>
+        public static bool AreCollinearByAngle(Vector3 a, Vector3 b, Vector3 c, double tolerance = Vector3.COS_ANGLE_EPSILON)
+        {
+            var baX = b.X - a.X;
+            var baY = b.Y - a.Y;
+            var baZ = b.Z - a.Z;
+            var baLength = Math.Sqrt(Math.Pow(baX, 2) + Math.Pow(baY, 2) + Math.Pow(baZ, 2));
+            if (baLength < Vector3.EPSILON)
+            {
+                return true;
+            }
+            baX = baX / baLength;
+            baY = baY / baLength;
+            baZ = baZ / baLength;
+
+            var cbX = c.X - b.X;
+            var cbY = c.Y - b.Y;
+            var cbZ = c.Z - b.Z;
+            var cbLength = Math.Sqrt(Math.Pow(cbX, 2) + Math.Pow(cbY, 2) + Math.Pow(cbZ, 2));
+            if (cbLength < Vector3.EPSILON)
+            {
+                return true;
+            }
+            cbX = cbX / cbLength;
+            cbY = cbY / cbLength;
+            cbZ = cbZ / cbLength;
+
+            return Math.Abs(baX * cbX + baY * cbY + baZ * cbZ) > tolerance;
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Vector3Extensions.cs
+++ b/Elements/src/Geometry/Vector3Extensions.cs
@@ -39,10 +39,11 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Are the provided points along the same line?
+        /// Check whether three points are on the same line withing certain distance.
         /// </summary>
-        /// <param name="points"></param>
-        public static bool AreCollinear(this IList<Vector3> points)
+        /// <param name="points">List of points to check. Order is not important.</param>
+        /// <param name="tolerance">Distance tolerance.</param>
+        public static bool AreCollinearByDistance(this IList<Vector3> points, double tolerance = Vector3.EPSILON)
         {
             if (points == null || points.Count == 0)
             {
@@ -56,12 +57,15 @@ namespace Elements.Geometry
                 return true;
             }
             var fitDir = fitLine.Direction();
-            var epsilonSquared = Vector3.EPSILON * Vector3.EPSILON;
+            var toleranceSquared = tolerance * tolerance;
             return directions.All(d =>
             {
+                // Since fitDir is Unitized - dot give the length of projection d onto fitDir.
                 var dot = d.Dot(fitDir);
                 var lengthSquared = d.LengthSquared();
-                return lengthSquared - (dot * dot) < epsilonSquared;
+                // By Pythagoras' theorem d.Length()^2 = dot^2 + distance^2. 
+                // if it's less than tolerance squared - point is close enough to the fit line.
+                return lengthSquared - (dot * dot) < toleranceSquared;
             });
         }
 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -917,7 +917,7 @@ namespace Elements.Spatial.AdaptiveGrid
                     if (u == start)
                     {
                         if (startDirection.HasValue &&
-                            !AreCollinearInplace(_grid.GetVertex(startDirection.Value).Point, vertex.Point, v.Point))
+                            !Vector3.AreCollinearByAngle(_grid.GetVertex(startDirection.Value).Point, vertex.Point, v.Point))
                         {
                             newWeight += CalculateTurnCost(edgeWeight.Factor, vertex, startDirection.Value, edgeWeights);
                         }
@@ -925,13 +925,13 @@ namespace Elements.Spatial.AdaptiveGrid
                     else
                     {
                         var vertexBefore = _grid.GetVertex(path[u]);
-                        if (!AreCollinearInplace(vertexBefore.Point, vertex.Point, v.Point))
+                        if (!Vector3.AreCollinearByAngle(vertexBefore.Point, vertex.Point, v.Point))
                         {
                             newWeight += CalculateTurnCost(edgeWeight.Factor, vertex, vertexBefore.Id, edgeWeights);
                         }
                         if (pathDirections != null &&
                             pathDirections.TryGetValue(v.Id, out var vertexAfter) && vertexAfter.HasValue &&
-                            !AreCollinearInplace(vertex.Point, v.Point, _grid.GetVertex(vertexAfter.Value).Point))
+                            !Vector3.AreCollinearByAngle(vertex.Point, v.Point, _grid.GetVertex(vertexAfter.Value).Point))
                         {
                             newWeight += CalculateTurnCost(edgeWeight.Factor, v, vertexAfter.Value, edgeWeights);
                         }
@@ -1017,7 +1017,7 @@ namespace Elements.Spatial.AdaptiveGrid
                     if (u == start)
                     {
                         if (startDirection.HasValue &&
-                            !AreCollinearInplace(_grid.GetVertex(startDirection.Value).Point, vertex.Point, v.Point))
+                            !Vector3.AreCollinearByAngle(_grid.GetVertex(startDirection.Value).Point, vertex.Point, v.Point))
                         {
                             newWeight += CalculateTurnCost(edgeWeight.Factor, vertex, startDirection.Value, edgeWeights);
                         }
@@ -1028,7 +1028,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         //Add turn cost if the direction is changed.
                         var before = path[u];
                         var leftBefore = _grid.GetVertex(before.Item1.Item1);
-                        var leftCollinear = AreCollinearInplace(leftBefore.Point, vertex.Point, v.Point);
+                        var leftCollinear = Vector3.AreCollinearByAngle(leftBefore.Point, vertex.Point, v.Point);
                         var leftCost = cost.Item1 + newWeight;
                         if (!leftCollinear)
                         {
@@ -1041,7 +1041,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         {
                             var rigthBefore = _grid.GetVertex(before.Item2.Item1);
                             rigthCost = cost.Item2 + newWeight;
-                            if (!AreCollinearInplace(rigthBefore.Point, vertex.Point, v.Point))
+                            if (!Vector3.AreCollinearByAngle(rigthBefore.Point, vertex.Point, v.Point))
                             {
                                 rigthCost += CalculateTurnCost(
                                     edgeWeight.Factor, vertex, rigthBefore.Id, edgeWeights);
@@ -1375,7 +1375,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         if (before1 != 0)
                         {
                             var beforeV1 = _grid.GetVertex(before.Item1.Item1);
-                            if (!AreCollinearInplace(beforeV1.Point, activeV.Point, nextV.Point))
+                            if (!Vector3.AreCollinearByAngle(beforeV1.Point, activeV.Point, nextV.Point))
                             {
                                 var edge = activeV.Edges.Where(
                                     e => e.StartId == beforeV1.Id || e.EndId == beforeV1.Id).First();
@@ -1387,7 +1387,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         if (before2 != 0)
                         {
                             var beforeV2 = _grid.GetVertex(before.Item2.Item1);
-                            if (!AreCollinearInplace(beforeV2.Point, activeV.Point, nextV.Point))
+                            if (!Vector3.AreCollinearByAngle(beforeV2.Point, activeV.Point, nextV.Point))
                             {
                                 var edge = activeV.Edges.Where(
                                     e => e.StartId == beforeV2.Id || e.EndId == beforeV2.Id).First();
@@ -1428,36 +1428,6 @@ namespace Elements.Spatial.AdaptiveGrid
                 Compare(v, travelCost, ref bestCost, ref bestIndex);
             }
             return bestIndex;
-        }
-
-        //This is the same as Vector3.AreCollinear but avoiding all expensive validations.
-        private bool AreCollinearInplace(Vector3 a, Vector3 b, Vector3 c)
-        {
-            var baX = b.X - a.X;
-            var baY = b.Y - a.Y;
-            var baZ = b.Z - a.Z;
-            var baLength = Math.Sqrt(Math.Pow(baX, 2) + Math.Pow(baY, 2) + Math.Pow(baZ, 2));
-            if (baLength < Vector3.EPSILON)
-            {
-                return true;
-            }
-            baX = baX / baLength;
-            baY = baY / baLength;
-            baZ = baZ / baLength;
-
-            var cbX = c.X - b.X;
-            var cbY = c.Y - b.Y;
-            var cbZ = c.Z - b.Z;
-            var cbLength = Math.Sqrt(Math.Pow(cbX, 2) + Math.Pow(cbY, 2) + Math.Pow(cbZ, 2));
-            if (cbLength < Vector3.EPSILON)
-            {
-                return true;
-            }
-            cbX = cbX / cbLength;
-            cbY = cbY / cbLength;
-            cbZ = cbZ / cbLength;
-
-            return Math.Abs(baX * cbX + baY * cbY + baZ * cbZ) > (1 - Vector3.EPSILON);
         }
 
         private void CombinePath(List<ulong> mainPath, List<ulong> newPortion)

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -287,6 +287,40 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
+        public void LineTrimWithPolygonInfinite()
+        {
+            var polygon = new Polygon(new[]
+            {
+                new Vector3(0, 0),
+                new Vector3(0, 5),
+                new Vector3(2, 5),
+                new Vector3(2, 2),
+                new Vector3(3, 3),
+                new Vector3(4, 2),
+                new Vector3(4, 5),
+                new Vector3(6, 5),
+                new Vector3(6, 0)
+            });
+
+            var line = new Line(new Vector3(10, 3), new Vector3(8, 3));
+            var inside = line.Trim(polygon, out var outside, infinite: true);
+            Assert.Equal(2, inside.Count);
+            // Sorted in line direction.
+            Assert.Equal(new Vector3(6, 3), inside[0].Start);
+            Assert.Equal(new Vector3(4, 3), inside[0].End);
+            Assert.Equal(new Vector3(2, 3), inside[1].Start);
+            Assert.Equal(new Vector3(0, 3), inside[1].End);
+
+            // (3; 3) point splits outside point into two segments.
+            // Outer outside segments are discarded when infinite is false.
+            Assert.Equal(2, outside.Count);
+            Assert.Equal(new Vector3(4, 3), outside[0].Start);
+            Assert.Equal(new Vector3(3, 3), outside[0].End);
+            Assert.Equal(new Vector3(3, 3), outside[1].Start);
+            Assert.Equal(new Vector3(2, 3), outside[1].End);
+        }
+
+        [Fact]
         public void ExtendToProfile()
         {
             Name = "ExtendToProfile";
@@ -457,12 +491,12 @@ namespace Elements.Geometry.Tests
                 (8,0,Vector3.EPSILON * 0.5),
                 (-4, 0, 0)
             };
-            Assert.True(points1.AreCollinear());
+            Assert.True(points1.AreCollinearByDistance());
 
             points1.Add(
                   (-6, Vector3.EPSILON * 2, 0)
             );
-            Assert.False(points1.AreCollinear());
+            Assert.False(points1.AreCollinearByDistance());
         }
 
         [Fact]

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -420,26 +420,49 @@ namespace Elements.Tests
         }
 
         [Fact]
-        public void Collinear()
+        public void CollinearByDistance()
         {
             Vector3 p0 = new Vector3(0, 0, 0);
             Vector3 p1 = new Vector3(10, 10, 10);
             Vector3 p2 = new Vector3(20, 20, 20);
             Vector3 p3 = new Vector3(15, 5, 20);
 
-            var p4 = new Vector3(0, -118.7170, 13.8152);
-            var p5 = new Vector3(0, -80.4465, 13.8152);
-            var p6 = new Vector3(0, -118.7170, 13.8173);
-            var p7 = new Vector3(0, 33.5632, 13.8173);
+            Vector3 p4 = new Vector3(0, -118.7170, 13.8152);
+            Vector3 p5 = new Vector3(0, -80.4465, 13.8152);
+            Vector3 p6 = new Vector3(0, -118.7170, 13.8173);
+            Vector3 p7 = new Vector3(0, 33.5632, 13.8173);
 
-
-            Assert.True(Vector3.AreCollinear(p0, p1, p2));
-            Assert.False(Vector3.AreCollinear(p0, p1, p3));
+            Assert.True(Vector3.AreCollinearByDistance(p0, p1, p2));
+            Assert.False(Vector3.AreCollinearByDistance(p0, p1, p3));
 
             var zeroPlane = new Plane(Vector3.Origin, Vector3.YAxis);
             Assert.False(p4.Project(zeroPlane).IsAlmostEqualTo(p6.Project(zeroPlane)));
-            Assert.False(Vector3.AreCollinear(p4, p5, p6));
-            Assert.False(Vector3.AreCollinear(p4, p5, p7));
+            Assert.False(Vector3.AreCollinearByDistance(p4, p5, p6));
+            Assert.False(Vector3.AreCollinearByDistance(p4, p5, p7));
+        }
+
+        [Fact]
+        public void CollinearByAngle()
+        {
+            Vector3 p0 = new Vector3(0, 0, 0);
+            Vector3 p1 = new Vector3(10, 10, 10);
+            Vector3 p2 = new Vector3(20, 20, 20);
+            Vector3 p3 = new Vector3(15, 5, 20);
+
+            Assert.True(Vector3.AreCollinearByDistance(p0, p1, p2));
+            Assert.False(Vector3.AreCollinearByDistance(p0, p1, p3));
+
+            // Small angle delta can accumulate significant distance delta
+            Vector3 p4 = new Vector3(10000, 0);
+            Vector3 p5 = new Vector3(20000, 0.1);
+            Assert.True(Vector3.AreCollinearByAngle(p0, p4, p5));
+            Assert.False(Vector3.AreCollinearByAngle(p0, p4, p5, Math.Cos(Units.DegreesToRadians(0.0001))));
+
+            // Order is important
+            Vector3 p6 = new Vector3(10, 0);
+            Vector3 p7 = new Vector3(10, 0.0001);
+            Assert.False(Vector3.AreCollinearByAngle(p0, p6, p7));
+            Assert.True(Vector3.AreCollinearByAngle(p6, p0, p7));
         }
 
         [Fact]
@@ -456,9 +479,9 @@ namespace Elements.Tests
             Vector3 p7 = new Vector3(2, 0);
 
             Assert.True(p1.IsAlmostEqualTo(p2));
-            Assert.True(new[] { p0, p1, p2, p3 }.AreCollinear());
+            Assert.True(new[] { p0, p1, p2, p3 }.AreCollinearByDistance());
             Assert.True(p5.IsAlmostEqualTo(p6));
-            Assert.True(new[] { p4, p5, p6, p7 }.AreCollinear());
+            Assert.True(new[] { p4, p5, p6, p7 }.AreCollinearByDistance());
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
- AdaptiveGraphRouting has AreCollinearInplace - optimized and cheap collinear check that avoid creating (and validating in constructor) of new Vector3 objects and approximately 6 time faster for the version that uses fit line.
- AreCollinear for 3 point used dot approach as well before but not it also uses fit line approach.
- I also has a function in external project that was basically a copy of Line.Trim but uses infinite line. It was required to find all possible intersection with polygon.
- I think that this might be a good opportunity to make the code I have public so I did this PR as a proposal.

DESCRIPTION:
- I think both versions of AreCollinear are valid if it's clear what they do. AreCollinearByDistance uses fit line and guarantees that all points are no more than tolerance away from a common line. AreCollinearByAngle is simpliear and guarantees that  3 points forms the same unsigned angle within certain tolerance (0.001 degrees by default).
- Infinite parameter fits well in Line.Trim since many functions have this parameter and it was not requiring to much change.  

TESTING:
- Added LineTrimWithPolygonInfinite test for Line.Trim
- Added CollinearByAngle for AreCollinearByAngle

FUTURE WORK:
- There is no AreCollinearByAngle for a list of point. One can be created if required. I did not added it because it's not so trivial as I initially thought.
- I added  COS_ANGLE_EPSILON = 0.99999999984769128; as cos of 0.001, so AreCollinear is bound it some real threshold but it still feels complicated since it can be used only in cases when cos is expected.  

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.
