### PR TITLE
Add AllowOutsideBoundary and Intersects to Obstacle 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - `Ray.NearbyPoints()`
 - `PointOctree<T>`
 - `Message` class along with helper creation methods.
+- `AdaptiveGrid.Obstacle.AllowOutsideBoundary` property 
+- `AdaptiveGrid.Obstacle.Intersects(Polyline polyline, double tolerance = 1e-05)` method
 
 ### Changed
 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -1255,7 +1255,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <param name="tolerance">How far outside the range numbers are considered inside.
         /// When tolerance positive - range is increased by it, when negative - decreased.</param>
         /// <returns>Low, Inside or High.</returns>
-        private PointOrientation NumberOrientation(
+        private static PointOrientation NumberOrientation(
             double number,
             (double Min, double Max) domain,
             double tolerance)
@@ -1280,7 +1280,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <param name="startInside">Is start point of line inside the domain.</param>
         /// <param name="endInside">Is end point of line inside the domain.</param>
         /// <returns>Low, Inside or High.</returns>
-        private bool IsLineInDomain(
+        public static bool IsLineInDomain(
             (Vector3 Start, Vector3 End) line,
             (Vector3 Min, Vector3 Max) domain,
             double xyTolerance, double zTolerance, 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -282,10 +282,10 @@ namespace Elements.Spatial.AdaptiveGrid
                     var cornersAtElevation = corners.Select(
                         c => c.ProjectAlong(frame.ZAxis, plane)).ToList();
 
-                    AddEdgesOnLine(cornersAtElevation[0], cornersAtElevation[1], intersections);
-                    AddEdgesOnLine(cornersAtElevation[1], cornersAtElevation[2], intersections);
-                    AddEdgesOnLine(cornersAtElevation[2], cornersAtElevation[3], intersections);
-                    AddEdgesOnLine(cornersAtElevation[3], cornersAtElevation[0], intersections);
+                    AddEdgesOnLine(cornersAtElevation[0], cornersAtElevation[1], intersections, obstacle.AllowOutsideBoudary);
+                    AddEdgesOnLine(cornersAtElevation[1], cornersAtElevation[2], intersections, obstacle.AllowOutsideBoudary);
+                    AddEdgesOnLine(cornersAtElevation[2], cornersAtElevation[3], intersections, obstacle.AllowOutsideBoudary);
+                    AddEdgesOnLine(cornersAtElevation[3], cornersAtElevation[0], intersections, obstacle.AllowOutsideBoudary);
 
                     foreach (var item in group)
                     {
@@ -949,9 +949,9 @@ namespace Elements.Spatial.AdaptiveGrid
             return addedEdges;
         }
 
-        private void AddEdgesOnLine(Vector3 start, Vector3 end, IEnumerable<Vector3> candidates)
+        private void AddEdgesOnLine(Vector3 start, Vector3 end, IEnumerable<Vector3> candidates, bool allowEdgesOutsideBoudnary)
         {
-            if (Boundaries != null)
+            if (Boundaries != null && !allowEdgesOutsideBoudnary)
             {
                 var boundary2d = new Polygon(Boundaries.Vertices.Select(v => new Vector3(v.X, v.Y)).ToList());
                 var inside = new Line(new Vector3(start.X, start.Y), new Vector3(end.X, end.Y)).Trim(boundary2d, out var _);

--- a/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
@@ -152,7 +152,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// Should edges be created when obstacle is outside <see cref="AdaptiveGrid.Boundaries"/>, it will work only when <see cref="Perimeter"/> property is true />
         /// </summary>
-        public bool AllowOutsideBoudary { get; }
+        public bool AllowOutsideBoudary { get; set; }
 
         /// <summary>
         /// Transformation of bounding box created from the list of points.

--- a/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
@@ -158,5 +158,27 @@ namespace Elements.Spatial.AdaptiveGrid
         /// Transformation of bounding box created from the list of points.
         /// </summary>
         public Transform Transform { get; set; }
+
+        /// <summary>
+        /// Check if any segment of polyline intersects with obstacle or is inside of obstacle
+        /// </summary>
+        /// <param name="polyline">Polyline to check</param>
+        /// <param name="tolerance">Tolerance for checks</param>
+        /// <returns>Result of check</returns>
+        public bool Intersects(Polyline polyline, double tolerance = 1e-05)
+        {
+            var minX = Points.Min(x => x.X);
+            var maxX = Points.Max(x => x.X);
+            var minY = Points.Min(x => x.Y);
+            var maxY = Points.Max(x => x.Y);
+            var minZ = Points.Min(x => x.Z);
+            var maxZ = Points.Max(x => x.Z);
+
+            var domain = (new Vector3(minX, minY, minZ), new Vector3(maxX, maxY, maxZ));
+
+            return polyline
+                .Segments()
+                .Any(x => AdaptiveGrid.IsLineInDomain((x.Start, x.End), domain, tolerance, tolerance, out var _, out var _));
+        }
     }
 }

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -369,7 +369,6 @@ namespace Elements.Tests
             Assert.All(grid.GetVertices(), x => Assert.Equal(2, x.Edges.Count));
 
             WriteToModelWithRandomMaterials(grid);
-            Model.ToGlTF("../../../MisalignedColumn.gltf");
         }
 
         [Theory]

--- a/Elements/test/ObstacleTests.cs
+++ b/Elements/test/ObstacleTests.cs
@@ -1,0 +1,45 @@
+﻿using Elements.Geometry;
+using Elements.Spatial.AdaptiveGrid;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Elements
+{
+    public class ObstacleTests
+    {
+
+        [Theory]
+        [MemberData(nameof(GetIntersectsData))]
+        public void IntersectsTest(Polyline polyline, bool expectedResult)
+        {
+            var rectangle = Polygon.Rectangle(10, 10);
+            var obstacle = Obstacle.From2DPolygon(rectangle, 10);
+
+            var result = obstacle.Intersects(polyline);
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        public static IEnumerable<object[]> GetIntersectsData()
+        {
+            var smallPolygon = Polygon.Rectangle(5, 5);
+            //Polygon fully inside
+            yield return new object[] { smallPolygon.TransformedPolygon(new Transform(0, 0, 2)), true };
+            //Polygon fully outside
+            yield return new object[] { smallPolygon.TransformedPolygon(new Transform(0, 0, -2)), false };
+            //Only one vertex inside
+            yield return new object[] { smallPolygon.TransformedPolygon(new Transform(5, 5, 2)), true };
+            //Vertex on perimeter
+            yield return new object[] { smallPolygon.TransformedPolygon(new Transform(10, 10, 2)), false };
+
+            var bigPolygon = Polygon.Rectangle(20, 20);
+            //Obstacle inside polygon 
+            yield return new object[] { bigPolygon.TransformedPolygon(new Transform(0, 0, 2)), false };
+            //One segment intersecting with obstacle
+            yield return new object[] { bigPolygon.TransformedPolygon(new Transform(10, 0, 2)), true };
+
+        }
+    }
+}


### PR DESCRIPTION
BACKGROUND:
I wanted to combine two behaviors of `Obstacle` subtraction. 
1. When there is a `Boundary` set in `AdaptiveGrid` only the intersection between `Boundary` and `Obstacle` perimeter is subtracted from `Grid`. 
2. When `Boundary` is `null`, whole `Obstacle` perimeter is subtracted from `Grid`

DESCRIPTION:
Together with @wynged we came up with solution of adding `AllowOutsideBoundary` property which is configurable for each `Obstacle`. When new property is set to true, the whole perimeter is subtracted from `Grid`

I also added `Intersects(Polyline polyline)` method to `Obstacle` which I found useful.  It uses `IsLineInDomain` method from `AdaptiveGrid` which I had to make public and static. 

TESTING:
Run unit tests, which are in this PR
  
FUTURE WORK:
None

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
Maybe `IsLineInDomain` method be part of `Obstacle` class. It is a question to main author of this class @DmytroMuravskyi 
