### PR TITLE
Add Polyline Intersects method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `Transform.RotateAboutPoint` and `Transform.RotatedAboutPoint` convenience methods.
 - `DoubleToleranceComparer`
 - `Line.IsOnPlane()` method
+- `Polyline.Intersects(Line line, out List<Vector3> intersections, bool infinite = false, bool includeEnds = false)` method
 
 ### Changed
 

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -967,6 +967,31 @@ namespace Elements.Geometry
             }
             return;
         }
+
+        /// <summary>
+        /// Check if polyline intersects with line
+        /// </summary>
+        /// <param name="line">Line to check</param>
+        /// <param name="intersections">Intersections between polyline and line</param>
+        /// <param name="infinite">Threat the line as infinite?</param>
+        /// <param name="includeEnds">If the end of line lies exactly on the vertex of polyline, count it as an intersection? </param>
+        /// <returns>True if line intersects with polyline, false if they do not intersect</returns>
+        public bool Intersects(Line line, out List<Vector3> intersections, bool infinite = false, bool includeEnds = false)
+        {
+            var segments = Segments();
+
+            intersections = new List<Vector3>();
+
+            foreach (var segment in segments)
+            {
+                if (segment.Intersects(line, out var point, infinite: infinite, includeEnds: includeEnds))
+                {
+                    intersections.Add(point);
+                }
+            }
+
+            return intersections.Any();
+        }
     }
 
     /// <summary>

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -239,5 +239,41 @@ namespace Elements.Geometry.Tests
                 }
             }
         }
+
+        [Fact]
+        public void Intersects()
+        {
+            var polyline = new Polyline(
+                new Vector3(-5,-5), 
+                new Vector3(-5, 5), 
+                new Vector3(5,5), 
+                new Vector3(5, -5));
+
+            var notIntersectingLine = new Line(new Vector3(-3, 0), new Vector3(3, 0));
+
+            Assert.False(polyline.Intersects(notIntersectingLine, out var result));
+            Assert.Empty(result);
+
+            Assert.True(polyline.Intersects(notIntersectingLine, out result, infinite: true));
+            Assert.Collection(result,
+                x => Assert.True(x.IsAlmostEqualTo(new Vector3(-5, 0))),
+                x => Assert.True(x.IsAlmostEqualTo(new Vector3(5, 0))));
+
+            var sharedStartLine = new Line(new Vector3(-5, 0), new Vector3(3, 0));
+            Assert.False(polyline.Intersects(sharedStartLine, out result));
+            Assert.Empty(result);
+
+            Assert.True(polyline.Intersects(sharedStartLine, out result, includeEnds: true));
+            Assert.Collection(result,
+                x => Assert.True(x.IsAlmostEqualTo(sharedStartLine.Start)));
+
+            var collinearSegmentLine = new Line(new Vector3(-5, -5), new Vector3(-5, 5));
+            Assert.False(polyline.Intersects(collinearSegmentLine, out result));
+
+            Assert.True(polyline.Intersects(collinearSegmentLine, out result, includeEnds: true));
+            Assert.Collection(result,
+                x => Assert.True(x.IsAlmostEqualTo(collinearSegmentLine.End)));
+
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
I didn't find method that will check if provided `Polyline` intersects with other `Line` 

DESCRIPTION:
Method goes through all segments of `Polyline` and checks if line intersects with it. It has all optional parameters which has `Line.Intersects(...)` method

TESTING:
Run unit tests 
  
FUTURE WORK:
None

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/844)
<!-- Reviewable:end -->
