### PR TITLE
Add DoubleToleranceComparer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `Vector3Extensions.BestFitLine(this IList<Vector3> points)`
 - `Polygon.FromAlignedBoundingBox2d(IEnumerable<Vector3> points, Vector3 axis, double minSideSize = 0.1)`
 - `Transform.RotateAboutPoint` and `Transform.RotatedAboutPoint` convenience methods.
+- `DoubleToleranceComparer`
 
 ### Changed
 

--- a/Elements/src/Search/DoubleToleranceComparer.cs
+++ b/Elements/src/Search/DoubleToleranceComparer.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+
+namespace Elements.Search
+{
+    /// <summary>
+    /// Double comparer that treats all numbers withing tolerance as the same.
+    /// This comparer doesn't use hash code as it is *impossible* to create a hashing 
+    /// algorithm that consistently returns identical values for any two points
+    /// within tolerance of each other.
+    /// </summary>
+    public class DoubleToleranceComparer : IEqualityComparer<double>
+    {
+        /// <summary>
+        /// Create a comparer.
+        /// </summary>
+        /// <param name="tolerance">Number tolerance</param>
+        public DoubleToleranceComparer(double tolerance)
+        {
+            _tolerance = tolerance;
+        }
+
+        /// <summary>
+        /// Check if two numbers are the same withing tolerance
+        /// </summary>
+        /// <param name="x">First number</param>
+        /// <param name="y">Second number</param>
+        /// <returns>True if x should be treated the same as y.</returns>
+        public bool Equals(double x, double y)
+        {
+            return x.ApproximatelyEquals(y, _tolerance);
+        }
+
+        /// <summary>
+        /// Hash code for number. Always returns 0.
+        /// </summary>
+        /// <param name="obj">number</param>
+        /// <returns>0</returns>
+        public int GetHashCode(double obj)
+        {
+            return 0;
+        }
+
+        private double _tolerance;
+    }
+}

--- a/Elements/src/Search/DoubleToleranceComparer.cs
+++ b/Elements/src/Search/DoubleToleranceComparer.cs
@@ -7,6 +7,8 @@ namespace Elements.Search
     /// This comparer doesn't use hash code as it is *impossible* to create a hashing 
     /// algorithm that consistently returns identical values for any two points
     /// within tolerance of each other.
+    /// Note that any item that is not withing tolerance of other key is set as a new key.
+    /// This mean that keys are not always whole number in the middle of a range.
     /// </summary>
     public class DoubleToleranceComparer : IEqualityComparer<double>
     {

--- a/Elements/src/Search/DoubleToleranceComparer.cs
+++ b/Elements/src/Search/DoubleToleranceComparer.cs
@@ -3,11 +3,11 @@
 namespace Elements.Search
 {
     /// <summary>
-    /// Double comparer that treats all numbers withing tolerance as the same.
+    /// Double comparer that treats all numbers within tolerance as the same.
     /// This comparer doesn't use hash code as it is *impossible* to create a hashing 
     /// algorithm that consistently returns identical values for any two points
     /// within tolerance of each other.
-    /// Note that any item that is not withing tolerance of other key is set as a new key.
+    /// Note that any item that is not within tolerance of other key is set as a new key.
     /// This mean that keys are not always whole number in the middle of a range.
     /// </summary>
     public class DoubleToleranceComparer : IEqualityComparer<double>
@@ -22,7 +22,7 @@ namespace Elements.Search
         }
 
         /// <summary>
-        /// Check if two numbers are the same withing tolerance
+        /// Check if two numbers are the same within tolerance
         /// </summary>
         /// <param name="x">First number</param>
         /// <param name="y">Second number</param>

--- a/Elements/test/DoubleToleranceComparerTests.cs
+++ b/Elements/test/DoubleToleranceComparerTests.cs
@@ -30,6 +30,13 @@ namespace Elements.Tests
             Assert.Equal(2, groups.Count());
             Assert.True(groups.FirstOrDefault(g => g.Key.ApproximatelyEquals(1)).Count() == 2);
             Assert.True(groups.FirstOrDefault(g => g.Key.ApproximatelyEquals(2)).Count() == 3);
+            
+            //First "unique" item is set as a key. 
+            List<double> firstIsKey = new List<double> { 1.000005, 1.00001, 1, 0.999995 };
+            groups = firstIsKey.GroupBy(n => n, new DoubleToleranceComparer(Vector3.EPSILON));
+            Assert.Equal(2, groups.Count());
+            Assert.True(groups.FirstOrDefault(g => g.Key == 1.000005).Count() == 3);
+            Assert.True(groups.FirstOrDefault(g => g.Key == 0.999995).Count() == 1);
         }
     }
 }

--- a/Elements/test/DoubleToleranceComparerTests.cs
+++ b/Elements/test/DoubleToleranceComparerTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+using Xunit;
+using Elements.Search;
+using Elements.Geometry;
+
+namespace Elements.Tests
+{
+    public class DoubleToleranceComparerTests : ModelTest
+    {
+        [Fact]
+        public void DoubleToleranceComparerTest()
+        {
+            List<double> differentNumbers = new List<double> { 1, 2, 3, 4, 5 };
+            var groups = differentNumbers.GroupBy(n => n, new DoubleToleranceComparer(Vector3.EPSILON));
+            Assert.Equal(5, groups.Count());
+            Assert.True(groups.All(g => g.Count() == 1));
+
+            List<double> sameNumbers = new List<double> { 1, 2, 3, 2, 3 };
+            groups = sameNumbers.GroupBy(n => n, new DoubleToleranceComparer(Vector3.EPSILON));
+            Assert.Equal(3, groups.Count());
+            Assert.True(groups.FirstOrDefault(g => g.Key.ApproximatelyEquals(1)).Count() == 1);
+            Assert.True(groups.FirstOrDefault(g => g.Key.ApproximatelyEquals(2)).Count() == 2);
+            Assert.True(groups.FirstOrDefault(g => g.Key.ApproximatelyEquals(3)).Count() == 2);
+
+            List<double> closeNumbers = new List<double> { 1, 2, 1.000001, 2.000002, 1.99999999 };
+            groups = closeNumbers.GroupBy(n => n, new DoubleToleranceComparer(Vector3.EPSILON));
+            Assert.Equal(2, groups.Count());
+            Assert.True(groups.FirstOrDefault(g => g.Key.ApproximatelyEquals(1)).Count() == 2);
+            Assert.True(groups.FirstOrDefault(g => g.Key.ApproximatelyEquals(2)).Count() == 3);
+        }
+    }
+}


### PR DESCRIPTION
BACKGROUND:
- AdaptiveGrid needed a way to group items by Z coordinate within certain tolerance.

DESCRIPTION:
- Added DoubleToleranceComparer that treats all numbers within tolerance as the same.
This comparer doesn't use hash code as it is *impossible* to create a hashing algorithm that consistently returns identical values for any two points within tolerance of each other.
Note that any item that is not within tolerance of other key is set as a new key.
This mean that keys are not always whole number in the middle of a range.

TESTING:
- Added DoubleToleranceComparerTests test.
 
REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- These is Vector3Comparer class that is similar but it uses GetHashCode that make it volatile in behavior. It may be considered to make it also always use 0 as hash code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/837)
<!-- Reviewable:end -->
