### PR TITLE
Public Edge and Vertex constructors 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - `Vector3.AreCollinear` are renamed into `Vector3.AreCollinearByDistance` and added `tolerance` parameter.
 - `Line.Trim` - added `infinite` for the cases when line needs to be treated as infinite.
 - `Vector3.ClosestPointOn` - added `infinite` for the cases when line needs to be treated as infinite.
+- `Elements.Geometry.Solids.Edge` public constructor
+- `Elements.Geometry.Solids.Vertex` public constructor
 
 ### Fixed
 

--- a/Elements/src/Geometry/Solids/Edge.cs
+++ b/Elements/src/Geometry/Solids/Edge.cs
@@ -26,7 +26,7 @@ namespace Elements.Geometry.Solids
         /// <param name="id"></param>
         /// <param name="from">The start Vertex of the Edge.</param>
         /// <param name="to">The end Vertex of the Edge.</param>
-        internal Edge(long id, Vertex from, Vertex to)
+        public Edge(long id, Vertex from, Vertex to)
         {
             this.Id = id;
             this.Left = new HalfEdge(this, from);

--- a/Elements/src/Geometry/Solids/Vertex.cs
+++ b/Elements/src/Geometry/Solids/Vertex.cs
@@ -25,7 +25,7 @@ namespace Elements.Geometry.Solids
         /// </summary>
         /// <param name="id"></param>
         /// <param name="point">The location of the Vertex.</param>
-        internal Vertex(long id, Vector3 point)
+        public Vertex(long id, Vector3 point)
         {
             this.Id = id;
             this.Point = point;


### PR DESCRIPTION
BACKGROUND:
I wanted to optimize performance and use `Elements.Geometry.Solids.Edge` class instead of `Line`, unfortunately there is not any public constructor for it. 

DESCRIPTION:
Change `Elements.Geometry.Solids.Edge` and `Elements.Geometry.Solids.Vertex` constructors from internal to public.

TESTING:
Run unit tests 
  
FUTURE WORK:
No additional work is required 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
There isn't any

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/833)
<!-- Reviewable:end -->
