### PR TITLE
Obstacle wall creation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - #805
 - `Polyline.Intersects(Polygon polygon, out List<Polyline> sharedSegments)` bug when polyline start/end is on polygon perimeter
 - `GltfBufferExtensions.CombineBufferAndFixRefs` bug when combining buffers from multiple gltf files.
+- `Obstacle.FromWall` was failing when producing a polygon.
 
 ## 1.1.0
 

--- a/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
@@ -50,8 +50,8 @@ namespace Elements.Spatial.AdaptiveGrid
             (
                 wall.CenterLine.Start + ortho * wall.Thickness / 2,
                 wall.CenterLine.End + ortho * wall.Thickness / 2,
-                wall.CenterLine.Start - ortho * wall.Thickness / 2,
-                wall.CenterLine.End - ortho * wall.Thickness / 2
+                wall.CenterLine.End - ortho * wall.Thickness / 2,
+                wall.CenterLine.Start - ortho * wall.Thickness / 2
             );
             var transfrom = new Transform(Vector3.Origin,
                 wall.CenterLine.Direction(), ortho, Vector3.ZAxis);
@@ -142,11 +142,11 @@ namespace Elements.Spatial.AdaptiveGrid
             .Vertices
             .SelectMany(x => new List<Vector3> { x, x + new Vector3(0, 0, Height) })
             .ToList() ?? new List<Vector3>();
-        
+
         /// <summary>
         /// Perimeter defining obstacle.
         /// </summary>
-        public Polygon Boundary 
+        public Polygon Boundary
         {
             get => _boundary;
             set
@@ -159,7 +159,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// Obstacle height, offset by Boundary normal vector
         /// </summary>
-        public double Height 
+        public double Height
         {
             get => _height;
             set
@@ -172,7 +172,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// Offset of bounding box created from the list of points.
         /// </summary>
-        public double Offset 
+        public double Offset
         {
             get => _offset;
             set
@@ -236,30 +236,30 @@ namespace Elements.Spatial.AdaptiveGrid
         private bool DoesPolygonIntersectsWithLine(Polygon polygon, Line line, double tolerance = 1e-05)
         {
             var plane = polygon.Plane();
-            if(!line.Intersects(plane, out var intersection, true))
+            if (!line.Intersects(plane, out var intersection, true))
             {
                 return false;
             }
 
-            if(!polygon.Contains3D(intersection))
+            if (!polygon.Contains3D(intersection))
             {
                 return false;
             }
 
             var points = new List<Vector3> { line.Start, line.End };
 
-            return points.Any(x => plane.SignedDistanceTo(x) < - tolerance);
-            
+            return points.Any(x => plane.SignedDistanceTo(x) < -tolerance);
+
         }
 
         private bool IntersectsWithHorizontalPolygon(Polygon polygon, Line line, double tolerance = 1e-05)
         {
-            if(polygon.Contains3D(line.Start) || polygon.Contains3D(line.End))
+            if (polygon.Contains3D(line.Start) || polygon.Contains3D(line.End))
             {
                 return true;
             }
 
-            if(!polygon.Intersects(line, out var intersections, false, includeEnds: true))
+            if (!polygon.Intersects(line, out var intersections, false, includeEnds: true))
             {
                 return false;
             }
@@ -269,7 +269,7 @@ namespace Elements.Spatial.AdaptiveGrid
 
         private void UpdatePolygons()
         {
-            if(Boundary == null)
+            if (Boundary == null)
             {
                 return;
             }
@@ -280,14 +280,14 @@ namespace Elements.Spatial.AdaptiveGrid
             var boundaryTransform = new Transform(Boundary.Centroid(), Boundary.Plane().Normal);
             var boundary = Boundary.TransformedPolygon(boundaryTransform.Inverted()).Offset(Offset).FirstOrDefault();
 
-            if(boundary == null)
+            if (boundary == null)
             {
                 return;
             }
 
             boundary = boundary.TransformedPolygon(boundaryTransform);
 
-            if(Transform != null)
+            if (Transform != null)
             {
                 boundary = boundary.TransformedPolygon(Transform);
             }
@@ -303,7 +303,7 @@ namespace Elements.Spatial.AdaptiveGrid
 
             var topVector = boundary.Normal().Negate() * (Height + 2 * Offset);
 
-            if(topVector.IsAlmostEqualTo(Vector3.Origin))
+            if (topVector.IsAlmostEqualTo(Vector3.Origin))
             {
                 return;
             }
@@ -316,7 +316,7 @@ namespace Elements.Spatial.AdaptiveGrid
             {
                 var polygon = new Polygon(segment.Start, segment.End, segment.End + topVector, segment.Start + topVector).Reversed();
                 _secondaryPolygons.Add(polygon);
-            }            
+            }
         }
     }
 }

--- a/Elements/test/ObstacleTests.cs
+++ b/Elements/test/ObstacleTests.cs
@@ -60,9 +60,9 @@ namespace Elements
             var smallPolygon = Polygon.Rectangle(5, 5);
             //Polygon fully inside
             yield return new object[] { smallPolygon.TransformedPolygon(new Transform(0, 0, 2)), true, 1 };
-            //Polygon fully outside below 
+            //Polygon fully outside below
             yield return new object[] { smallPolygon.TransformedPolygon(new Transform(0, 0, -2)), false, 2 };
-            //Polygon fully outside on side 
+            //Polygon fully outside on side
             yield return new object[] { smallPolygon.TransformedPolygon(new Transform().Rotated(Vector3.YAxis, 90).Moved(7, 0, 5)), false, 3 };
             //Only one vertex inside
             yield return new object[] { smallPolygon.TransformedPolygon(new Transform(5, 5, 2)), true, 4 };
@@ -70,7 +70,7 @@ namespace Elements
             yield return new object[] { smallPolygon.TransformedPolygon(new Transform(10, 10, 2)), false, 5 };
 
             var bigPolygon = Polygon.Rectangle(20, 20);
-            //Obstacle inside polygon 
+            //Obstacle inside polygon
             yield return new object[] { bigPolygon.TransformedPolygon(new Transform(0, 0, 2)), false, 6 };
             //One segment intersecting with obstacle
             yield return new object[] { bigPolygon.TransformedPolygon(new Transform(10, 0, 2)), true, 7 };
@@ -115,6 +115,22 @@ namespace Elements
             var result = obstacle.Intersects(polyline);
 
             Assert.False(result);
+        }
+
+        [Fact]
+        public void ObstacleFromWall()
+        {
+            var wall = new StandardWall(new Line(Vector3.Origin, new Vector3(10, 0)), 0.5, 3);
+            var obstacle = Obstacle.FromWall(wall, 0.5);
+
+            // intersects wall line
+            Assert.True(obstacle.Intersects(new Line(Vector3.Origin, new Vector3(10, 0))));
+            // intersects line that crosses wall
+            Assert.True(obstacle.Intersects(new Line(new Vector3(3, -1, 2), new Vector3(3, 1, 3))));
+            // intersects line that crosses wall at the top
+            Assert.True(obstacle.Intersects(new Line(new Vector3(3, -1, 3.5), new Vector3(3, 1, 3.5))));
+            // does not intersect line that is above wall
+            Assert.False(obstacle.Intersects(new Line(new Vector3(0, 0, 4), new Vector3(10, 0, 4))));
         }
 
         [Fact]

--- a/Elements/test/ObstacleTests.cs
+++ b/Elements/test/ObstacleTests.cs
@@ -120,7 +120,8 @@ namespace Elements
         [Fact]
         public void ObstacleFromWall()
         {
-            var wall = new StandardWall(new Line(Vector3.Origin, new Vector3(10, 0)), 0.5, 3);
+            Line centerLine = new Line(Vector3.Origin, new Vector3(10, 0));
+            var wall = new StandardWall(centerLine, 0.5, 3);
             var obstacle = Obstacle.FromWall(wall, 0.5);
 
             // intersects wall line
@@ -131,6 +132,11 @@ namespace Elements
             Assert.True(obstacle.Intersects(new Line(new Vector3(3, -1, 3.5), new Vector3(3, 1, 3.5))));
             // does not intersect line that is above wall
             Assert.False(obstacle.Intersects(new Line(new Vector3(0, 0, 4), new Vector3(10, 0, 4))));
+
+            // ensure that line direction does not matter
+            centerLine = centerLine.Reversed();
+            var wall2 = new StandardWall(centerLine, 0.5, 3);
+            var obstacle2 = Obstacle.FromWall(wall2, 0.5);
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
- One of our functions was failing after being published with the latest version of Elements.

DESCRIPTION:
- Change the order of vertex addition when creating a polygon from a wall.
- Add tests to catch this and confirm some basic obstacle behavior.
- bunch of whitespace linting

TESTING:
- Tests run
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/884)
<!-- Reviewable:end -->
