### PR TITLE
Change Line.PointOnLine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.2
+## 1.1.0
 
 ### Added
 
@@ -22,6 +22,7 @@
 - `Vector3.ClosestPointOn` - added `infinite` for the cases when line needs to be treated as infinite.
 - `Elements.Geometry.Solids.Edge` public constructor
 - `Elements.Geometry.Solids.Vertex` public constructor
+- `Line.PointOnLine` now uses distance to line instead of dot product. 
 
 ### Fixed
 

--- a/Elements/src/Beam.cs
+++ b/Elements/src/Beam.cs
@@ -59,6 +59,9 @@ namespace Elements
                     string name = null) : base(curve, profile, material, startSetback, endSetback, rotation, transform, representation, isElementDefinition, id, name)
         { }
 
+        /// <summary>
+        /// Construct an empty beam.
+        /// </summary>
         public Beam() { }
     }
 }

--- a/Elements/src/Beam.cs
+++ b/Elements/src/Beam.cs
@@ -60,7 +60,7 @@ namespace Elements
         { }
 
         /// <summary>
-        /// Construct an empty beam.
+        /// Construct a beam.
         /// </summary>
         public Beam() { }
     }

--- a/Elements/src/Column.cs
+++ b/Elements/src/Column.cs
@@ -83,6 +83,9 @@ namespace Elements
             this.Height = height;
         }
 
+        /// <summary>
+        /// Construct empty Column.
+        /// </summary>
         public Column()
         {
         }

--- a/Elements/src/Column.cs
+++ b/Elements/src/Column.cs
@@ -84,7 +84,7 @@ namespace Elements
         }
 
         /// <summary>
-        /// Construct empty Column.
+        /// Construct a column.
         /// </summary>
         public Column()
         {

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -480,22 +480,26 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Test if a point lies within this line segment
+        /// Test if a point lies within a tolerance distance from given line segment
         /// </summary>
         /// <param name="point">The point to test.</param>
-        /// <param name="includeEnds">Consider a point at the endpoint as on the line.</param>
+        /// <param name="includeEnds">Consider a point at the endpoint as on the line.
+        /// When true - point  tolerance away from end points considered on line.
+        /// When false - point should be inside the line, but not exactly above end points.</param>
         public bool PointOnLine(Vector3 point, bool includeEnds = false)
         {
             return Line.PointOnLine(point, Start, End, includeEnds);
         }
 
         /// <summary>
-        /// Test if a point lies within a given line segment
+        /// Test if a point lies within a tolerance distance from given line segment
         /// </summary>
         /// <param name="point">The point to test.</param>
         /// <param name="start">The start point of the line segment.</param>
         /// <param name="end">The end point of the line segment.</param>
-        /// <param name="includeEnds">Consider a point at the endpoint as on the line.</param>
+        /// <param name="includeEnds">Consider a point at the endpoint as on the line.
+        /// When true - point  tolerance away from end points considered on line.
+        /// When false - point should be inside the line, but not exactly above end points.</param>
         public static bool PointOnLine(Vector3 point, Vector3 start, Vector3 end, bool includeEnds = false)
         {
             if (includeEnds && (point.IsAlmostEqualTo(start) || point.IsAlmostEqualTo(end)))

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -480,26 +480,26 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Test if a point lies within a tolerance distance from given line segment
+        /// Test if a point lies within tolerance of this line segment.
         /// </summary>
         /// <param name="point">The point to test.</param>
         /// <param name="includeEnds">Consider a point at the endpoint as on the line.
-        /// When true - point  tolerance away from end points considered on line.
-        /// When false - point should be inside the line, but not exactly above end points.</param>
+        /// When true, any point within tolerance of the end points will be considered on the line.
+        /// When false, points precisely at the ends of the line will not be considered on the line.</param>
         public bool PointOnLine(Vector3 point, bool includeEnds = false)
         {
             return Line.PointOnLine(point, Start, End, includeEnds);
         }
 
         /// <summary>
-        /// Test if a point lies within a tolerance distance from given line segment
+        /// Test if a point lies within tolerance of a given line segment.
         /// </summary>
         /// <param name="point">The point to test.</param>
         /// <param name="start">The start point of the line segment.</param>
         /// <param name="end">The end point of the line segment.</param>
         /// <param name="includeEnds">Consider a point at the endpoint as on the line.
-        /// When true - point  tolerance away from end points considered on line.
-        /// When false - point should be inside the line, but not exactly above end points.</param>
+        /// When true, any point within tolerance of the end points will be considered on the line.
+        /// When false, points precisely at the ends of the line will not be considered on the line.</param>
         public static bool PointOnLine(Vector3 point, Vector3 start, Vector3 end, bool includeEnds = false)
         {
             if (includeEnds && (point.IsAlmostEqualTo(start) || point.IsAlmostEqualTo(end)))

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -498,11 +498,19 @@ namespace Elements.Geometry
         /// <param name="includeEnds">Consider a point at the endpoint as on the line.</param>
         public static bool PointOnLine(Vector3 point, Vector3 start, Vector3 end, bool includeEnds = false)
         {
-            if (includeEnds && (point.DistanceTo(start) < Vector3.EPSILON || point.DistanceTo(end) < Vector3.EPSILON))
+            if (includeEnds && (point.IsAlmostEqualTo(start) || point.IsAlmostEqualTo(end)))
             {
                 return true;
             }
-            return (start - point).Unitized().Dot((end - point).Unitized()) < (Vector3.EPSILON - 1);
+
+            var delta = end - start;
+            var lambda = (point - start).Dot(delta) / (end - start).Dot(delta);
+            if( lambda > 0 && lambda < 1)
+            {
+                var pointOnLine = start + lambda * delta;
+                return pointOnLine.IsAlmostEqualTo(point);
+            }
+            return false;
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1120,6 +1120,7 @@ namespace Elements.Geometry
             return (point - start).Length() / (end - start).Length();
         }
 
+        /// <summary>
         /// Creates new line with vertices of current and joined line
         /// </summary>
         /// <param name="line">Collinear line</param>
@@ -1145,6 +1146,7 @@ namespace Elements.Geometry
                 : joinedLine.Reversed();
         }
 
+        /// <summary>
         /// Projects current line onto a plane
         /// </summary>
         /// <param name="plane">Plane to project</param>
@@ -1244,6 +1246,7 @@ namespace Elements.Geometry
         /// Find the 'b' coefficient of the straight line equation (y = m * x + b) using the least squares method
         /// </summary>
         /// <param name="points">Points for which best fit line should be found.</param>
+        /// <param name="m">'m' coefficient of the straight line equation.</param>
         /// <returns>The 'b' coefficient of the straight line equation.</returns>
         private static double FindBCoefficient(IList<Vector3> points, double m)
         {

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -866,7 +866,7 @@ namespace Elements.Geometry
         /// <param name="a">The first point.</param>
         /// <param name="b">The second point.</param>
         /// <param name="c">The third point.</param>
-        /// <param name="tolerance">Angle tolerance as cos.</param>
+        /// <param name="cosAngleTolerance">Angle tolerance as cos.</param>
         /// <returns></returns>
         public static bool AreCollinearByAngle(Vector3 a, Vector3 b, Vector3 c, double cosAngleTolerance = Vector3.COS_ANGLE_EPSILON)
         {

--- a/Elements/src/StructuralFraming.cs
+++ b/Elements/src/StructuralFraming.cs
@@ -71,7 +71,7 @@ namespace Elements
         }
 
         /// <summary>
-        /// Construct empty beam.
+        /// Construct a framing element.
         /// </summary>
         public StructuralFraming() { }
 

--- a/Elements/src/StructuralFraming.cs
+++ b/Elements/src/StructuralFraming.cs
@@ -70,6 +70,9 @@ namespace Elements
             this.UpdateRepresentations();
         }
 
+        /// <summary>
+        /// Construct empty beam.
+        /// </summary>
         public StructuralFraming() { }
 
         private void SetProperties(Curve curve,

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -735,6 +735,56 @@ namespace Elements.Geometry.Tests
             Assert.Equal(expectedLine, result);
         }
 
+        [Fact]
+        public void PointOnLine()
+        {
+            Vector3 start = new Vector3(0, 0, 0);
+            Vector3 end = new Vector3(10, 0, 0);
+
+            //1. End points
+            Assert.False(Line.PointOnLine(start, start, end));
+            Assert.False(Line.PointOnLine(start, start, end));
+            Assert.True(Line.PointOnLine(start, start, end, true));
+            Assert.True(Line.PointOnLine(start, start, end, true));
+
+            //2. Almost end point
+            Vector3 test = new Vector3(1e-6, 0, 0);
+            Assert.True(Line.PointOnLine(test, start, end));
+            Assert.True(Line.PointOnLine(test, start, end, true));
+            test = new Vector3(1e-6, 1e-6, 0);
+            Assert.True(Line.PointOnLine(test, start, end));
+            Assert.True(Line.PointOnLine(test, start, end, true));
+
+            //3. Midpoint
+            test = new Vector3(4, 0, 0);
+            Assert.True(Line.PointOnLine(test, start, end));
+            Assert.True(Line.PointOnLine(test, start, end, true));
+
+            //3. Almost midpoint
+            test = new Vector3(4, 5e-6, 0);
+            Assert.True(Line.PointOnLine(test, start, end));
+            Assert.True(Line.PointOnLine(test, start, end, true));
+
+            //4. Point not on the line
+            test = new Vector3(5, 1, 0);
+            Assert.False(Line.PointOnLine(test, start, end));
+            Assert.False(Line.PointOnLine(test, start, end, true));
+
+            //5. Large line
+            Vector3 farEnd = new Vector3(150, 0, 0);
+            test = new Vector3(100, 0.1, 0);
+            Assert.False(Line.PointOnLine(test, start, farEnd));
+            Assert.False(Line.PointOnLine(test, start, farEnd, true));
+
+            //6. Collinear point outside line
+            test = new Vector3(15, 0, 0);
+            Assert.False(Line.PointOnLine(test, start, end));
+            Assert.False(Line.PointOnLine(test, start, end, true));
+            test = new Vector3(-5, 0, 0);
+            Assert.False(Line.PointOnLine(test, start, end));
+            Assert.False(Line.PointOnLine(test, start, end, true));
+        }
+
         public static IEnumerable<object[]> ProjectedData()
         {
             var line = new Line(Vector3.Origin, new Vector3(5, 5, 5));

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -721,8 +721,8 @@ namespace Elements.Geometry.Tests
                 new Vector3(10.21,8.65)
             };
             var line3 = Line.BestFit(points3);
-            var mCoef = 0.5615;
-            var bCoef = 2.034;
+            var mCoef = 0.56150040095236275;
+            var bCoef = 2.03395076348772;
             Assert.True(line3.PointOnLine(new Vector3(2, mCoef * 2 + bCoef)));
             Assert.True(line3.PointOnLine(new Vector3(7, mCoef * 7 + bCoef)));
         }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -745,7 +745,6 @@ namespace Elements.Geometry.Tests
             Assert.False(Line.PointOnLine(start, start, end));
             Assert.False(Line.PointOnLine(start, start, end));
             Assert.True(Line.PointOnLine(start, start, end, true));
-            Assert.True(Line.PointOnLine(start, start, end, true));
 
             //2. Almost end point
             Vector3 test = new Vector3(1e-6, 0, 0);

--- a/Elements/test/ProfileTests.cs
+++ b/Elements/test/ProfileTests.cs
@@ -539,7 +539,7 @@ namespace Elements.Tests
             // Value determined experimentally. If this test breaks, verify output visually —
             // it's not necessarily the end of the world if the number changes slightly, but we want to
             // make sure the results look sensible.
-            Assert.Equal(444, splits.Count);
+            Assert.Equal(441, splits.Count);
             var random = new Random(11);
             foreach (var s in splits)
             {


### PR DESCRIPTION
BACKGROUND:
Vector3.PointOnLine is based on dot product and because of that answer is angle based. The longer the line is - the bigger deviation is allowed. For example Line((0, 0, 0), (150, 0, 0) will return true for (100, 0.1, 0) point that can lead to unwanted results.
Because how includeEnds parameter is coded it's unclear what it means: when it's false exactly end point will always return true, but when numeric noise is present: (1e-6, 0, 0) will return True for the line above but (1e-6, 1e-6, 0) will return false.

DESCRIPTION:
PointOnLine is now distance based and is based on calculations from Vector3.DistanceTo(Line): return true if point is less than tolerance away from the line.
New implementation is not using Sqrt so it's quicker than old one although it uses extra checks.
New implementation has similar behavior for end points: when includeEnds is false the exact same point will return false but both (1e-6, 0, 0) and (1e-6, 1e-6, 0) will not return true because they both less than tolerance away.

TESTING:
- Add PointOnLine test to LineTest.
- Adjust results of SplitComplexProfileWithInnerVoids test
- Increase precision of BestFitLine test.

FUTURE WORK:
- There may be other functions based on dot product that are error prone based on inputs size.
 
REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Active section of `CHANGELOG.md` had wrong label 1.0.2 although target version is 1.1.0. It happened because 1.0.2 was skipped in changelog when it was developed. This is fixed now.
- I resolved leftover minor warnings, so the only one left is about using pre-selease version of SixLabours.Fonts. If we could resolve it as well we would be warnings free.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/836)
<!-- Reviewable:end -->
