### PR TITLE
fix splitting of clockwise profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `AdaptiveGrid.SubtractObstacle` worked incorrectly in `AdaptiveGrid.Boundary` had elevation.
 - #805
 - `Polyline.Intersects(Polygon polygon, out List<Polyline> sharedSegments)` bug when polyline start/end is on polygon perimeter 
+- `Profile.Split` would fail if the perimeter was clockwise-wound.
 
 ## 1.1.0
 

--- a/Elements/src/Geometry/Profile.cs
+++ b/Elements/src/Geometry/Profile.cs
@@ -488,14 +488,16 @@ namespace Elements.Geometry
             List<Profile> resultProfiles = new List<Profile>();
             foreach (var inputProfile in profiles)
             {
+                var polygons = new List<Polygon>();
                 if (inputProfile.Perimeter.IsClockWise())
                 {
-                    inputProfile.Perimeter = inputProfile.Perimeter.Reversed();
+                    polygons.Add(inputProfile.Perimeter.Reversed());
                 }
-                inputProfile.OrientVoids();
-                var polygons = new List<Polygon>() {
-                    inputProfile.Perimeter
-                };
+                else
+                {
+                    polygons.Add(inputProfile.Perimeter);
+                }
+
                 var splitters = new List<Polyline>(splitLines);
                 if (inputProfile.Voids != null)
                 {

--- a/Elements/src/Geometry/Profile.cs
+++ b/Elements/src/Geometry/Profile.cs
@@ -488,6 +488,10 @@ namespace Elements.Geometry
             List<Profile> resultProfiles = new List<Profile>();
             foreach (var inputProfile in profiles)
             {
+                if (inputProfile.Perimeter.IsClockWise())
+                {
+                    inputProfile.Perimeter = inputProfile.Perimeter.Reversed();
+                }
                 inputProfile.OrientVoids();
                 var polygons = new List<Polygon>() {
                     inputProfile.Perimeter

--- a/Elements/test/ProfileTests.cs
+++ b/Elements/test/ProfileTests.cs
@@ -551,5 +551,16 @@ namespace Elements.Tests
                 Model.AddElement(ge);
             }
         }
+
+        [Fact]
+        public void ProfilesWoundClockwiseSplitCorrectly()
+        {
+            Name = nameof(ProfilesWoundClockwiseSplitCorrectly);
+            var polygon = new Polygon((0, 0, 0), (0, 10, 0), (10, 10, 0), (10, 0, 0));
+            var polylineOffsetInside = new Polygon((3, 3), (3, 7), (7, 7), (7, 3));
+            var extendedLines = polylineOffsetInside.Segments().Select(s => s.ExtendTo(polygon, true).ToPolyline(1)).ToList();
+            var splitResults = Elements.Geometry.Profile.Split(new[] { new Profile(polygon) }, extendedLines);
+            Assert.Equal(9, splitResults.Count);
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- Fixes #877 

DESCRIPTION:
- Forces split profiles to be counter-clockwise wound, since the code measures rotation angle relative to positive Z. 

TESTING:
- I added a new test from user code, and verified it produced the expected results. 
  
FUTURE WORK:
- We might want to figure out an average `Normal` for the profiles and feed that as the normal to the polygonizer, so we can respect the input winding. But in the case that some profiles are CW, and some are CCW, it's not clear what the algorithm should do. 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/878)
<!-- Reviewable:end -->
