### PR TITLE
Add GetTileCells method to TiledCeiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - `Material` now supports a `DrawInFront` property.
+- `TiledCeiling.GetTileCells()`
 
 ### Changed
 

--- a/Elements/src/TiledCeiling.cs
+++ b/Elements/src/TiledCeiling.cs
@@ -248,6 +248,17 @@ namespace Elements
             return GetGrid().V.GetCells().Count(cell => cell.Type?.Contains(_spaceCellName) == false);
         }
 
+        /// <summary>
+        /// Get tiles cells as Grid2d.
+        /// </summary>
+        /// <returns>List of tiles grids.</returns>
+        public List<Grid2d> GetTileCells()
+        {
+            return GetGrid().GetCells()
+                    .Where(c => c.Type?.Contains(_spaceCellName) == false)
+                    .ToList();
+        }
+
         private List<Polygon> BuildCeilingTiles()
         {
             var cells = GetGrid().GetCells();

--- a/Elements/src/TiledCeiling.cs
+++ b/Elements/src/TiledCeiling.cs
@@ -249,7 +249,7 @@ namespace Elements
         }
 
         /// <summary>
-        /// Get tiles cells as Grid2d.
+        /// Get the tile cells as Grid2d.
         /// </summary>
         /// <returns>List of tiles grids.</returns>
         public List<Grid2d> GetTileCells()


### PR DESCRIPTION
DESCRIPTION:
- Add GetTileCells method to TiledCeiling, that returns all tile cells of ceiling as Grid2d

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/826)
<!-- Reviewable:end -->
