### PR TITLE
Polyline intersects Polygon bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `Obstacle.FromBox` works properly with `AdaptiveGrid` transformation.
 - `AdaptiveGrid.SubtractObstacle` worked incorrectly in `AdaptiveGrid.Boundary` had elevation.
 - #805
+- `Polyline.Intersects(Polygon polygon, out List<Polyline> sharedSegments)` bug when polyline start/end is on polygon perimeter 
 
 ## 1.1.0
 

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -325,18 +325,6 @@ namespace Elements.Geometry.Tests
             Assert.Empty(sharedSegments);
         }
 
-        [Fact]
-        public void Test()
-        {
-            var polyline = new Polyline(new Vector3(-3, -2), new Vector3(-1, 0), new Vector3(-1, 5));
-            var expectedResult = new Polyline(new Vector3(-3, -2), new Vector3(-1, 0), new Vector3(-1, 2));
-            var polygon = Polygon.Rectangle(6, 4);
-            var result = polyline.Intersects(polygon, out var sharedSegments);
-
-            Assert.True(result);
-            Assert.Collection(sharedSegments, x => Assert.True(x.Equals(expectedResult)));
-        }
-
         [Theory]
         [MemberData(nameof(GetPolygonIntersectsTestData))]
         public void PolygonIntersectsReturnsOneSegment(Polyline polyline, Polyline expectedResult)
@@ -351,40 +339,67 @@ namespace Elements.Geometry.Tests
         public static IEnumerable<object[]> GetPolygonIntersectsTestData()
         {
             //Polyline is inside boundary
-            yield return new object[] { new Polyline(new Vector3(2, 0), new Vector3(-2, 0), new Vector3(-2, 1)),
-                new Polyline(new Vector3(2, 0), new Vector3(-2, 0), new Vector3(-2, 1)) };
+            yield return new object[] 
+            { 
+                new Polyline(new Vector3(2, 0), new Vector3(-2, 0), new Vector3(-2, 1)),
+                new Polyline(new Vector3(2, 0), new Vector3(-2, 0), new Vector3(-2, 1)) 
+            };
 
             //Polyline both ends outside boundary
-            yield return new object[] { new Polyline(new Vector3(-1, 5), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -5)),
-                new Polyline(new Vector3(-1, 2), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -2)) };
+            yield return new object[] 
+            { 
+                new Polyline(new Vector3(-1, 5), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -5)),
+                new Polyline(new Vector3(-1, 2), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -2)) 
+            };
 
             //Polyline end is on polygon boundary
-            yield return new object[] { new Polyline(new Vector3(-1, 5), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -2)),
-                new Polyline(new Vector3(-1, 2), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -2)) };
+            yield return new object[] 
+            { 
+                new Polyline(new Vector3(-1, 5), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -2)),
+                new Polyline(new Vector3(-1, 2), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -2)) 
+            };
 
             //Polyline start is on polygon boundary
-            yield return new object[] { new Polyline(new Vector3(-1, -5), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, 2)),
-                new Polyline(new Vector3(-1, -2), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, 2)) };
+            yield return new object[] 
+            { 
+                new Polyline(new Vector3(-1, -5), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, 2)),
+                new Polyline(new Vector3(-1, -2), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, 2)) 
+            };
 
             //Polyline end is inside boundary
-            yield return new object[] { new Polyline(new Vector3(1, 5), new Vector3(1,0), Vector3.Origin),
-                new Polyline(new Vector3(1, 2), new Vector3(1, 0), Vector3.Origin) };
+            yield return new object[] 
+            { 
+                new Polyline(new Vector3(1, 5), new Vector3(1,0), Vector3.Origin),
+                new Polyline(new Vector3(1, 2), new Vector3(1, 0), Vector3.Origin) 
+            };
 
             //Polyline start is inside boundary
-            yield return new object[] { new Polyline(new Vector3(-1, -5), new Vector3(-1, 0), Vector3.Origin),
-                new Polyline(new Vector3(-1, -2), new Vector3(-1, 0), Vector3.Origin) };
+            yield return new object[] 
+            { 
+                new Polyline(new Vector3(-1, -5), new Vector3(-1, 0), Vector3.Origin),
+                new Polyline(new Vector3(-1, -2), new Vector3(-1, 0), Vector3.Origin) 
+            };
 
             //Polyline end is boundary vertex
-            yield return new object[] { new Polyline(new Vector3(-1, -5), new Vector3(-1, 0), new Vector3(3, 2)),
-                new Polyline(new Vector3(-1, -2), new Vector3(-1, 0), new Vector3(3, 2)) };
+            yield return new object[] 
+            { 
+                new Polyline(new Vector3(-1, -5), new Vector3(-1, 0), new Vector3(3, 2)),
+                new Polyline(new Vector3(-1, -2), new Vector3(-1, 0), new Vector3(3, 2)) 
+            };
 
             //Polyline start is boundary vertex
-            yield return new object[] { new Polyline(new Vector3(-3, -2), new Vector3(-1, 0), new Vector3(-1, 5)),
-                new Polyline(new Vector3(-3, -2), new Vector3(-1, 0), new Vector3(-1, 2)) };
+            yield return new object[] 
+            { 
+                new Polyline(new Vector3(-3, -2), new Vector3(-1, 0), new Vector3(-1, 5)),
+                new Polyline(new Vector3(-3, -2), new Vector3(-1, 0), new Vector3(-1, 2)) 
+            };
 
             //Polyline segment is part of boundary
-            yield return new object[] { new Polyline(new Vector3(-1, 5), new Vector3(-1, 0), new Vector3(3, 0), new Vector3(3, 1)),
-                new Polyline(new Vector3(-1, 2), new Vector3(-1, 0), new Vector3(3, 0)) };
+            yield return new object[] 
+            { 
+                new Polyline(new Vector3(-1, 5), new Vector3(-1, 0), new Vector3(3, 0), new Vector3(3, 1)),
+                new Polyline(new Vector3(-1, 2), new Vector3(-1, 0), new Vector3(3, 0)) 
+            };
         }
 
         [Fact]

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -1,6 +1,6 @@
+using Elements.Tests;
 using System.Collections.Generic;
 using System.Linq;
-using Elements.Tests;
 using Xunit;
 
 namespace Elements.Geometry.Tests
@@ -326,44 +326,65 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
-        public void PolygonIntersectsReturnsPolylineWhenIsInside()
+        public void Test()
         {
-            var polygon = Polygon.Rectangle(4, 8);
-            var polyline = new Polyline(
-                new Vector3(-1, -2),
-                new Vector3(-1, 2),
-                new Vector3(1, 2),
-                new Vector3(1, -2));
-
+            var polyline = new Polyline(new Vector3(-3, -2), new Vector3(-1, 0), new Vector3(-1, 5));
+            var expectedResult = new Polyline(new Vector3(-3, -2), new Vector3(-1, 0), new Vector3(-1, 2));
+            var polygon = Polygon.Rectangle(6, 4);
             var result = polyline.Intersects(polygon, out var sharedSegments);
 
             Assert.True(result);
-            Assert.Single(sharedSegments);
-            Assert.Collection(sharedSegments, (x => Assert.Equal(polyline, x)));
+            Assert.Collection(sharedSegments, x => Assert.True(x.Equals(expectedResult)));
         }
 
-        [Fact]
-        public void PolygonIntersectsReturnsNewSegmentWhenTwoIntersections()
+        [Theory]
+        [MemberData(nameof(GetPolygonIntersectsTestData))]
+        public void PolygonIntersectsReturnsOneSegment(Polyline polyline, Polyline expectedResult)
         {
             var polygon = Polygon.Rectangle(6, 4);
-
-            var polyline = new Polyline(
-                new Vector3(-1, -3),
-                new Vector3(-1, 1),
-                new Vector3(1, 1),
-                new Vector3(1, -3));
-
-            var expectedResult = new Polyline(
-                new Vector3(-1, -2),
-                new Vector3(-1, 1),
-                new Vector3(1, 1),
-                new Vector3(1, -2));
-
             var result = polyline.Intersects(polygon, out var sharedSegments);
 
             Assert.True(result);
-            Assert.Single(sharedSegments);
             Assert.Collection(sharedSegments, x => Assert.True(x.Equals(expectedResult)));
+        }
+
+        public static IEnumerable<object[]> GetPolygonIntersectsTestData()
+        {
+            //Polyline is inside boundary
+            yield return new object[] { new Polyline(new Vector3(2, 0), new Vector3(-2, 0), new Vector3(-2, 1)),
+                new Polyline(new Vector3(2, 0), new Vector3(-2, 0), new Vector3(-2, 1)) };
+
+            //Polyline both ends outside boundary
+            yield return new object[] { new Polyline(new Vector3(-1, 5), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -5)),
+                new Polyline(new Vector3(-1, 2), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -2)) };
+
+            //Polyline end is on polygon boundary
+            yield return new object[] { new Polyline(new Vector3(-1, 5), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -2)),
+                new Polyline(new Vector3(-1, 2), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -2)) };
+
+            //Polyline start is on polygon boundary
+            yield return new object[] { new Polyline(new Vector3(-1, -5), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, 2)),
+                new Polyline(new Vector3(-1, -2), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, 2)) };
+
+            //Polyline end is inside boundary
+            yield return new object[] { new Polyline(new Vector3(1, 5), new Vector3(1,0), Vector3.Origin),
+                new Polyline(new Vector3(1, 2), new Vector3(1, 0), Vector3.Origin) };
+
+            //Polyline start is inside boundary
+            yield return new object[] { new Polyline(new Vector3(-1, -5), new Vector3(-1, 0), Vector3.Origin),
+                new Polyline(new Vector3(-1, -2), new Vector3(-1, 0), Vector3.Origin) };
+
+            //Polyline end is boundary vertex
+            yield return new object[] { new Polyline(new Vector3(-1, -5), new Vector3(-1, 0), new Vector3(3, 2)),
+                new Polyline(new Vector3(-1, -2), new Vector3(-1, 0), new Vector3(3, 2)) };
+
+            //Polyline start is boundary vertex
+            yield return new object[] { new Polyline(new Vector3(-3, -2), new Vector3(-1, 0), new Vector3(-1, 5)),
+                new Polyline(new Vector3(-3, -2), new Vector3(-1, 0), new Vector3(-1, 2)) };
+
+            //Polyline segment is part of boundary
+            yield return new object[] { new Polyline(new Vector3(-1, 5), new Vector3(-1, 0), new Vector3(3, 0), new Vector3(3, 1)),
+                new Polyline(new Vector3(-1, 2), new Vector3(-1, 0), new Vector3(3, 0)) };
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
I found that `Polyline.Intersects(Polygon polygon, out List<Polyline> sharedSegments)` returns wrong results when polyline start or end is on polygon perimeter.

DESCRIPTION:
I set `includeEnds` flag to true, when methods collects intersections between polygon segments and polyline. I had to add filtering of the same vectors for case polyline intersects with polygon vertex. 

TESTING:
Run unit test 
  
FUTURE WORK:
None

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
None

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/868)
<!-- Reviewable:end -->
