### PR TITLE
add support for override-linked dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `BBox3.Extend` method is public now
 - `AdaptiveGrid.Boundary` can be left null.
 - `Obstacle` properties `Points`, `Offset`, `Perimeter` and `Transform` can be modified from outside.
+- `LinearDimension`s now support `IOverrideLinked` behavior.
 
 ### Fixed
 

--- a/Elements/src/Annotations/Annotation.cs
+++ b/Elements/src/Annotations/Annotation.cs
@@ -1,5 +1,3 @@
-using Elements.Geometry;
-
 namespace Elements.Annotations
 {
     /// <summary>

--- a/Elements/src/Annotations/IOverrideLinked.cs
+++ b/Elements/src/Annotations/IOverrideLinked.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace Elements.Annotations
+{
+    /// <summary>
+    /// An annotation element which may be linked to the value of a property of
+    /// another element.
+    /// </summary>
+    public interface IOverrideLinked
+    {
+        /// <summary>
+        /// The property to which this annotation is linked.
+        /// </summary>
+        /// <value>Null if not linked, otherwise, a LinkedPropertyInfo
+        /// describing the linked element, property, and override
+        /// details.</value>
+        LinkedPropertyInfo LinkedProperty { get; set; }
+    }
+
+    /// <summary>
+    /// Information describing a linked property for this annotation. For
+    /// instance, a dimension which represents the width of a mass would store
+    /// linked property info describing the box element's "Width" property.
+    /// </summary>
+    public class LinkedPropertyInfo
+    {
+        /// <summary>
+        /// The id of the element that this property is linked to. 
+        /// </summary>
+        public Guid ElementId { get; set; }
+
+        /// <summary>
+        /// The name of the override containing the linked property.
+        /// </summary>
+        public string OverrideName { get; set; }
+
+        /// <summary>
+        /// The name of the linked property.
+        /// </summary>
+        public string PropertyName { get; set; }
+
+        /// <summary>
+        /// If true, this annotation should only be visible when the linked element is selected.
+        /// </summary>
+
+        public bool VisibleOnlyOnSelection { get; set; }
+
+        /// <summary>
+        /// If the linked property is an array, this is the index of the value
+        /// in the array this annotation represents.
+        /// </summary>
+        public int? Index { get; set; }
+    }
+}

--- a/Elements/src/Annotations/LinearDimension.cs
+++ b/Elements/src/Annotations/LinearDimension.cs
@@ -25,8 +25,7 @@ namespace Elements.Annotations
         public Plane ReferencePlane { get; protected set; }
 
         /// <summary>
-        /// If this dimension is linked to a property of another element,
-        /// information about that element and property.
+        /// Information about the element and property that this dimension is linked to, if any.
         /// </summary>
         public LinkedPropertyInfo LinkedProperty { get; set; } = null;
 

--- a/Elements/src/Annotations/LinearDimension.cs
+++ b/Elements/src/Annotations/LinearDimension.cs
@@ -7,7 +7,7 @@ namespace Elements.Annotations
     /// <summary>
     /// A linear dimension.
     /// </summary>
-    public abstract class LinearDimension : Annotation
+    public abstract class LinearDimension : Annotation, IOverrideLinked
     {
         /// <summary>
         /// The start of the dimension.
@@ -23,6 +23,12 @@ namespace Elements.Annotations
         /// The plane on which the start and end points are projected.
         /// </summary>
         public Plane ReferencePlane { get; protected set; }
+
+        /// <summary>
+        /// If this dimension is linked to a property of another element,
+        /// information about that element and property.
+        /// </summary>
+        public LinkedPropertyInfo LinkedProperty { get; set; } = null;
 
         /// <summary>
         /// Create a linear dimension with a reference plane.


### PR DESCRIPTION
BACKGROUND:
- To support intuitive geometric override editing, we want to support "editable dimensions" for objects. 

DESCRIPTION:
- Adds special metadata to `LinearDimension` objects by way of an `IOverrideLinked` interface. If this data is present, the Hypar web UI treats these dimensions differently (see corresponding PR).

TESTING:
- I created a test function (Editable Dimensions Example) here: `workflows/0e49a6cf-bcf6-4ce8-b80f-382b3ee2d388` (Note that this requires the corresponding Explore branch or sandbox: https://github.com/hypar-io/Explore/pull/2405)
- See also usage example here: https://github.com/andrewheumann/EditableDimensionsExample
  
FUTURE WORK:
- We may want other kinds of special behaviors for other classes of annotations in the future.

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- In general we try to avoid Hypar-specific behaviors in Elements, but this seemed reasonable since it was necessarily attached to a built-in type, and we already have some notion of overrides in this project.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/871)
<!-- Reviewable:end -->
