### PR TITLE
Add Line IsOnPlane method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `Polygon.FromAlignedBoundingBox2d(IEnumerable<Vector3> points, Vector3 axis, double minSideSize = 0.1)`
 - `Transform.RotateAboutPoint` and `Transform.RotatedAboutPoint` convenience methods.
 - `DoubleToleranceComparer`
+- `Line.IsOnPlane()` method
 
 ### Changed
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1259,5 +1259,17 @@ namespace Elements.Geometry
             var b = (sumy - m * sumx) / points.Count;
             return b;
         }
+
+        /// <summary>
+        /// Checks if line lays on plane
+        /// </summary>
+        /// <param name="plane">Plane to check</param>
+        /// <param name="tolerance">Optional tolerance value</param>
+        /// <returns>The result of check if line lays on plane</returns>
+        public bool IsOnPlane(Plane plane, double tolerance = 1E-05)
+        {
+            return Start.DistanceTo(plane).ApproximatelyEquals(0, tolerance)
+                && End.DistanceTo(plane).ApproximatelyEquals(0, tolerance);
+        }
     }
 }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -784,6 +784,32 @@ namespace Elements.Geometry.Tests
             Assert.False(Line.PointOnLine(test, start, end, true));
         }
 
+        [Fact]
+        public void IsOnPlane()
+        {
+            var plane = new Plane(Vector3.Origin, Vector3.ZAxis);
+
+            var lineOnPlane = new Line(new Vector3(1, 2), new Vector3(3, 2));
+            Assert.True(lineOnPlane.IsOnPlane(plane));
+
+            var tolerance = 0.001;
+            var lineOnPlaneWithTolerance = new Line(new Vector3(1, 2, 0.0009), new Vector3(3, 2, -0.0009));
+            Assert.True(lineOnPlaneWithTolerance.IsOnPlane(plane, tolerance));
+
+            var lineAbovePlane = new Line(new Vector3(1, 2, 3), new Vector3(3, 2, 3));
+            Assert.False(lineAbovePlane.IsOnPlane(plane));
+
+            var lineWithStartOnPlane = new Line(new Vector3(1, 2), new Vector3(3, 2, 3));
+            Assert.False(lineWithStartOnPlane.IsOnPlane(plane));
+
+            var lineWithEndOnPlane = new Line(new Vector3(1, 2, 3), new Vector3(3, 2));
+            Assert.False(lineWithEndOnPlane.IsOnPlane(plane));
+
+            var lineIntersectingPlane = new Line(new Vector3(1, 2, -3), new Vector3(3, 2, 3));
+            Assert.True(lineIntersectingPlane.Intersects(plane, out var _));
+            Assert.False(lineIntersectingPlane.IsOnPlane(plane));
+        }
+
         public static IEnumerable<object[]> ProjectedData()
         {
             var line = new Line(Vector3.Origin, new Vector3(5, 5, 5));


### PR DESCRIPTION
BACKGROUND:
I didn't find method that checks if particular line lays on plane.

DESCRIPTION:
The method checks distance of `Line.Start` and `Line.End` to `Plane`. If all distances are approximately 0, it means that line lays on plane. The method has optional tolerance parameter. 

TESTING:
Run unit tests 
  
FUTURE WORK:
None

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/840)
<!-- Reviewable:end -->
