### PR TITLE
Fix tolerance for AreCoplanar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.2
+## 1.1.0
 
 ### Added
 
@@ -29,6 +29,7 @@
 - `Line.Intersects(BBox3 box, out List<Vector> results, bool infinite = false)` fix incomplete results when line misaligned with bounding box 
 - Fixed a mathematical error in `MercatorProjection.MetersToLatLon`, which was returning longitude values that were skewed.
 - `Grid2d.IsTrimmed` would occasionally return `true` for cells that were not actually trimmed.
+- `Vector3[].AreCoplanar()` computed its tolerance for deviation incorrectly, this is fixed.
 
 ## 1.0.1
 

--- a/Elements/src/Geometry/Vector3Extensions.cs
+++ b/Elements/src/Geometry/Vector3Extensions.cs
@@ -29,7 +29,7 @@ namespace Elements.Geometry
             {
                 var d = points[i];
                 var cd = d - a;
-                var tp = ab.Dot(ac.Cross(cd));
+                var tp = ab.Dot(ac.Cross(cd).Unitized());
                 if (Math.Abs(tp) > Vector3.EPSILON)
                 {
                     return false;

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -2044,5 +2044,16 @@ namespace Elements.Geometry.Tests
                 Vector3.Origin,
             });
         }
+
+
+        [Fact]
+        public void CoplanarWithinTolerance()
+        {
+            // this polygon has some small amount of deviation from planar (6.3e-7)
+            var json = "{\n            \"discriminator\": \"Elements.Geometry.Polygon\",\n            \"Vertices\": [\n              {\n                \"X\": 30.00108,\n                \"Y\": 0.17123,\n                \"Z\": 24.666666666666668\n              },\n              {\n                \"X\": -2.5323,\n                \"Y\": 0.17123,\n                \"Z\": 24.666666666666668\n              },\n              {\n                \"X\": -2.5322999954223633,\n                \"Y\": -8.758851356437756,\n                \"Z\": 24.66666603088379\n              },\n              {\n                \"X\": -2.5323,\n                \"Y\": -21.3088,\n                \"Z\": 24.666666666666668\n              },\n              {\n                \"X\": 7.8653690051598115,\n                \"Y\": -21.308799743652344,\n                \"Z\": 24.66666603088379\n              },\n              {\n                \"X\": 14.06867950383497,\n                \"Y\": -21.308799743652344,\n                \"Z\": 24.66666603088379\n              },\n              {\n                \"X\": 21.64777460957137,\n                \"Y\": -21.308799743652344,\n                \"Z\": 24.66666603088379\n              },\n              {\n                \"X\": 30.00108,\n                \"Y\": -21.3088,\n                \"Z\": 24.666666666666668\n              }\n            ]\n          }";
+            // verify does not throw
+            var polygon = JsonConvert.DeserializeObject<Polygon>(json);
+            Assert.NotNull(polygon);
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- The `AreCoplanar` extension method for collections of vertices had an error that caused it to be potentially several orders of magnitude more sensitive to deviation than it was intended to be. Specifically, checking the dot product with the un-unitized cross product meant that the deviation was multiplied by the area of the parallelogram between the first two edges, which could be quite a large number, effectively tightening the tolerance of the method.

DESCRIPTION:
- Fixes the error and adds a test

TESTING:
- A new test deserializing a polygon with a deviation in the z of 6.3e-7 is added
- All other tests are passing
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/838)
<!-- Reviewable:end -->
