### PR TITLE
Polyline Intersects line bugfixes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Fixed a mathematical error in `MercatorProjection.MetersToLatLon`, which was returning longitude values that were skewed.
 - `Grid2d.IsTrimmed` would occasionally return `true` for cells that were not actually trimmed.
 - `Vector3[].AreCoplanar()` computed its tolerance for deviation incorrectly, this is fixed.
+- `Polyline.Intersects(Line line, out List<Vector3> intersections, bool infinite = false, bool includeEnds = false)` fix wrong results when infinite flag is set, fix for overlapping points when include ends is set 
 
 ## 1.0.1
 

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -1008,7 +1008,10 @@ namespace Elements.Geometry
             {
                 if (segment.Intersects(line, out var point, infinite: infinite, includeEnds: includeEnds))
                 {
-                    intersections.Add(point);
+                    if (segment.PointOnLine(point, includeEnds) && intersections.All(x => !x.IsAlmostEqualTo(point)))
+                    {
+                        intersections.Add(point);
+                    }
                 }
             }
 

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -292,6 +292,21 @@ namespace Elements.Geometry.Tests
             Assert.True(polyline.Intersects(collinearSegmentLine, out result, includeEnds: true));
             Assert.Collection(result,
                 x => Assert.True(x.IsAlmostEqualTo(collinearSegmentLine.End)));
+
+            var lPolygon = Polygon.L(10, 10, 4);
+            var upperLine = new Line(new Vector3(5, 1), new Vector3(5, 2));
+            Assert.False(lPolygon.Intersects(upperLine, out result));
+            Assert.True(lPolygon.Intersects(upperLine, out result, infinite: true));
+            Assert.Collection(result,
+                x => x.IsAlmostEqualTo(new Vector3(5, 0)),
+                x => x.IsAlmostEqualTo(new Vector3(5, 4)));
+
+            var verticiesLine = new Line(Vector3.Origin, new Vector3(4, 4));
+            Assert.False(lPolygon.Intersects(verticiesLine, out result));
+            Assert.True(lPolygon.Intersects(verticiesLine, out result, includeEnds: true));
+            Assert.Collection(result,
+                x => x.IsAlmostEqualTo(verticiesLine.Start),
+                x => x.IsAlmostEqualTo(verticiesLine.End));
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
I found two bugs in `Polyline.Intersects(Line line ....)` method. 
- On L-shape polygons, method returns results outside of polygon perimeter when infinite flag is set true.
![image](https://user-images.githubusercontent.com/97615778/182779860-941ea94c-9760-481b-8d44-22293b0056e2.png)
- Method returns duplicated points for lines which share vertices with polygon 

DESCRIPTION:
First bugfix checks if calculated intersection point actually lies on polyline 

Second bugfix checks if calculated intersection point hasn't already been added to list of results.

TESTING:
I added unit tests which reproduce bugs
  
FUTURE WORK:
None 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
None

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/847)
<!-- Reviewable:end -->
