### PR TITLE
add message class and helper creation methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.2.0
 
+### Added
+- Message class along with helper creation methods.
+
 ### Changed
 - MeshElement constructor signature modified to be compatible with code generation.
 
@@ -53,7 +56,7 @@
 - Fixed a mathematical error in `MercatorProjection.MetersToLatLon`, which was returning longitude values that were skewed.
 - `Grid2d.IsTrimmed` would occasionally return `true` for cells that were not actually trimmed.
 - `Vector3[].AreCoplanar()` computed its tolerance for deviation incorrectly, this is fixed.
-- `Polyline.Intersects(Line line, out List<Vector3> intersections, bool infinite = false, bool includeEnds = false)` fix wrong results when infinite flag is set, fix for overlapping points when include ends is set 
+- `Polyline.Intersects(Line line, out List<Vector3> intersections, bool infinite = false, bool includeEnds = false)` fix wrong results when infinite flag is set, fix for overlapping points when include ends is set
 
 ## 1.0.1
 

--- a/Elements/src/Annotations/Message.cs
+++ b/Elements/src/Annotations/Message.cs
@@ -5,6 +5,8 @@ namespace Elements.Annotations
 {
     /// <summary>An element that stores warning messages.</summary>
     [JsonConverter(typeof(Elements.Serialization.JSON.JsonInheritanceConverter), "discriminator")]
+    // TODO: We probably don't want to inherit from GeometricElement for ever.  It would be better for Messages to
+    // behave more like actual Annotation elements while still being capable of having an appearance in 3D in some circumstances.
     public partial class Message : GeometricElement
     {
         /// <summary>

--- a/Elements/src/Annotations/Message.cs
+++ b/Elements/src/Annotations/Message.cs
@@ -1,0 +1,52 @@
+using Elements.Geometry;
+using Newtonsoft.Json;
+
+namespace Elements.Annotations
+{
+    /// <summary>An element that stores warning messages.</summary>
+    [JsonConverter(typeof(Elements.Serialization.JSON.JsonInheritanceConverter), "discriminator")]
+    public partial class Message : GeometricElement
+    {
+        /// <summary>
+        /// Default json constructor for a message that may have geometry.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="stackTrace"></param>
+        /// <param name="severity"></param>
+        /// <param name="transform"></param>
+        /// <param name="material"></param>
+        /// <param name="representation"></param>
+        /// <param name="isElementDefinition"></param>
+        /// <param name="id"></param>
+        /// <param name="name"></param>
+        [JsonConstructor]
+        public Message(string @message, string @stackTrace, MessageSeverity @severity, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+            : base(transform, material, representation, isElementDefinition, id, name)
+        {
+            this.MessageText = @message;
+            this.StackTrace = @stackTrace;
+            this.Severity = @severity;
+        }
+
+        /// <summary>
+        /// Empty constructor.
+        /// </summary>
+        public Message()
+            : base()
+        {
+        }
+
+        /// <summary>A warning message for the user.</summary>
+        [JsonProperty("Message", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string MessageText { get; set; }
+
+        /// <summary>Developer specific message about the failure in the code.</summary>
+        [JsonProperty("Stack Trace", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string StackTrace { get; set; }
+
+        /// <summary>Developer specific message about the failure in the code.</summary>
+        [JsonProperty("Severity", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public MessageSeverity Severity { get; set; }
+    }
+}

--- a/Elements/src/Annotations/MessageSeverity.cs
+++ b/Elements/src/Annotations/MessageSeverity.cs
@@ -1,0 +1,23 @@
+namespace Elements.Annotations
+{
+    /// <summary>
+    /// The severity of a given message.
+    /// </summary>
+    public enum MessageSeverity
+    {
+        /// <summary>
+        /// Message is for information purposes only.
+        /// </summary>
+        Info,
+
+        /// <summary>
+        /// Message is for a warning.
+        /// </summary>
+        Warning,
+
+        /// <summary>
+        /// Message is for an error.
+        /// </summary>
+        Error
+    };
+}

--- a/Elements/src/Annotations/Messages.cs
+++ b/Elements/src/Annotations/Messages.cs
@@ -1,0 +1,228 @@
+﻿using Elements;
+using Elements.Geometry;
+using Elements.Geometry.Solids;
+using System;
+using System.Collections.Generic;
+
+namespace Elements.Annotations
+{
+    public partial class Message
+    {
+        /// <summary>
+        /// The material used for messages with "Info" severity.
+        /// </summary>
+        public static Material InfoMaterial { get; set; } = new Material("InfoMessage",
+                                                                         new Color(0, 0, 1, 0.7));
+
+
+        /// <summary>
+        /// The material used for messages with "Warning" severity.
+        /// </summary>
+        public static Material WarningMaterial { get; set; } = new Material("WarningMessage",
+                                                                            new Color(1, 1, 0, 0.7));
+
+        /// <summary>
+        /// The material used for messages with "Error" severity.
+        /// </summary>
+        public static Material ErrorMaterial { get; set; } = new Material("ErrorMessage",
+                                                                          new Color(1, 0, 0, 0.7));
+
+
+        private const string DefaultName = "Message";
+        private const double DefaultSideLength = 0.3;
+
+        /// <summary>
+        /// Create a simple message from the given text.
+        /// </summary>
+        /// <param name="message">The message to the user.</param>
+        /// <param name="name">The name given to the message.</param>
+        /// <param name="severity">The severity of the message.</param>
+        /// <param name="stackTrace">Any stack trace associated with the message.</param>
+        /// <returns></returns>
+        public static Message FromText(string message,
+                                       string name = null,
+                                       MessageSeverity severity = MessageSeverity.Warning,
+                                       string stackTrace = null)
+        {
+            return new Message(message, stackTrace, severity, name: name ?? DefaultName);
+        }
+
+        /// <summary>
+        /// Create a simple message at a point.
+        /// </summary>
+        /// <param name="messageText">The message to the user.</param>
+        /// <param name="point"></param>
+        /// <param name="severity">The severity of the message.</param>
+        /// <param name="sideLength"></param>
+        /// <param name="name">The name given to the message.</param>
+        /// <param name="stackTrace">Any stack trace associated with the message.</param>
+        /// <returns></returns>
+        public static Message FromPoint(string messageText,
+                                             Vector3? point,
+                                             MessageSeverity severity = MessageSeverity.Warning,
+                                             double sideLength = DefaultSideLength,
+                                             string name = null,
+                                             string stackTrace = null)
+        {
+            var transform = point.HasValue
+                ? new Transform(point.Value).Moved(z: -sideLength / 2)
+                : new Transform();
+            var message = new Message(messageText,
+                                      stackTrace,
+                                      severity,
+                                      transform,
+                                      MaterialForSeverity(severity),
+                                      null,
+                                      false,
+                                      Guid.NewGuid(),
+                                      name ?? DefaultName);
+            if (point.HasValue)
+            {
+                var extrude = new Extrude(Polygon.Rectangle(
+                    sideLength, sideLength), sideLength, Vector3.ZAxis, false);
+
+                message.Representation = new Representation(new[] { extrude });
+            }
+
+            return message;
+        }
+
+        /// <summary>
+        /// Create a simple message along a line.
+        /// </summary>
+        /// <param name="messageText">The message to the user.</param>
+        /// <param name="line"></param>
+        /// <param name="severity">The severity of the message.</param>
+        /// <param name="sideLength"></param>
+        /// <param name="name">The name given to the message.</param>
+        /// <param name="stackTrace">Any stack trace associated with the message.</param>
+        /// <returns></returns>
+        public static Message FromLine(string messageText,
+                                       Line line,
+                                       MessageSeverity severity = MessageSeverity.Warning,
+                                       double sideLength = DefaultSideLength,
+                                       string name = null,
+                                       string stackTrace = null)
+        {
+            var xAxis = line.Direction();
+            Vector3 yAxis;
+            if (xAxis.IsParallelTo(Vector3.ZAxis))
+            {
+                yAxis = xAxis.Cross(Vector3.YAxis);
+            }
+            else
+            {
+                yAxis = xAxis.Cross(Vector3.ZAxis);
+            }
+            var zAxis = yAxis.Cross(xAxis);
+            var toPipeLineTransform = new Transform(line.Start, xAxis, yAxis, zAxis);
+
+            var localLine = new Line(new Vector3(0, 0, 0), new Vector3(line.Length(), 0, 0));
+
+            var extrude = new Extrude(localLine.Thicken(sideLength),
+                                      sideLength,
+                                      Vector3.ZAxis,
+                                      false);
+            var message = new Message(messageText,
+                                      stackTrace,
+                                      severity,
+                                      toPipeLineTransform.Moved(new Vector3(0, 0, -sideLength / 2)),
+                                      MaterialForSeverity(severity),
+                                      new Representation(new[] { extrude }),
+                                      id: Guid.NewGuid(),
+                                      name: name ?? DefaultName);
+            return message;
+        }
+
+        /// <summary>
+        /// Create a simple message from a polygon.
+        /// </summary>
+        /// <param name="messageText">The message to the user.</param>
+        /// <param name="polygon"></param>
+        /// <param name="severity">The severity of the message.</param>
+        /// <param name="height"></param>
+        /// <param name="name">The name given to the message.</param>
+        /// <param name="stackTrace">Any stack trace associated with the message.</param>
+        /// <returns></returns>
+        public static Message FromPolygon(string messageText,
+                                          Polygon polygon,
+                                          MessageSeverity severity = MessageSeverity.Warning,
+                                          double height = 0,
+                                          string name = null,
+                                          string stackTrace = null)
+        {
+            const double messageHeightSubtleLift = 0.02;
+            SolidOperation solid = new Lamina(polygon, false);
+            if (height > 0)
+            {
+                solid = new Extrude(polygon, height, Vector3.ZAxis, false);
+            }
+            var message = new Message(messageText,
+                                      stackTrace,
+                                      severity,
+                                      new Transform().Moved(z: messageHeightSubtleLift),
+                                      MaterialForSeverity(severity),
+                                      new Representation(new[] { solid }),
+                                      false,
+                                      Guid.NewGuid(),
+                                      name ?? DefaultName);
+            return message;
+        }
+
+        /// <summary>
+        /// Create a simple message from polygons.
+        /// </summary>
+        /// <param name="messageText">The message to the user.</param>
+        /// <param name="polygons"></param>
+        /// <param name="severity">The severity of the message.</param>
+        /// <param name="height"></param>
+        /// <param name="name">The name given to the message.</param>
+        /// <param name="stackTrace">Any stack trace associated with the message.</param>
+        /// <returns></returns>
+        public static Message[] FromPolygons(string messageText,
+                                             IEnumerable<Polygon> polygons,
+                                             MessageSeverity severity = MessageSeverity.Warning,
+                                             double height = 0,
+                                             string name = null,
+                                             string stackTrace = null)
+        {
+            var messages = new List<Message>();
+            foreach (var polygon in polygons)
+            {
+                var message = FromPolygon(messageText, polygon, severity, height, name);
+                messages.Add(message);
+            }
+            return messages.ToArray();
+        }
+
+        /// <summary>
+        /// Extract the string details including any stack trace from the exception.
+        /// </summary>
+        /// <param name="e">The Exception.</param>
+        /// <returns></returns>
+        public static string DetailsFromException(Exception e)
+        {
+            string message = e.Message;
+            if (!string.IsNullOrWhiteSpace(e.StackTrace))
+            {
+                message += "\n" + e.StackTrace;
+            }
+            return message;
+        }
+
+        private static Material MaterialForSeverity(MessageSeverity severity)
+        {
+            switch (severity)
+            {
+                case MessageSeverity.Info:
+                    return InfoMaterial;
+                case MessageSeverity.Warning:
+                    return WarningMaterial;
+                case MessageSeverity.Error:
+                    return ErrorMaterial;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(severity), severity, null);
+            }
+        }
+    }
+}

--- a/Elements/src/Annotations/Messages.cs
+++ b/Elements/src/Annotations/Messages.cs
@@ -152,11 +152,7 @@ namespace Elements.Annotations
                                           string stackTrace = null)
         {
             const double messageHeightSubtleLift = 0.02;
-            SolidOperation solid = new Lamina(polygon, false);
-            if (height > 0)
-            {
-                solid = new Extrude(polygon, height, Vector3.ZAxis, false);
-            }
+            SolidOperation solid = height > 0 ? new Extrude(polygon, height, Vector3.ZAxis, false) : new Lamina(polygon, false) as SolidOperation;
             var message = new Message(messageText,
                                       stackTrace,
                                       severity,


### PR DESCRIPTION
BACKGROUND:
- We want to create messages that exist in space and contain information for users.

DESCRIPTION:
- Create the Messages class as well as some corresponding creation utilities.
- Add the concept of Severity to a message and support varying colors for the messages.

TESTING:
- This workflow has a function called "WarningsWarnings!!" that uses this version of elements to experiment with the new message type.
  
FUTURE WORK:
- Messages should not be GeometricElements forever.  This is a temporary measure to start standardizing, but we hsould improve the behavior and make them more "Annotation-like".

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/860)
<!-- Reviewable:end -->
