### PR TITLE
Make mesh code gen compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.0
+
+### Changed
+- MeshElement constructor signature modified to be compatible with code generation.
+
 ## 1.1.0
 
 ### Added
@@ -24,12 +29,12 @@
 - `Vector3.ClosestPointOn` - added `infinite` for the cases when line needs to be treated as infinite.
 - `Elements.Geometry.Solids.Edge` public constructor
 - `Elements.Geometry.Solids.Vertex` public constructor
-- `Line.PointOnLine` now uses distance to line instead of dot product. 
+- `Line.PointOnLine` now uses distance to line instead of dot product.
 
 ### Fixed
 
 - `Profile.Split` would sometimes fail if the profile being split contained voids.
-- `Line.Intersects(BBox3 box, out List<Vector> results, bool infinite = false)` fix incomplete results when line misaligned with bounding box 
+- `Line.Intersects(BBox3 box, out List<Vector> results, bool infinite = false)` fix incomplete results when line misaligned with bounding box
 - Fixed a mathematical error in `MercatorProjection.MetersToLatLon`, which was returning longitude values that were skewed.
 - `Grid2d.IsTrimmed` would occasionally return `true` for cells that were not actually trimmed.
 - `Vector3[].AreCoplanar()` computed its tolerance for deviation incorrectly, this is fixed.

--- a/Elements/src/ImportMeshElement.cs
+++ b/Elements/src/ImportMeshElement.cs
@@ -31,8 +31,9 @@ namespace Elements
                          Material material = null,
                          Guid id = default(Guid),
                          string name = null) : base(null,
-                                                    material == null ? BuiltInMaterials.Default : material,
                                                     new Transform(),
+                                                    material == null ? BuiltInMaterials.Default : material,
+                                                    null,
                                                     true,
                                                     id == default(Guid) ? Guid.NewGuid() : id,
                                                     name)

--- a/Elements/src/MeshElement.cs
+++ b/Elements/src/MeshElement.cs
@@ -31,15 +31,17 @@ namespace Elements
         /// Construct an import mesh element.
         /// </summary>
         /// <param name="mesh">The element's mesh.</param>
-        /// <param name="material">The element's material.</param>
         /// <param name="transform">The element's transform.</param>
+        /// <param name="material">The element's material.</param>
+        /// <param name="representation">The element's representation.</param>
         /// <param name="isElementDefinition">Is this element a definition?</param>
         /// <param name="id">The element's id.</param>
         /// <param name="name">The element's name.</param>
         [JsonConstructor]
         public MeshElement(Mesh mesh,
-                            Material material = null,
                             Transform transform = null,
+                            Material material = null,
+                            Representation representation = null,
                             bool isElementDefinition = false,
                             Guid id = default(Guid),
                             string name = null) : base(transform == null ? new Transform() : transform,
@@ -50,33 +52,6 @@ namespace Elements
                                                        name)
         {
             this._mesh = mesh;
-        }
-
-        /// <summary>
-        /// Construct an import mesh element.  This constructor is necessary for compatibility with elements that
-        /// inherit from this class via json schema and code generation.
-        /// </summary>
-        /// <param name="mesh">The element's mesh.</param>
-        /// <param name="transform">The element's transform.</param>
-        /// <param name="material">The element's material.</param>
-        /// <param name="representation">The element's representation.</param>
-        /// <param name="isElementDefinition">Is this element a definition?</param>
-        /// <param name="id">The element's id.</param>
-        /// <param name="name">The element's name.</param>
-        public MeshElement(Mesh mesh,
-                            Transform transform = null,
-                            Material material = null,
-                            Representation representation = null,
-                            bool isElementDefinition = false,
-                            Guid id = default(Guid),
-                            string name = null) : this(mesh,
-                                                        material,
-                                                        transform,
-                                                        isElementDefinition,
-                                                        id,
-                                                        name)
-        {
-
         }
 
         /// <summary>

--- a/Elements/src/MeshElement.cs
+++ b/Elements/src/MeshElement.cs
@@ -52,6 +52,42 @@ namespace Elements
             this._mesh = mesh;
         }
 
+        /// <summary>
+        /// Construct an import mesh element.  This constructor is necessary for compatibility with elements that
+        /// inherit from this class via json schema and code generation.
+        /// </summary>
+        /// <param name="mesh">The element's mesh.</param>
+        /// <param name="transform">The element's transform.</param>
+        /// <param name="material">The element's material.</param>
+        /// <param name="representation">The element's representation.</param>
+        /// <param name="isElementDefinition">Is this element a definition?</param>
+        /// <param name="id">The element's id.</param>
+        /// <param name="name">The element's name.</param>
+        public MeshElement(Mesh mesh,
+                            Transform transform = null,
+                            Material material = null,
+                            Representation representation = null,
+                            bool isElementDefinition = false,
+                            Guid id = default(Guid),
+                            string name = null) : this(mesh,
+                                                        material,
+                                                        transform,
+                                                        isElementDefinition,
+                                                        id,
+                                                        name)
+        {
+
+        }
+
+        /// <summary>
+        /// Empty constructor for compatibility purposes. It is best to use the
+        /// structured constructor with arguments, to ensure the mesh is correctly created.
+        /// </summary>
+        public MeshElement() : base()
+        {
+
+        }
+
         internal MeshElement(Material material = null,
                             Transform transform = null,
                             bool isElementDefinition = false,

--- a/Elements/src/MeshElement.cs
+++ b/Elements/src/MeshElement.cs
@@ -60,7 +60,7 @@ namespace Elements
         /// </summary>
         public MeshElement() : base()
         {
-
+            _mesh = new Mesh();
         }
 
         internal MeshElement(Material material = null,

--- a/Elements/test/BBox3Tests.cs
+++ b/Elements/test/BBox3Tests.cs
@@ -212,7 +212,7 @@ namespace Elements.Tests
                 }
             }
             mesh.ComputeNormals();
-            var meshElement = new MeshElement(mesh, new Material("Lime", Colors.Lime), new Transform(new Vector3(-7, -8, 0), new Vector3(-5, 3, 2)));
+            var meshElement = new MeshElement(mesh, new Transform(new Vector3(-7, -8, 0), new Vector3(-5, 3, 2)), new Material("Lime", Colors.Lime));
             return meshElement;
         }
 

--- a/Elements/test/MaterialTests.cs
+++ b/Elements/test/MaterialTests.cs
@@ -100,7 +100,7 @@ namespace Elements.Tests
 
             var m = new Material("test", Colors.Orange, emissiveTexture: "./Textures/Checkerboard.png", emissiveFactor: 0.5);
             var sphere = Mesh.Sphere(2, 30);
-            Model.AddElement(new MeshElement(sphere, m));
+            Model.AddElement(new MeshElement(sphere, material: m));
         }
 
         [Fact]

--- a/Elements/test/MeshElementTests.cs
+++ b/Elements/test/MeshElementTests.cs
@@ -41,7 +41,7 @@ namespace Elements.Tests
                 }
             }
             mesh.ComputeNormals();
-            var meshElement = new MeshElement(mesh, new Material("Lime", Colors.Lime));
+            var meshElement = new MeshElement(mesh, material: new Material("Lime", Colors.Lime));
             //</example>
             this.Model.AddElement(meshElement);
         }

--- a/Elements/test/MeshPrimitivesTests.cs
+++ b/Elements/test/MeshPrimitivesTests.cs
@@ -13,7 +13,7 @@ namespace Elements.Tests
             var s = Mesh.Sphere(3, 20);
             Assert.Equal(401, s.Vertices.Count);
             Assert.Equal(760, s.Triangles.Count);
-            Model.AddElement(new MeshElement(s, m));
+            Model.AddElement(new MeshElement(s, material: m));
         }
     }
 }

--- a/Elements/test/TopographyTests.cs
+++ b/Elements/test/TopographyTests.cs
@@ -268,7 +268,7 @@ namespace Elements.Tests
             csg.Tessellate(ref result);
 
             var material = new Material($"Topo", Colors.White, 0.0f, 0.0f, "./Topography/Texture_12454f24-690a-43e2-826d-e4deae5eb82e_2.jpg");
-            this.Model.AddElement(new MeshElement(result, material));
+            this.Model.AddElement(new MeshElement(result, material: material));
         }
 
         [Fact]
@@ -344,7 +344,7 @@ namespace Elements.Tests
 
             foreach (var mesh in fillVolumes)
             {
-                this.Model.AddElement(new MeshElement(mesh, BuiltInMaterials.XAxis));
+                this.Model.AddElement(new MeshElement(mesh, material: BuiltInMaterials.XAxis));
             }
         }
 


### PR DESCRIPTION
BACKGROUND:
- A user wanted to create a new element that inherited from MeshElement.  They did this with a schema so their constructor was code generated, and this revealed that MeshElement's constructor was not configured correctly to be compatible with code gen.

DESCRIPTION:
- modify the constructor of MeshElement to be compatible with the constructor signature expected by code gen.

TESTING:
- This schema will code gen, and be invalid unless you reference a local elements of this branch.
```
{
    "$id": "https://hypar.io/Schemas/CivilSurface.json",
    "$schema": "http://json-schema.org/draft-07/schema#",
    "description": "A beam.",
    "title": "specialMesh",
    "x-namespace": "Elements",
    "type": [
        "object",
        "null"
    ],
    "allOf": [
        {
            "$ref": "https://prod-api.hypar.io/schemas/MeshElement"
        }
    ],
    "required": [
        "CenterLine",
        "Profile"
    ],
    "properties": {
        "CenterLine": {
            "description": "The center line of the beam.",
            "$ref": "https://hypar.io/Schemas/Geometry/Line.json"
        },
        "Profile": {
            "description": "The beam's cross section.",
            "$ref": "https://hypar.io/Schemas/Geometry/Profile.json"
        }
    },
    "additionalProperties": false
}
```

add it to your hypar.json something like this
```
    "element_types": [
        "./specialMesh.json"
    ],
```
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/848)
<!-- Reviewable:end -->
