### PR TITLE
In memory images for textures.

### DIFF
--- a/Elements/src/Image.cs
+++ b/Elements/src/Image.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.Net;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace Elements
+{
+    /// <summary>
+    /// An image.
+    /// </summary>
+    internal class Image
+    {
+        /// <summary>
+        /// Create an image.
+        /// </summary>
+        /// <param name="uri">The URI of the image.</param>
+        /// <returns>An image or null if an image cannot be created from the provided URI.</returns>
+        internal static Image<Rgba32> CreateFromUri(Uri uri)
+        {
+            if (!RemoteFileExists(uri))
+            {
+                return null;
+            }
+
+            var webClient = new WebClient();
+            byte[] imageBytes = webClient.DownloadData(uri);
+
+            // We don't wrap this in a using statement because
+            // we hold onto the image in other places.
+            var texImage = SixLabors.ImageSharp.Image.Load(imageBytes);
+
+            // Flip the texture image vertically
+            // to align with OpenGL convention.
+            // 0,1  1,1
+            // 0,0  1,0
+            texImage.Mutate(x => x.Flip(FlipMode.Vertical));
+
+            return texImage;
+        }
+
+        /// <summary>
+        /// Create an image.
+        /// </summary>
+        /// <param name="data">A byte array containing the image data.</param>
+        /// <returns>An image.</returns>
+        internal static Image<Rgba32> CreateFromBytes(byte[] data)
+        {
+            var texImage = SixLabors.ImageSharp.Image.Load(data);
+            return texImage;
+        }
+
+        internal static bool RemoteFileExists(Uri uri)
+        {
+            if (uri.IsFile)
+            {
+                var localPath = uri.LocalPath;
+                return File.Exists(localPath);
+            }
+
+            // https://stackoverflow.com/questions/924679/c-sharp-how-can-i-check-if-a-url-exists-is-valid
+            try
+            {
+                HttpWebRequest request = WebRequest.Create(uri) as HttpWebRequest;
+                request.Method = "HEAD";
+                HttpWebResponse response = request.GetResponse() as HttpWebResponse;
+                var ok = response.StatusCode == HttpStatusCode.OK;
+                response.Close();
+                return ok;
+            }
+            catch (Exception ex)
+            {
+                //Any exception will returns false.
+                Console.WriteLine(ex.Message);
+                return false;
+            }
+        }
+    }
+}

--- a/Elements/src/Serialization/glTF/GltfMergingUtils.cs
+++ b/Elements/src/Serialization/glTF/GltfMergingUtils.cs
@@ -25,7 +25,7 @@ namespace Elements.Serialization.glTF
                                         List<glTFLoader.Schema.Mesh> meshes,
                                         List<glTFLoader.Schema.Material> materials,
                                         List<Texture> textures,
-                                        List<Image> images,
+                                        List<glTFLoader.Schema.Image> images,
                                         List<Sampler> samplers,
                                         bool shouldAddMaterials,
                                         System.Guid contentElementId,

--- a/Elements/test/MaterialTests.cs
+++ b/Elements/test/MaterialTests.cs
@@ -118,8 +118,33 @@ namespace Elements.Tests
         public void ImplicitConversion()
         {
             var material = new Material("A test", (0.5, 1, 0.2));
-
             Assert.Equal(new Color(0.9, 0.3, 0.5, 1.0), (0.9, 0.3, 0.5));
+        }
+
+        [Fact]
+        public void RemoteTexture()
+        {
+            this.Name = "RemoteTexture";
+            var m = new Material("test",
+                                 Colors.Gray,
+                                 0.0f,
+                                 0.0f,
+                                 "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+                                 true);
+            var mass = new Mass(new Circle(Vector3.Origin, 5).ToPolygon(), 10, m);
+            this.Model.AddElement(mass);
+        }
+
+        [Fact]
+        public void RemoteTextureThrowsWithBadUrl()
+        {
+            this.Name = "RemoteTexture";
+            Assert.Throws<ArgumentException>(() => new Material("test",
+                                 Colors.Gray,
+                                 0.0f,
+                                 0.0f,
+                                 "https://www.noimage.com/noimage.png",
+                                 true));
         }
     }
 }

--- a/Elements/test/TopographyTests.cs
+++ b/Elements/test/TopographyTests.cs
@@ -192,14 +192,14 @@ namespace Elements.Tests
             var topoImage = new Image<Rgba32>(512 * 2, 512 * 2);
             var mapImage = new Image<Rgba32>(1024 * 2, 1024 * 2);
 
-            using (var map0 = Image.Load<Rgba32>(maps[0]))
-            using (var map1 = Image.Load<Rgba32>(maps[1]))
-            using (var map2 = Image.Load<Rgba32>(maps[2]))
-            using (var map3 = Image.Load<Rgba32>(maps[3]))
-            using (var topo0 = Image.Load<Rgba32>(topos[0]))
-            using (var topo1 = Image.Load<Rgba32>(topos[1]))
-            using (var topo2 = Image.Load<Rgba32>(topos[2]))
-            using (var topo3 = Image.Load<Rgba32>(topos[3]))
+            using (var map0 = SixLabors.ImageSharp.Image.Load<Rgba32>(maps[0]))
+            using (var map1 = SixLabors.ImageSharp.Image.Load<Rgba32>(maps[1]))
+            using (var map2 = SixLabors.ImageSharp.Image.Load<Rgba32>(maps[2]))
+            using (var map3 = SixLabors.ImageSharp.Image.Load<Rgba32>(maps[3]))
+            using (var topo0 = SixLabors.ImageSharp.Image.Load<Rgba32>(topos[0]))
+            using (var topo1 = SixLabors.ImageSharp.Image.Load<Rgba32>(topos[1]))
+            using (var topo2 = SixLabors.ImageSharp.Image.Load<Rgba32>(topos[2]))
+            using (var topo3 = SixLabors.ImageSharp.Image.Load<Rgba32>(topos[3]))
             {
                 topoImage.Mutate(o => o
                 .DrawImage(topo0, new Point(0, 0), 1.0f)


### PR DESCRIPTION
BACKGROUND:
The API for creating textures for materials in Elements currently takes a relative file path and writes an image file to disk internally. This will not work for wasm scenarios where disk i/o operations are forbidden.

DESCRIPTION:
This pull request adds two new APIs to `Material`, enabling the user to build materials from `byte[]` and from `Image<Rgba32>` objects. Additionally, it extends the current relative path support to more robust `Uri` support, including absolute file paths using `file://`, relative paths, and protocols like `http://` and `https://`. 

TESTING:
- New tests are added that get images from the web to be usedd as textures.

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.
