### PR TITLE
fix for MetersToLatLon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 - `Profile.Split` would sometimes fail if the profile being split contained voids.
 - `Line.Intersects(BBox3 box, out List<Vector> results, bool infinite = false)` fix incomplete results when line misaligned with bounding box 
-
+- Fixed a mathematical error in `MercatorProjection.MetersToLatLon`, which was returning longitude values that were skewed.
 ## 1.0.1
 
 ### Added

--- a/Elements/src/Spatial/MercatorProjection.cs
+++ b/Elements/src/Spatial/MercatorProjection.cs
@@ -42,7 +42,7 @@ namespace Elements.Spatial
         {
             var phi = Units.DegreesToRadians(relativeToOrigin.Latitude);
             var locationX = location.X / Math.Cos(phi);
-            var locationY = location.Y / Math.Cos(phi);
+            var locationY = location.Y;
             var lon = XToLon(locationX) + relativeToOrigin.Longitude;
             var lat = YToLat(locationY) + relativeToOrigin.Latitude;
             return new Position(lat, lon);

--- a/Elements/test/MercatorProjectionTests.cs
+++ b/Elements/test/MercatorProjectionTests.cs
@@ -1,5 +1,6 @@
 
 using System;
+using System.Linq;
 using Elements.GeoJSON;
 using Elements.Geometry;
 using Xunit;
@@ -28,6 +29,15 @@ namespace Elements.Tests
             var p2ConvertedBack = Position.FromVectorMeters(p1, xy);
             Assert.Equal(p2.Latitude, p2ConvertedBack.Latitude, 2);
             Assert.Equal(p2.Longitude, p2ConvertedBack.Longitude, 2);
+
+            var xy1 = new Vector3(50, 50, 0);
+            var xy2 = new Vector3(100, 100, 0);
+            var xy1pos = Position.FromVectorMeters(p1, xy1);
+            var xy2pos = Position.FromVectorMeters(p1, xy2);
+            var xy1ConvertedBack = xy1pos.ToVectorMeters(p1);
+            var xy2ConvertedBack = xy2pos.ToVectorMeters(p1);
+            Assert.True(xy1.DistanceTo(xy1ConvertedBack) < 0.5);
+            Assert.True(xy2.DistanceTo(xy2ConvertedBack) < 0.5);
         }
     }
 }

--- a/Elements/test/MercatorProjectionTests.cs
+++ b/Elements/test/MercatorProjectionTests.cs
@@ -27,8 +27,8 @@ namespace Elements.Tests
             var p2 = new Position(40.70974164658192, -73.9918450388025);
             var xy = p2.ToVectorMeters(p1);
             var p2ConvertedBack = Position.FromVectorMeters(p1, xy);
-            Assert.Equal(p2.Latitude, p2ConvertedBack.Latitude, 2);
-            Assert.Equal(p2.Longitude, p2ConvertedBack.Longitude, 2);
+            Assert.Equal(p2.Latitude, p2ConvertedBack.Latitude, 3);
+            Assert.Equal(p2.Longitude, p2ConvertedBack.Longitude, 3);
 
             var xy1 = new Vector3(50, 50, 0);
             var xy2 = new Vector3(100, 100, 0);


### PR DESCRIPTION
BACKGROUND:
- I found that converting geolocated hypar geometry to lat/lon coordinates was producing areas that were systematically off.

DESCRIPTION:
- Corrects a mathematical error in our `MetersToLatLon` method and adds test code to verify conversion in both directions. 

TESTING:
- I added to an existing test, and also did a manual test with the `GeoJSON exporter` function, pulling output geometry into a 3rd party viewer and validating areas. 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.
