### PR TITLE
Fix buffer merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - `Ray.NearbyPoints()`
 - `PointOctree<T>`
 - `Message` class along with helper creation methods.
-- `AdaptiveGrid.Obstacle.AllowOutsideBoundary` property 
+- `AdaptiveGrid.Obstacle.AllowOutsideBoundary` property
 - `AdaptiveGrid.Obstacle.Intersects(Polyline polyline, double tolerance = 1e-05)` method
 - `AdaptiveGrid.Obstacle.Intersects(Line line, double tolerance = 1e-05)` method
 - `AdaptiveGrid.Obstacle.IsInside(Vector3 point, double tolerance = 1e-05)` method
@@ -32,7 +32,8 @@
 - `Obstacle.FromBox` works properly with `AdaptiveGrid` transformation.
 - `AdaptiveGrid.SubtractObstacle` worked incorrectly in `AdaptiveGrid.Boundary` had elevation.
 - #805
-- `Polyline.Intersects(Polygon polygon, out List<Polyline> sharedSegments)` bug when polyline start/end is on polygon perimeter 
+- `Polyline.Intersects(Polygon polygon, out List<Polyline> sharedSegments)` bug when polyline start/end is on polygon perimeter
+- `GltfBufferExtensions.CombineBufferAndFixRefs` bug when combining buffers from multiple gltf files.
 
 ## 1.1.0
 

--- a/Elements/src/Serialization/glTF/GltfBufferExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfBufferExtensions.cs
@@ -71,7 +71,7 @@ namespace Elements.Serialization.glTF
                     foreach (var buffView in referringViews)
                     {
                         buffView.Buffer = 0;
-                        buffView.ByteOffset += index + 1;
+                        buffView.ByteOffset += index;
                     }
                 }
 

--- a/Elements/test/ContentTests.cs
+++ b/Elements/test/ContentTests.cs
@@ -42,7 +42,6 @@ namespace Elements.Tests
             var str = boxType2.ToString();
             boxType.AdditionalProperties["ImportantParameter"] = "The Value";
 
-
             var testCatalog = new ContentCatalog(new List<ContentElement> { boxType, boxType2 }, new List<Element>(), Guid.NewGuid(), "test");
 
             var savePath = "../../../models/ContentCatalog.json";
@@ -93,10 +92,10 @@ namespace Elements.Tests
             model.AddElement(twoDuck);
             // </example>
             var sw = System.Diagnostics.Stopwatch.StartNew();
-            model.ToGlTF("./models/ContentInstancing.glb");
+            model.ToGlTF($"./models/{nameof(InstanceContentElement)}.glb");
             var firstRun = sw.Elapsed.TotalSeconds;
             sw.Restart();
-            model.ToGlTF("./models/ContentInstancing.gltf", false);
+            model.ToGlTF($"./models/{nameof(InstanceContentElement)}.gltf", false);
             var secondRun = sw.Elapsed.TotalSeconds;
             Assert.True(firstRun > secondRun); // caching should result in faster model generation second time.
         }


### PR DESCRIPTION
BACKGROUND:
- A contributor noticed that they were not getting valid models produced by one of the functions when running a recent elements alpha.  It seemed to only occur in a function with content.

DESCRIPTION:
- The index incrementing for merged buffers was wrong, creating invalid buffer view accessors.

TESTING:
- you can run the content test "IsntanceContentElement" that produce glbs.  Included are the before and the after.  Before this change the glb cannot be opened.
[InstanceContentElement.zip](https://github.com/hypar-io/Elements/files/9480186/InstanceContentElement.zip)

  
FUTURE WORK:
- ~Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?~

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/882)
<!-- Reviewable:end -->
