### PR TITLE
playground explore fixes

### DIFF
--- a/Elements.Playground/App.razor
+++ b/Elements.Playground/App.razor
@@ -1,10 +1,1 @@
-<Router AppAssembly="@typeof(Program).Assembly">
-    <Found Context="routeData">
-        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
-    </Found>
-    <NotFound>
-        <LayoutView Layout="@typeof(MainLayout)">
-            <p>Sorry, there's nothing at this address.</p>
-        </LayoutView>
-    </NotFound>
-</Router>
+<Elements.Playground.ElementsAPI />

--- a/Elements.Playground/ElementsAPI.razor
+++ b/Elements.Playground/ElementsAPI.razor
@@ -8,8 +8,11 @@
 
     public class Result
     {
-        public bool Success { get; set;}
-        public string Output { get; set;}
+        public bool Success { get; set; }
+
+        public string Output { get; set; }
+
+        public string ModelJson { get; set; }
     }
 
     // Why do we need a component to call Elements compile and
@@ -60,14 +63,14 @@
             };
         }
 
-        var model = await (Task<object>)executionDelegate(new object[] { globals, null });
+        var model = await (Task<object>)executionDelegate(new object[] { globals, null }) as Elements.Model;
         Console.WriteLine($"Run successful in {sw.ElapsedMilliseconds} ms");
         sw.Reset();
 
         await Task.Run(async () =>
         {
             sw.Start();
-            var glb = ((Elements.Model)model).ToGlTF();
+            var glb = model.ToGlTF();
             await runtime.InvokeVoidAsync("elements.loadModel", glb);
             Console.WriteLine($"GlTF loaded in {sw.ElapsedMilliseconds} ms");
             success = true;
@@ -80,13 +83,22 @@
         return new Result()
         {
             Success = success,
-            Output = writer.ToString()
+            Output = writer.ToString(),
+            ModelJson = model.ToJson()
         };
     }
 
     [JSInvokable]
     public static Result Compile(string code)
     {
+        if (!Compiler.IsReady())
+        {
+            return new Result
+            {
+                Success = false,
+                Output = "Compiler not ready"
+            };
+        }
         var sw = Stopwatch.StartNew();
 
         var currentOut = Console.Out;
@@ -132,10 +144,9 @@
     }
 
     [JSInvokable]
-    public static void UpdateInputs(Dictionary<string,double> inputs)
+    public static void UpdateInputs(string json)
     {
-        globals.Inputs.Clear();
-        globals.Inputs = inputs;
+        globals.InputJson = json;
         return;
     }
 }

--- a/Elements.Playground/README.md
+++ b/Elements.Playground/README.md
@@ -1,8 +1,10 @@
 # Elements Playground
 The elements web assembly API, for using Elements in the browser.
 
-### Running
-`dotnet watch run`
+### Running Locally
+`./serve.sh` - to serve Elements wasm assets
+Edit `wwwroot/index.html` to use localhost:5001, instead of the `https://elements.hypar.io` url.
+Serve `wwroot` (e.g. `python3 -m http.server`).
 
 ### Publishing
 `dotnet publish -c release`

--- a/Elements.Playground/_Imports.razor
+++ b/Elements.Playground/_Imports.razor
@@ -16,7 +16,6 @@
 @using Elements.Geometry
 @using Elements.Geometry.Profiles
 @using Elements.Serialization.glTF
-@using System.Diagnostics
 @using Microsoft.CodeAnalysis.CSharp.Scripting
 @using Microsoft.CodeAnalysis
 @using Microsoft.CodeAnalysis.CSharp

--- a/Elements.Playground/serve.py
+++ b/Elements.Playground/serve.py
@@ -1,0 +1,38 @@
+
+# !/usr/bin/env python3
+
+# Use this to serve the built Elements.Playground locally. 
+
+# Adapted from Francesco Pira's python http server with cors: https://fpira.com/blog/2020/05/python-http-server-with-cors
+
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+import sys
+import os
+
+# app client URL
+client = 'http://localhost:8080'
+
+# move to the framework directory
+os.chdir('bin/release/net6.0/publish/wwwroot/_framework')
+
+
+class CORSRequestHandler(SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header('Access-Control-Allow-Origin', client)
+        self.send_header('Access-Control-Allow-Methods', client)
+        self.send_header('Access-Control-Allow-Headers', client)
+        self.send_header('Access-Control-Allow-Credentials', 'true')
+        self.send_header('Cache-Control', 'no-store, no-cache, must-revalidate')
+        return super(CORSRequestHandler, self).end_headers()
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.end_headers()
+
+
+host = sys.argv[1] if len(sys.argv) > 2 else '0.0.0.0'
+port = int(sys.argv[len(sys.argv) - 1]) if len(sys.argv) > 1 else 5001
+
+print("Listening on {}:{}".format(host, port))
+httpd = HTTPServer((host, port), CORSRequestHandler)
+httpd.serve_forever()

--- a/Elements.Playground/serve.sh
+++ b/Elements.Playground/serve.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+echo "Building the app..."
+dotnet publish -c release -p:RunAOTCompilation=false
+
+echo "Serving the build assets at http://localhost:5001"
+python3 -m serve.py

--- a/Elements.Playground/wwwroot/index.html
+++ b/Elements.Playground/wwwroot/index.html
@@ -11,16 +11,13 @@
 
 <body>
     <app></app>
-    <script src="_framework/blazor.webassembly.js" autostart="false"></script>
+    <script src="https://elements.hypar.io/blazor.webassembly.js" autostart="false"></script>
     <script>
         // Insert this code into your web application
         // to load blazor assets locally, for testing,
         // or from elements.hypar.io, for production.
-        async function startBlazor() {
+        async function startBlazor () {
             let root = 'https://elements.hypar.io'
-            if (window.origin.includes("https://localhost:")) {
-                root = `${window.origin}/_framework`;
-            }
             await Blazor.start({
                 loadBootResource: function (type, name, defaultUri, integrity) {
                     // console.log(`Loading: '${type}', '${name}', '${defaultUri}', '${integrity}'`);
@@ -31,6 +28,7 @@
                         case 'dotnetjs':
                         case 'dotnetwasm':
                         case 'timezonedata':
+                        case 'pdb':
                             return `${root}/${name}`
                     }
                     return null
@@ -39,14 +37,14 @@
         }
         startBlazor()
 
-        async function updateInputs(value) {
-            elements.updateInputs({ "height": parseFloat(value) });
+        async function updateInputs (value) {
+            elements.updateInputs(JSON.stringify({ "height": parseFloat(value) }));
             let result = await elements.run();
             let resultDiv = document.getElementById("result");
             resultDiv.innerHTML = result.output;
         }
 
-        async function compile() {
+        async function compile () {
             let result = await elements.compile(elements.testCode);
             let resultDiv = document.getElementById("result");
             resultDiv.innerHTML = result.output;

--- a/Elements.Playground/wwwroot/index.html
+++ b/Elements.Playground/wwwroot/index.html
@@ -17,6 +17,7 @@
         // to load blazor assets locally, for testing,
         // or from elements.hypar.io, for production.
         async function startBlazor () {
+            // If you are running locally, replace this with http://localhost:5001
             let root = 'https://elements.hypar.io'
             await Blazor.start({
                 loadBootResource: function (type, name, defaultUri, integrity) {

--- a/Elements.Playground/wwwroot/js/elements.d.ts
+++ b/Elements.Playground/wwwroot/js/elements.d.ts
@@ -1,0 +1,11 @@
+export interface RunResult {
+    output: string,
+    success: boolean,
+    modelJson?: string,
+}
+export class Elements {
+    public testCode: string
+    compile(code: string): Promise<RunResult>
+    run(): Promise<RunResult>
+    updateInputs(inputs: string): Promise<void>
+}

--- a/Elements.Playground/wwwroot/js/elements.js
+++ b/Elements.Playground/wwwroot/js/elements.js
@@ -1,3 +1,4 @@
+// Note: If updating this file to expose new APIs, please also update the adjacent type definition file at elements.d.ts.
 class Elements {
     testCode = `
     var model = new Model(); 

--- a/Elements.Playground/wwwroot/js/elements.js
+++ b/Elements.Playground/wwwroot/js/elements.js
@@ -1,20 +1,30 @@
 class Elements {
-    compilerReference = null;
-    testCode = 'var model = new Model(); var mass = new Mass(Polygon.Rectangle(1,1), Inputs.ContainsKey("height") ? Inputs["height"]: 5, BuiltInMaterials.Wood); Console.WriteLine($"The volume of the mass is {mass.Volume()}."); model.AddElement(mass); return model;';
+    testCode = `
+    var model = new Model(); 
+    // This class can be modified to suit your needs. It
+    // should be a model of the JSON you plan to send through updateInputs.
+    class InputClass {
+        public double? Height {get; set;}
+    }
+    var input = JsonSerializer.Deserialize<InputClass>(InputJson);
+    var mass = new Mass(Polygon.Rectangle(1,1), input.Height ?? 5, BuiltInMaterials.Wood); 
+    Console.WriteLine($"The volume of the mass is {mass.Volume()}."); 
+    model.AddElement(mass); 
+    return model;`
 
-    async compile(code) {
+    async compile (code) {
         return DotNet.invokeMethodAsync('Elements.Playground', 'Compile', code)
     }
 
-    async run() {
+    async run () {
         return DotNet.invokeMethodAsync('Elements.Playground', 'Run');
     }
 
-    async updateInputs(inputs) {
+    async updateInputs (inputs) {
         return DotNet.invokeMethod('Elements.Playground', 'UpdateInputs', inputs);
     }
 
-    loadModel(bytes) {
+    loadModel (bytes) {
         // console.debug(bytes);
         return true;
     }


### PR DESCRIPTION
BACKGROUND:
- I had to make some adjustments to the `wasm` branch to support calling it from Hypar's front-end. 

DESCRIPTION:
- I removed the Blazor Router, which was getting confused when being called from e.g. `localhost:8080/workflows/{id}`, and just return the elements API component directly
- I changed the `Globals` object to take a JSON string, instead of a dictionary.
- I updated the `Run` operation to return the model json
- I added a `serve` script for use during local Elements development.

TESTING:
- I tested this by building and deploying (a version that ALSO had branch `stj-ah` merged in, in case it matters) to S3, and building an explore sandbox that calls into this code. I verified I could compile and run custom elements code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/875)
<!-- Reviewable:end -->
