### PR TITLE
Fix Line.Bestfit error when there are duplicated points

### DIFF
--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1186,7 +1186,7 @@ namespace Elements.Geometry
             }
             else if (distinctPoints.Count == 2)
             {
-                return new Line(points[0], points[1]);
+                return new Line(distinctPoints[0], distinctPoints[1]);
             }
 
             // find the coefficients of the straight line equation (y = m * x + b) using the least squares method


### PR DESCRIPTION
BACKGROUND:
- Line cannot be created if `points` contain duplicated points

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/856)
<!-- Reviewable:end -->
