### PR TITLE
Fix Polyline Frame consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - MeshElement constructor signature modified to be compatible with code generation.
 
+### Fixed
+- Fixed a bug where `Polyline.Frames` would return inconsistently-oriented transforms.
+
 ## 1.1.0
 
 ### Added

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -517,6 +517,7 @@ namespace Elements.Geometry
                     tangent = v1;
                 }
             }
+            tangent = tangent.Negate();
             return new Transform(origin, up.Cross(tangent), tangent);
         }
 

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -312,7 +312,7 @@ namespace Elements.Geometry
                 for (var i = 2; i < this.Vertices.Count; i++)
                 {
                     previousDirection = (this.Vertices[i] - this.Vertices[1]).Unitized();
-                    if (Math.Abs(previousDirection.Dot(nextDirection)) > 1 - Vector3.EPSILON)
+                    if (Math.Abs(previousDirection.Dot(nextDirection)) < 1 - Vector3.EPSILON)
                     {
                         break;
                     }
@@ -326,7 +326,7 @@ namespace Elements.Geometry
             {
                 // If this vertex has a bend, use the normal computed from the previous and next edges.
                 // Otherwise keep using the normal from the previous bend.
-                if (i < result.Length - 1)
+                if (i > 0 && i < result.Length - 1)
                 {
                     var direction = (this.Vertices[i + 1] - this.Vertices[i]).Unitized();
                     if (Math.Abs(nextDirection.Dot(direction)) < 1 - Vector3.EPSILON)
@@ -338,12 +338,12 @@ namespace Elements.Geometry
                 var normal = nextDirection.Cross(previousDirection);
 
                 // Flip the normal if it's pointing away from the previous point's normal.
-                if (i > 1 && previousNormal.Dot(normal) < 0)
+                if (i >= 1 && previousNormal.Dot(normal) < 0)
                 {
                     normal *= -1;
                 }
                 result[i] = normal.Unitized();
-                previousNormal = normal;
+                previousNormal = result[i];
             }
             return result;
         }
@@ -353,7 +353,7 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="startSetback"></param>
         /// <param name="endSetback"></param>
-        public override Transform[] Frames(double startSetback, double endSetback)
+        public override Transform[] Frames(double startSetback = 0, double endSetback = 0)
         {
             var normals = this.NormalsAtVertices();
 
@@ -489,31 +489,35 @@ namespace Elements.Geometry
             return new Transform(this.Vertices[i], x, x.Cross(up));
         }
 
-        private Transform CreateOrthogonalTransform(int i, Vector3 a, Vector3 up)
+        private Transform CreateOrthogonalTransform(int i, Vector3 origin, Vector3 up)
         {
-            Vector3 b, x, c;
+            Vector3 prev, next, tangent;
 
             if (i == 0)
             {
-                b = this.Vertices[i + 1];
-                var z = (a - b).Unitized();
-                return new Transform(a, up.Cross(z), z);
+                next = this.Vertices[i + 1];
+                tangent = (next - origin).Unitized();
             }
             else if (i == this.Vertices.Count - 1)
             {
-                b = this.Vertices[i - 1];
-                var z = (b - a).Unitized();
-                return new Transform(a, up.Cross(z), z);
+                prev = this.Vertices[i - 1];
+                tangent = (origin - prev).Unitized();
             }
             else
             {
-                b = this.Vertices[i - 1];
-                c = this.Vertices[i + 1];
-                var v1 = (b - a).Unitized();
-                var v2 = (c - a).Unitized();
-                x = v1.Average(v2).Negate();
-                return new Transform(this.Vertices[i], x, x.Cross(up));
+                prev = this.Vertices[i - 1];
+                next = this.Vertices[i + 1];
+                var v1 = (origin - prev).Unitized();
+                var v2 = (next - origin).Unitized();
+                tangent = v1.Average(v2).Unitized();
+                // if a segment doubles back on itself, this will be zero — just
+                // pick one tangent if this happens.
+                if (tangent.IsZero())
+                {
+                    tangent = v1;
+                }
             }
+            return new Transform(origin, up.Cross(tangent), tangent);
         }
 
         /// <summary>
@@ -1079,7 +1083,7 @@ namespace Elements.Geometry
         /// <returns>New polyline or null if any of points is not on polyline</returns>
         public Polyline GetSubsegment(Vector3 start, Vector3 end)
         {
-            if(start.IsAlmostEqualTo(end))
+            if (start.IsAlmostEqualTo(end))
             {
                 return null;
             }
@@ -1087,7 +1091,7 @@ namespace Elements.Geometry
             var startParameter = GetParameterAt(start);
             var endParameter = GetParameterAt(end);
 
-            if(startParameter < 0 || endParameter < 0)
+            if (startParameter < 0 || endParameter < 0)
             {
                 return null;
             }
@@ -1097,7 +1101,7 @@ namespace Elements.Geometry
             var vertices = new List<Vector3>();
             var lastVertex = Vector3.Origin;
 
-            if(startParameter < endParameter)
+            if (startParameter < endParameter)
             {
                 firstParameter = startParameter;
                 lastParameter = endParameter;

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -538,6 +538,8 @@ namespace Elements.Geometry.Tests
                 (10, 0, 0)
             );
 
+            Bezier bezier = new Bezier(curve.Vertices.ToList()).TransformedBezier(new Transform(30, 0, 0));
+
             var frames = curve.Frames();
 
             for (int i = 0; i < frames.Length - 1; i++)
@@ -548,8 +550,25 @@ namespace Elements.Geometry.Tests
                 var nextNormal = nextFrame.ZAxis;
                 Assert.True(currNormal.Dot(nextNormal) > 0.0);
             }
+
+            var bFrames = bezier.Frames();
+
+            var parameters = new List<double>();
+            for (int i = 0; i < 20; i++)
+            {
+                parameters.Add(i / 19.0);
+            }
+
+            var movedCrv = curve.TransformedPolyline(new Transform(15, 0, 0));
+
+            var transformAtFrames = parameters.Select(p => movedCrv.TransformAt(p));
+
             Model.AddElements(frames.SelectMany(f => f.ToModelCurves()));
+            Model.AddElements(bFrames.SelectMany(f => f.ToModelCurves()));
+            Model.AddElements(transformAtFrames.SelectMany(f => f.ToModelCurves()));
             Model.AddElement(curve);
+            Model.AddElement(movedCrv);
+            Model.AddElement(bezier);
         }
     }
 }

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -263,9 +263,9 @@ namespace Elements.Geometry.Tests
         public void Intersects()
         {
             var polyline = new Polyline(
-                new Vector3(-5,-5), 
-                new Vector3(-5, 5), 
-                new Vector3(5,5), 
+                new Vector3(-5, -5),
+                new Vector3(-5, 5),
+                new Vector3(5, 5),
                 new Vector3(5, -5));
 
             var notIntersectingLine = new Line(new Vector3(-3, 0), new Vector3(3, 0));
@@ -500,7 +500,7 @@ namespace Elements.Geometry.Tests
                 new Vector3(5, -5));
 
             var result = polyline.GetSubsegment(new Vector3(-5, -3), new Vector3(5, 3));
-            
+
             var expectedResult = new Polyline(new Vector3(-5, -3),
                 new Vector3(-5, 5),
                 new Vector3(5, 5),
@@ -524,6 +524,32 @@ namespace Elements.Geometry.Tests
             var endSubsegment = polyline.GetSubsegment(middlePoint, polyline.End);
             var endSubsegmentExpected = new Polyline(middlePoint, new Vector3(5, 5), polyline.End);
             Assert.Equal(endSubsegmentExpected, endSubsegment);
+        }
+
+        [Fact]
+        public void PolylineFrameNormalsAreConsistent()
+        {
+            Name = nameof(PolylineFrameNormalsAreConsistent);
+            Polyline curve = new Polyline(
+                (0, 0, 0),
+                (1, 0, 0),
+                (2, 4, 3),
+                (5, 3, 1),
+                (10, 0, 0)
+            );
+
+            var frames = curve.Frames();
+
+            for (int i = 0; i < frames.Length - 1; i++)
+            {
+                var currFrame = frames[i];
+                var nextFrame = frames[i + 1];
+                var currNormal = currFrame.ZAxis;
+                var nextNormal = nextFrame.ZAxis;
+                Assert.True(currNormal.Dot(nextNormal) > 0.0);
+            }
+            Model.AddElements(frames.SelectMany(f => f.ToModelCurves()));
+            Model.AddElement(curve);
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- Fixes #855 

DESCRIPTION:
- There were several bugs in `Polyline.NormalsAtVertices` and `Polyline.CreateOrthogonalTransform` resulting in inconsistently-oriented transforms. These have been resolved.

TESTING:
- I added a new test which failed on `master` and passes now — here are the results:
Before:
![before](https://user-images.githubusercontent.com/31935763/183677153-f54caa68-c625-48d8-983b-8e7545920b77.png)
After: 
![Screen Shot 2022-08-09 at 10 31 26 AM](https://user-images.githubusercontent.com/31935763/183677182-52e74b74-0f8b-4ac4-ad47-0e29d006add3.png)

I also verified that sweeps of non-planar polylines still looked sensible: 
![Screen Recording 2022-08-09 at 10 59 10 AM](https://user-images.githubusercontent.com/31935763/183684998-92e7b78e-42b9-4f02-a2e1-49f5a5e722f3.gif)

And visually verified other tests relying on Sweeps (which call this code):
![image](https://user-images.githubusercontent.com/31935763/183677671-ba65e77a-e32b-4345-9272-b84aef0016ec.png)

And verified consistency with `Frame` methods for other curves, and polyline's `TransformAt` method:
![image](https://user-images.githubusercontent.com/31935763/183685271-267d30c7-20a1-4d67-b2ad-f259e523070d.png)

  
FUTURE WORK:
- We should consider implementing a canonical "Rotation Minimizing Frame" here instead of inventing our own. See https://github.com/GSharker/G-Shark/blob/69d2286e38b6d928298329646759e69e1776cfa2/src/GShark/ExtendedMethods/Curve.cs#L59 and https://www.microsoft.com/en-us/research/wp-content/uploads/2016/12/Computation-of-rotation-minimizing-frames.pdf

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/857)
<!-- Reviewable:end -->
