### PR TITLE
Find all closed regions in a network.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,8 @@
 - `AdaptiveGrid.Obstacle.Intersects(Line line, double tolerance = 1e-05)` method
 - `AdaptiveGrid.Obstacle.IsInside(Vector3 point, double tolerance = 1e-05)` method
 - `Elements.SVG.SvgSection.CreatePlanFromFromModels(IList<Model> models, double elevation, SvgContext frontContext, SvgContext backContext, string path, bool showGrid = true, double gridHeadExtension = 2.0, double gridHeadRadius = 0.5, PlanRotation planRotation = PlanRotation.Angle, double planRotationDegrees = 0.0)`
-- `Network.FindAllClosedRegionsBypassingInternalLeaves(List<Vector3> allNodeLocations)`
 - `Network.FindAllClosedRegions(List<Vector3> allNodeLocations)`
 - `Network.TraverseSmallestPlaneAngle((int currentIndex, int previousIndex, IEnumerable<int> edgeIndices) traversalData,
-                                               List<Vector3> allNodeLocations,
-                                               List<LocalEdge> visitedEdges,
-                                               Network<T> network)`
-- `Network.TraverseSmallestPlaneAngleToNonLeaf((int currentIndex, int previousIndex, IEnumerable<int> edgeIndices) traversalData,
                                                List<Vector3> allNodeLocations,
                                                List<LocalEdge> visitedEdges,
                                                Network<T> network)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@
 - `AdaptiveGrid.Obstacle.Intersects(Line line, double tolerance = 1e-05)` method
 - `AdaptiveGrid.Obstacle.IsInside(Vector3 point, double tolerance = 1e-05)` method
 - `Elements.SVG.SvgSection.CreatePlanFromFromModels(IList<Model> models, double elevation, SvgContext frontContext, SvgContext backContext, string path, bool showGrid = true, double gridHeadExtension = 2.0, double gridHeadRadius = 0.5, PlanRotation planRotation = PlanRotation.Angle, double planRotationDegrees = 0.0)`
+- `Network.FindAllClosedRegionsBypassingInternalLeaves(List<Vector3> allNodeLocations)`
+- `Network.FindAllClosedRegions(List<Vector3> allNodeLocations)`
+- `Network.TraverseSmallestPlaneAngle((int currentIndex, int previousIndex, IEnumerable<int> edgeIndices) traversalData,
+                                               List<Vector3> allNodeLocations,
+                                               List<LocalEdge> visitedEdges,
+                                               Network<T> network)`
+- `Network.TraverseSmallestPlaneAngleToNonLeaf((int currentIndex, int previousIndex, IEnumerable<int> edgeIndices) traversalData,
+                                               List<Vector3> allNodeLocations,
+                                               List<LocalEdge> visitedEdges,
+                                               Network<T> network)`
 
 ### Changed
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1270,5 +1270,13 @@ namespace Elements.Geometry
             return Start.DistanceTo(plane).ApproximatelyEquals(0, tolerance)
                 && End.DistanceTo(plane).ApproximatelyEquals(0, tolerance);
         }
+
+        /// <summary>
+        /// A string representation of the line.
+        /// </summary>
+        public override string ToString()
+        {
+            return $"start: {Start}, end: {End}";
+        }
     }
 }

--- a/Elements/src/Search/BinaryTree.cs
+++ b/Elements/src/Search/BinaryTree.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace Elements.Search
 {
@@ -133,8 +134,10 @@ namespace Elements.Search
                 }
             }
 
-            BinaryTreeNode<T> newNode = new BinaryTreeNode<T>();
-            newNode.Data = value;
+            BinaryTreeNode<T> newNode = new BinaryTreeNode<T>
+            {
+                Data = value
+            };
 
             if (this.Root == null)
             {
@@ -254,6 +257,17 @@ namespace Elements.Search
         private int GetTreeDepth(BinaryTreeNode<T> parent)
         {
             return parent == null ? 0 : Math.Max(GetTreeDepth(parent.Left), GetTreeDepth(parent.Right)) + 1;
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            if (Root != null)
+            {
+                sb.AppendLine($"ROOT: {Root.Data}");
+                Root.Print(sb, "\t");
+            }
+            return sb.ToString();
         }
     }
 }

--- a/Elements/src/Search/BinaryTreeNode.cs
+++ b/Elements/src/Search/BinaryTreeNode.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace Elements.Search
 {
     /// <summary>
@@ -25,5 +27,19 @@ namespace Elements.Search
         /// The data to store.
         /// </summary>
         public T Data { get; set; }
+
+        public void Print(StringBuilder sb, string prefix)
+        {
+            if (Left != null)
+            {
+                sb.AppendLine($"{prefix}LEFT: {Left.Data}");
+                Left.Print(sb, prefix + "\t");
+            }
+            if (Right != null)
+            {
+                sb.AppendLine($"{prefix}RIGHT: {Right.Data}");
+                Right.Print(sb, prefix + "\t");
+            }
+        }
     }
 }

--- a/Elements/src/Search/LeftMostPointComparer.cs
+++ b/Elements/src/Search/LeftMostPointComparer.cs
@@ -32,42 +32,18 @@ namespace Elements.Search
             var a = _getSegment(t1);
             var b = _getSegment(t2);
 
-            var aLeft = a.Start.X <= a.End.X ? a.Start : a.End;
-            var bLeft = b.Start.X <= b.End.X ? b.Start : b.End;
+            var aLeft = a.Start.X <= a.End.X ? a.PointAt(0.001) : a.PointAt(0.999);
+            var bLeft = b.Start.X <= b.End.X ? b.PointAt(0.001) : b.PointAt(0.999);
 
-            if (aLeft == bLeft)
+            if (aLeft.Y.ApproximatelyEquals(bLeft.Y))
             {
-                // The left-most points of the lines are equal, but the lines
-                // themselves are not neccessarily equal. Use the lines' 
-                // bounding boxes to get the max points.
-                var bb1 = new BBox3();
-                bb1.Extend(a.Start);
-                bb1.Extend(a.End);
-                var bb2 = new BBox3();
-                bb2.Extend(b.Start);
-                bb2.Extend(b.End);
-                if (bb1.Max.Y > bb2.Max.Y)
-                {
-                    return -1;
-                }
-                else if (bb1.Max.Y < bb2.Max.Y)
-                {
-                    return 1;
-                }
                 return 0;
             }
-            else
+            if (aLeft.Y > bLeft.Y)
             {
-                if (aLeft.Y.ApproximatelyEquals(bLeft.Y))
-                {
-                    return 0;
-                }
-                if (aLeft.Y > bLeft.Y)
-                {
-                    return -1;
-                }
-                return 1;
+                return -1;
             }
+            return 1;
         }
     }
 }

--- a/Elements/src/Search/Network.cs
+++ b/Elements/src/Search/Network.cs
@@ -382,6 +382,7 @@ namespace Elements.Search
             for (var i = 0; i < this.NodeCount(); i++)
             {
                 var edgeCount = this.EdgesAt(i).Count();
+                // Leaf nodes
                 if (edgeCount == 1)
                 {
                     traversalStartIndices.Add(i);
@@ -408,6 +409,8 @@ namespace Elements.Search
                 }
 
                 result.Add(path);
+
+                Debug.WriteLine($"PATH: {string.Join(",", path)}");
             }
 
             for (var i = 0; i < nodeVisits.Length; i++)
@@ -437,6 +440,8 @@ namespace Elements.Search
                     }
 
                     result.Add(path);
+
+                    Debug.WriteLine($"PATH: {string.Join(",", path)}");
                 }
             }
 
@@ -460,6 +465,8 @@ namespace Elements.Search
             for (var i = 0; i < this.NodeCount(); i++)
             {
                 var edgeCount = this.EdgesAt(i).Count();
+
+                // Non-leaf nodes.
                 if (edgeCount > 1)
                 {
                     traversalStartIndices.Add(i);
@@ -515,12 +522,14 @@ namespace Elements.Search
             {
                 if (e == traversalData.previousIndex)
                 {
+                    Debug.WriteLine($"Skipping index {e} as previous.");
                     continue;
                 }
 
                 var visitedEdge = visitedEdges.FirstOrDefault(edge => edge.IsBetweenVertices(e, traversalData.currentIndex));
                 if (visitedEdge?.IsVisitedFromVertex(traversalData.currentIndex) == true)
                 {
+                    Debug.WriteLine($"Skipping index {e} as visited.");
                     continue;
                 }
 
@@ -536,8 +545,11 @@ namespace Elements.Search
                     angle = 180.0;
                 }
 
+                Debug.WriteLine($"{traversalData.currentIndex}:{e}:{angle}");
+
                 if (angle < minAngle)
                 {
+                    Debug.WriteLine("Found minimum.");
                     minAngle = angle;
                     minIndex = e;
                 }
@@ -579,6 +591,12 @@ namespace Elements.Search
                 if (visitedEdge?.IsVisitedFromVertex(traversalData.currentIndex) == true)
                 {
                     Debug.WriteLine($"Skipping index {e} as visited.");
+                    continue;
+                }
+
+                var visits = visitedEdges.Where(edge => edge.IsBetweenVertices(e, traversalData.currentIndex));
+                if (visits.Count() >= 2)
+                {
                     continue;
                 }
 

--- a/Elements/test/NetworkTests.cs
+++ b/Elements/test/NetworkTests.cs
@@ -265,39 +265,6 @@ namespace Elements.Tests
         }
 
         [Fact]
-        public void FindAllClosedRegionsWithoutLeaves()
-        {
-            this.Name = nameof(FindAllClosedRegionsWithoutLeaves);
-
-            var lines = CreateClosedRegionTestLines();
-
-            foreach (var line in lines)
-            {
-                this.Model.AddElement(new ModelCurve(line));
-            }
-
-            var network = Network<Line>.FromSegmentableItems(lines, (item) => { return item; }, out var allNodeLocations, out _);
-            var closedRegions = network.FindAllClosedRegionsBypassingInternalLeaves(allNodeLocations);
-
-            // According to Euler, there will be V + R = E + 2 regions
-            Assert.Equal(6, closedRegions.Count);
-
-            var r = new Random(23);
-            foreach (var region in closedRegions)
-            {
-                try
-                {
-                    var p = new Polygon(region.Select(i => allNodeLocations[i]).ToList());
-                    this.Model.AddElement(new Panel(p, r.NextMaterial()));
-                }
-                catch
-                {
-                    continue;
-                }
-            }
-        }
-
-        [Fact]
         public void FindAllClosedRegions()
         {
             this.Name = nameof(FindAllClosedRegions);
@@ -316,8 +283,7 @@ namespace Elements.Tests
             this.Model.AddElements(network.ToModelText(allNodeLocations, Colors.Black));
             this.Model.AddElements(network.ToModelArrows(allNodeLocations, Colors.Black));
 
-            // According to Euler, there will be V + R = E + 2 regions
-            Assert.Equal(9, closedRegions.Count);
+            Assert.Equal(5, closedRegions.Count);
 
             var r = new Random(23);
             foreach (var region in closedRegions)


### PR DESCRIPTION
BACKGROUND:
Our `Network` provides a basic traversal method that allows you to provide a traversal function. In several locations we have implemented traversal functions to find closed regions in the graph. This is useful when you have a collection of linear elements like walls or grids and want to find enclosed areas like rooms or structural bays.

DESCRIPTION:
- Changes the `LeftMostPointComparer` used by the `BinaryTree` in the line sweep algorithm to improve coincident point handling.
- Adds the `FindAllClosedRegions` method to the `Network` class to find closed regions without having to implement your own traversal strategy.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

See all the closed regions for a graph with lines 
![image](https://user-images.githubusercontent.com/1139788/190035244-c5f2926a-3fa3-4796-9e43-abf3d0019db0.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/885)
<!-- Reviewable:end -->
