### PR TITLE
always make the default material available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - `Ray.NearbyPoints()`
 - `PointOctree<T>`
 - `Message` class along with helper creation methods.
-- `AdaptiveGrid.Obstacle.AllowOutsideBoundary` property 
+- `AdaptiveGrid.Obstacle.AllowOutsideBoundary` property
 - `AdaptiveGrid.Obstacle.Intersects(Polyline polyline, double tolerance = 1e-05)` method
 - `AdaptiveGrid.Obstacle.Intersects(Line line, double tolerance = 1e-05)` method
 - `AdaptiveGrid.Obstacle.IsInside(Vector3 point, double tolerance = 1e-05)` method
@@ -32,7 +32,8 @@
 - `Obstacle.FromBox` works properly with `AdaptiveGrid` transformation.
 - `AdaptiveGrid.SubtractObstacle` worked incorrectly in `AdaptiveGrid.Boundary` had elevation.
 - #805
-- `Polyline.Intersects(Polygon polygon, out List<Polyline> sharedSegments)` bug when polyline start/end is on polygon perimeter 
+- `Polyline.Intersects(Polygon polygon, out List<Polyline> sharedSegments)` bug when polyline start/end is on polygon perimeter
+- Always make the default material available when writing a gltf file.
 
 ## 1.1.0
 

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -38,10 +38,10 @@ namespace Elements.Serialization.glTF
 
         /// <summary>
         /// In normal function use, this should be set to null.
-        /// If not null and set to a valid directory path, gltfs loaded for 
+        /// If not null and set to a valid directory path, gltfs loaded for
         /// content elements will be cached to this directory, and can be
         /// explicitly loaded by calling LoadGltfCacheFromDisk(). This is used
-        /// by `hypar run` and test capabilities to speed up repeated runs. 
+        /// by `hypar run` and test capabilities to speed up repeated runs.
         /// </summary>
         public static string GltfCachePath
         {
@@ -902,9 +902,9 @@ namespace Elements.Serialization.glTF
 
             // Attempt to pre-allocate these lists. This won't be perfect.
             // Before processing the geometry of an element we can't know
-            // how much to allocate. In the worst case, this will reduce 
+            // how much to allocate. In the worst case, this will reduce
             // the list resizing.
-            // TODO: In future work where we update element geometry during 
+            // TODO: In future work where we update element geometry during
             // UpdateRepresentations, we will know at this moment how big the
             // geometry for an element is, and we should tighten this up.
             var elementCount = model.AllElementsAssignableFromType<GeometricElement>().Count();
@@ -962,8 +962,8 @@ namespace Elements.Serialization.glTF
             }
 
             // Gltf can't handle a materials array with zero materials.
-            // So we add the default material if this happens.
-            if (materialsToAdd.Count == 0)
+            // and we always want the default material to be available.
+            if (!materialsToAdd.Contains(BuiltInMaterials.Default))
             {
                 materialsToAdd.Add(BuiltInMaterials.Default);
             }


### PR DESCRIPTION
BACKGROUND:
- While writing gltf for a model the default material was not available during mesh material assignment, which caused errors.

DESCRIPTION:
- Make it so that the default material is always available to the gltf mesh writers.

TESTING:
- tests all still pass, material is available.
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/879)
<!-- Reviewable:end -->
