### PR TITLE
Update build-docs.yml

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -13,6 +13,10 @@ jobs:
         with:
           fetch-depth: 10
           token: ${{ secrets.HYPAR_GITHUB_BOT_PAT }}
+      - name: Setup Git
+        run: |
+          git config user.name "hypar-eric-bot"
+          git config user.email "github.bot@hypar.io"
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -9,9 +9,10 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 10
+          token: ${{ secrets.HYPAR_GITHUB_BOT_PAT }}
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:


### PR DESCRIPTION
Use a token when checking out branch

BACKGROUND:
- Want our docs release action to be able to push to a branch.  
- following advice in this thread https://stackoverflow.com/questions/69263843/how-to-push-to-protected-main-branches-in-a-github-action 

DESCRIPTION:
- Secret has been added, and now that it is used to checkout the action the subsequent actions will be on that branch.

TESTING:
- will test after merge
  
FUTURE WORK:
- potentially more after testing.

REQUIRED:
- ~[ ] All changes are up to date in `CHANGELOG.md`.~

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/862)
<!-- Reviewable:end -->
