### PR TITLE
Add GetParameterAt method to polyline 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `Transform.RotateAboutPoint` and `Transform.RotatedAboutPoint` convenience methods.
 - `DoubleToleranceComparer`
 - `Line.IsOnPlane()` method
+- `Polyline.GetParameterAt(Vector3 point)` method
 
 ### Changed
 

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -967,6 +967,26 @@ namespace Elements.Geometry
             }
             return;
         }
+
+        /// <summary>
+        /// Calculate U parameter for point on polyline
+        /// </summary>
+        /// <param name="point">Point on polyline</param>
+        /// <returns>Returns U parameter for point on polyline</returns>
+        public double GetParameterAt(Vector3 point)
+        {
+            var segment = Segments().FirstOrDefault(x => x.PointOnLine(point, true));
+
+            if (segment == null)
+                return -1;
+
+            var segmentIndex = Segments().ToList().IndexOf(segment);
+
+            var segmentsLength = Segments().Where((x, i) => i < segmentIndex).Sum(x => x.Length());
+            var pointLength = segmentsLength + point.DistanceTo(segment.Start);
+
+            return pointLength / Length();
+        }
     }
 
     /// <summary>

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -978,7 +978,9 @@ namespace Elements.Geometry
             var segment = Segments().FirstOrDefault(x => x.PointOnLine(point, true));
 
             if (segment == null)
+            {
                 return -1;
+            }
 
             var segmentIndex = Segments().ToList().IndexOf(segment);
 

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -254,8 +254,8 @@ namespace Elements.Geometry.Tests
 
             var point = new Vector3(2, 4);
             var result = polyline.GetParameterAt(point);
-            var expedResult = 0.75d;
-            Assert.True(result.ApproximatelyEquals(expedResult));
+            var expectedResult = 0.75d;
+            Assert.True(result.ApproximatelyEquals(expectedResult));
             Assert.True(point.IsAlmostEqualTo(polyline.PointAt(result)));
         }
     }

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -239,5 +239,24 @@ namespace Elements.Geometry.Tests
                 }
             }
         }
+
+        [Fact]
+        public void GetParameterAt()
+        {
+            var start = new Vector3(1, 2);
+            var end = new Vector3(3, 4);
+
+            var polyline = new Polyline(new[] { start, new Vector3(1, 4), end });
+
+            Assert.Equal(0, polyline.GetParameterAt(start));
+            Assert.Equal(1, polyline.GetParameterAt(end));
+            Assert.Equal(-1, polyline.GetParameterAt(Vector3.Origin));
+
+            var point = new Vector3(2, 4);
+            var result = polyline.GetParameterAt(point);
+            var expedResult = 0.75d;
+            Assert.True(result.ApproximatelyEquals(expedResult));
+            Assert.True(point.IsAlmostEqualTo(polyline.PointAt(result)));
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
I didn't find method that will calculate U parameter for a point on polyline

DESCRIPTION:
Methods calculates U parameter for a point on polyline. When output of `Polyline.GetParameterAt()` method is used as an input for method `Polyline.PointAt()` it returns the same point.

TESTING:
Run unit tests 
  
FUTURE WORK:
None

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/843)
<!-- Reviewable:end -->
