### PR TITLE
Update build-docs.yml

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           fetch-depth: 10
           token: ${{ secrets.HYPAR_GITHUB_BOT_PAT }}
+          ref: master
       - name: Setup Git
         run: |
           git config user.name "hypar-eric-bot"


### PR DESCRIPTION
use explicit ref since the default for releases appears to be something else

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/864)
<!-- Reviewable:end -->
