### PR TITLE
Obstacle fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,15 @@
 ## 1.2.0
 
 ### Changed
+
 - MeshElement constructor signature modified to be compatible with code generation.
+- `AdaptiveGrid.Boundary` can be left null.
+- `Obstacle` properties `Points`, `Offset`, `Perimeter` and `Transform` can be modified from outside.
+
+### Fixed
+
+- `Obstacle.FromBox` works properly with `AdaptiveGrid` transformation.
+- `AdaptiveGrid.SubtractObstacle` worked incorrectly in `AdaptiveGrid.Boundary` had elevation.
 
 ## 1.1.0
 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -951,15 +951,19 @@ namespace Elements.Spatial.AdaptiveGrid
 
         private void AddEdgesOnLine(Vector3 start, Vector3 end, IEnumerable<Vector3> candidates)
         {
-            var inside = new Line(new Vector3(start.X, start.Y), new Vector3(end.X, end.Y)).Trim(Boundaries, out var _);
-            if (!inside.Any())
+            if (Boundaries != null)
             {
-                return;
-            }
+                var boundary2d = new Polygon(Boundaries.Vertices.Select(v => new Vector3(v.X, v.Y)).ToList());
+                var inside = new Line(new Vector3(start.X, start.Y), new Vector3(end.X, end.Y)).Trim(boundary2d, out var _);
+                if (!inside.Any())
+                {
+                    return;
+                }
 
-            var fi = inside.First();
-            start = new Vector3(fi.Start.X, fi.Start.Y, start.Z);
-            end = new Vector3(fi.End.X, fi.End.Y, end.Z);
+                var fi = inside.First();
+                start = new Vector3(fi.Start.X, fi.Start.Y, start.Z);
+                end = new Vector3(fi.End.X, fi.End.Y, end.Z);
+            }
 
             var onLine = candidates.Where(x => Line.PointOnLine(x, start, end));
             var ordered = onLine.OrderBy(x => (x - start).Dot(end - start));

--- a/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
@@ -64,8 +64,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <returns>New obstacle object.</returns>
         public static Obstacle FromBBox(BBox3 box, double offset = 0, bool perimeter = false)
         {
-            List<Vector3> points = new List<Vector3>() { box.Min, box.Max };
-            return new Obstacle(points, offset, perimeter, null);
+            return new Obstacle(box.Corners(), offset, perimeter, null);
         }
 
         /// <summary>
@@ -132,23 +131,23 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// List of points defining obstacle.
         /// </summary>
-        public List<Vector3> Points { get; private set; }
+        public List<Vector3> Points { get; set; }
 
         /// <summary>
         /// Offset of bounding box created from the list of points.
         /// </summary>
-        public double Offset { get; private set; }
+        public double Offset { get; set; }
 
         /// <summary>
         /// Should edges be created around obstacle.
         /// If false - any intersected edges are just discarded.
         /// If true - intersected edges are cut to obstacle and perimeter edges are inserted.
         /// </summary>
-        public bool Perimeter { get; private set; }
+        public bool Perimeter { get; set; }
 
         /// <summary>
         /// Transformation of bounding box created from the list of points.
         /// </summary>
-        public Transform Transform { get; private set; }
+        public Transform Transform { get; set; }
     }
 }

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -343,6 +343,44 @@ namespace Elements.Tests
 
             WriteToModelWithRandomMaterials(adaptiveGrid);
         }
+
+        [Fact]
+        public void BrokenSubtractionForMisalignedPolygon()
+        {
+            var boundaryVerticies = new List<Vector3>
+            {
+                new Vector3(0.241, -40, 7),
+                new Vector3(0.241, -60, 7),
+                new Vector3(80, -60.000000000000014, 7),
+                new Vector3(80, -40.000000000000014, 7)
+            };
+
+            var boundary = new Polygon(boundaryVerticies);
+
+            var grid = new AdaptiveGrid()
+            {
+                Boundaries = boundary
+            };
+
+            grid.AddFromPolygon(boundary, new[] { Vector3.Origin });
+
+            var profile = Polygon.Rectangle(0.2, 0.2);
+            var column = new Column(
+                new Vector3(0.5, -56.22727272727274),
+                10,
+                new Line(new Vector3(0.5, -56.22727272727274, 10), new Vector3(0.5, -56.22727272727274, 0)),
+                profile);
+
+            var obstacle = Obstacle.FromColumn(column, 0.2, true);
+            var result = grid.SubtractObstacle(obstacle);
+
+            Assert.True(result);
+            Assert.Equal(8, grid.GetEdges().Count);
+            Assert.All(grid.GetVertices(), x => Assert.Equal(2, x.Edges.Count));
+
+            WriteToModelWithRandomMaterials(grid);
+        }
+
         [Fact]
         public void AdaptiveGridLongSectionDoNowThrow()
         {

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Xunit;
 using Vertex = Elements.Spatial.AdaptiveGrid.Vertex;
@@ -16,9 +17,7 @@ namespace Elements.Tests
         [Fact, Trait("Category", "Examples")]
         public void AdaptiveGridPolygonKeyPointsExample()
         {
-            this.Name = "Elements_Spatial_AdaptiveGrid_AdaptiveGrid";
             // <example>
-            var random = new Random();
 
             var adaptiveGrid = new AdaptiveGrid();
             var points = new List<Vector3>()
@@ -32,19 +31,15 @@ namespace Elements.Tests
             adaptiveGrid.AddFromPolygon(Polygon.Rectangle(15, 10).TransformedPolygon(
                 new Transform(new Vector3(), new Vector3(10, 0, 10))), points);
 
-            foreach (var edge in adaptiveGrid.GetEdges())
-            {
-                Model.AddElement(new ModelCurve(adaptiveGrid.GetLine(edge), material: random.NextMaterial()));
-            }
             // </example>
+
+            WriteToModelWithRandomMaterials(adaptiveGrid, "Elements_Spatial_AdaptiveGrid_AdaptiveGrid");
         }
 
         [Fact]
         public void AdaptiveGridBboxKeyPointsExample()
         {
-            this.Name = "Elements_Spatial_AdaptiveGrid_AdaptiveGridBboxKeyPoints";
             // <example2>
-            var random = new Random();
 
             var adaptiveGrid = new AdaptiveGrid();
             var points = new List<Vector3>()
@@ -75,11 +70,9 @@ namespace Elements.Tests
             };
             adaptiveGrid.AddFromPolygon(rectangle.TransformedPolygon(new Transform(new Vector3(0, 0, 2))), points);
 
-            foreach (var edge in adaptiveGrid.GetEdges())
-            {
-                Model.AddElement(new ModelCurve(adaptiveGrid.GetLine(edge), material: random.NextMaterial()));
-            }
             // </example2>
+
+            WriteToModelWithRandomMaterials(adaptiveGrid, "Elements_Spatial_AdaptiveGrid_AdaptiveGridBboxKeyPoints");
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
It was notified that after last big changes to AdaptiveGrid that new Obstacle object is not always cut correctly:
- When grid is rotated, obstacle created from box was too small in one dimension.
- When grid boundary has elevation, parts of obstacle were incorrectly treated as outside,

DESCRIPTION:
- Use all corner points of the box to define obstacle instead of just min and max points.
- Make boundary check always done in 2d, don't do any checks if boundary is null.

TESTING:
- Added new tests to AdaptiveGridTests: AdaptiveGridSubstructRotatedBox and BrokenSubtractionForMisalignedPolygon
- Added WriteToModelWithRandomMaterials helper function that writes result to model and can automatically get calling function name.
  
FUTURE WORK:
- We might want to investigate why Line.Trim(Polygon) returns different results for boundary that is above the line. 

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/863)
<!-- Reviewable:end -->
