### PR TITLE
Bugfix: remove offset from obstacle points

### DIFF
--- a/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
@@ -14,7 +14,6 @@ namespace Elements.Spatial.AdaptiveGrid
     /// </summary>
     public class Obstacle : GeometricElement
     {
-        private Transform _transform;
         private double _offset;
         private Polygon _boundary;
         private double _height;
@@ -139,7 +138,10 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// List of points defining obstacle.
         /// </summary>
-        public List<Vector3> Points => _primaryPolygons.SelectMany(x => x.Vertices).ToList();
+        public List<Vector3> Points => Boundary?
+            .Vertices
+            .SelectMany(x => new List<Vector3> { x, x + new Vector3(0, 0, Height) })
+            .ToList() ?? new List<Vector3>();
         
         /// <summary>
         /// Perimeter defining obstacle.


### PR DESCRIPTION
BACKGROUND:
When I was working on `Obstacle` changed bahaviour of an Obstacle object. When Points property is accessed I returned points list with offset applied, unfortunately `AdatpiveGrid.SubtractObstacle` uses Points without offset and adds it during subtract.

DESCRIPTION:
Return Points list without any offset

TESTING:
Run unit tests 
  
FUTURE WORK:
In future `AdatpiveGrid.SubtractObstacle` can use Obstacle `Intersects` methods 

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/880)
<!-- Reviewable:end -->
