### PR TITLE
Changed BBox3.Extend access modifier to public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - MeshElement constructor signature modified to be compatible with code generation.
+- `BBox3.Extend` method is public now
 
 ### Fixed
 - Fixed a bug where `Polyline.Frames` would return inconsistently-oriented transforms.

--- a/Elements/src/Geometry/BBox3.cs
+++ b/Elements/src/Geometry/BBox3.cs
@@ -90,18 +90,22 @@ namespace Elements.Geometry
             }
         }
 
-        internal void Extend(Vector3 v)
+        /// <summary>
+        /// Extend a bounding box with a new point
+        /// </summary>
+        /// <param name="point">The point which should be inside the extended bounding box</param>
+        public void Extend(Vector3 point)
         {
             var newMin = new Vector3(Min.X, Min.Y, Min.Z);
-            if (v.X < this.Min.X) newMin.X = v.X;
-            if (v.Y < this.Min.Y) newMin.Y = v.Y;
-            if (v.Z < this.Min.Z) newMin.Z = v.Z;
+            if (point.X < this.Min.X) newMin.X = point.X;
+            if (point.Y < this.Min.Y) newMin.Y = point.Y;
+            if (point.Z < this.Min.Z) newMin.Z = point.Z;
             this.Min = newMin;
 
             var newMax = new Vector3(Max.X, Max.Y, Max.Z);
-            if (v.X > this.Max.X) newMax.X = v.X;
-            if (v.Y > this.Max.Y) newMax.Y = v.Y;
-            if (v.Z > this.Max.Z) newMax.Z = v.Z;
+            if (point.X > this.Max.X) newMax.X = point.X;
+            if (point.Y > this.Max.Y) newMax.Y = point.Y;
+            if (point.Z > this.Max.Z) newMax.Z = point.Z;
             this.Max = newMax;
         }
 


### PR DESCRIPTION
BACKGROUND:
- It's a useful feature outside the assembly. I'm going to use it inside Revit converters to create aggregated bounding box for all elements inside view 

DESCRIPTION:
- Changed BBox3.Extend access modifier to public

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/861)
<!-- Reviewable:end -->
