### PR TITLE
add RotateAboutPoint method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `Line.BestFit(IList<Vector3> points)`
 - `Vector3Extensions.BestFitLine(this IList<Vector3> points)`
 - `Polygon.FromAlignedBoundingBox2d(IEnumerable<Vector3> points, Vector3 axis, double minSideSize = 0.1)`
+- `Transform.RotateAboutPoint` and `Transform.RotatedAboutPoint` convenience methods.
 
 ### Changed
 

--- a/Elements/src/Geometry/Transform.cs
+++ b/Elements/src/Geometry/Transform.cs
@@ -398,15 +398,40 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Apply a rotation to the transform about a center.
+        /// </summary>
+        /// <param name="point">The center of rotation.</param>
+        /// <param name="axis">The axis direction.</param>
+        /// <param name="angle">The angle of rotation in degrees.</param>
+        public void RotateAboutPoint(Vector3 point, Vector3 axis, double angle)
+        {
+            this.Move(point * -1);
+            this.Rotate(axis, angle);
+            this.Move(point);
+        }
+
+        /// <summary>
         /// Return a new transform which is a rotated copy of this transform.
         /// </summary>
         /// <param name="axis">The axis of rotation.</param>
         /// <param name="angle">The angle of rotation in degrees.</param>
-        /// <returns></returns>
         public Transform Rotated(Vector3 axis, double angle)
         {
             var result = new Transform(this);
             result.Rotate(axis, angle);
+            return result;
+        }
+
+        /// <summary>
+        /// Return a new Transform which is a rotated copy of this transform.
+        /// </summary>
+        /// <param name="point">The center of rotation.</param>
+        /// <param name="axis">The axis direction.</param>
+        /// <param name="angle">The angle of rotation in degrees.</param>
+        public Transform RotatedAboutPoint(Vector3 point, Vector3 axis, double angle)
+        {
+            var result = new Transform(this);
+            result.RotateAboutPoint(point, axis, angle);
             return result;
         }
 

--- a/Elements/test/TransformTests.cs
+++ b/Elements/test/TransformTests.cs
@@ -241,6 +241,19 @@ namespace Elements.Tests
 
             Assert.Equal(upT.YAxis, downT.YAxis.Negate());
         }
+
+        [Fact]
+        public void Transform_RotateAboutPoint()
+        {
+            Name = nameof(Transform_RotateAboutPoint);
+            var worldOrigin = new Transform();
+            Model.AddElements(worldOrigin.ToModelCurves());
+            var rectangle = Polygon.Rectangle((3, 4), (5, 6));
+            var center = rectangle.Centroid();
+            var rectangleRotatedAboutCenter = rectangle.TransformedPolygon(new Transform().RotatedAboutPoint(center, Vector3.ZAxis, 90));
+            Model.AddElement(rectangle);
+            Model.AddElement(rectangleRotatedAboutCenter);
+        }
     }
 
 }

--- a/Elements/test/TransformTests.cs
+++ b/Elements/test/TransformTests.cs
@@ -253,6 +253,7 @@ namespace Elements.Tests
             var rectangleRotatedAboutCenter = rectangle.TransformedPolygon(new Transform().RotatedAboutPoint(center, Vector3.ZAxis, 90));
             Model.AddElement(rectangle);
             Model.AddElement(rectangleRotatedAboutCenter);
+            Assert.Equal(center, rectangleRotatedAboutCenter.Centroid());
         }
     }
 

--- a/Elements/test/TransformTests.cs
+++ b/Elements/test/TransformTests.cs
@@ -248,7 +248,7 @@ namespace Elements.Tests
             Name = nameof(Transform_RotateAboutPoint);
             var worldOrigin = new Transform();
             Model.AddElements(worldOrigin.ToModelCurves());
-            var rectangle = Polygon.Rectangle((3, 4), (5, 6));
+            var rectangle = Polygon.Rectangle((3, 4), (5, 8));
             var center = rectangle.Centroid();
             var rectangleRotatedAboutCenter = rectangle.TransformedPolygon(new Transform().RotatedAboutPoint(center, Vector3.ZAxis, 90));
             Model.AddElement(rectangle);


### PR DESCRIPTION
BACKGROUND:
- Our rotate methods for transforms can be counter-intuitive, if the object you're trying to rotate is already positioned somewhere in space. 

DESCRIPTION:
- adds `RotateAboutPoint` and `RotatedAboutPoint` convenience methods for rotating a transform about a point and axis.

TESTING:
- Added a test to demonstrate.

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/834)
<!-- Reviewable:end -->
