### PR TITLE
don't create graphics buffers for element definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - `Polyline.Intersects(Polygon polygon, out List<Polyline> sharedSegments)` bug when polyline start/end is on polygon perimeter
 - `GltfBufferExtensions.CombineBufferAndFixRefs` bug when combining buffers from multiple gltf files.
 - `Obstacle.FromWall` was failing when producing a polygon.
+- GLTF creation does not include elements with custom buffers if they are `IsElementDefinition=true`.
 
 ## 1.1.0
 

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -1269,7 +1269,7 @@ namespace Elements.Serialization.glTF
                 }
             }
 
-            if (e is GeometricElement ge)
+            if (e is GeometricElement ge && !ge.IsElementDefinition)
             {
                 if (ge.TryToGraphicsBuffers(out List<GraphicsBuffers> gb, out string id, out MeshPrimitive.ModeEnum? mode))
                 {


### PR DESCRIPTION
BACKGROUND:
- Normally, we don't add elements that are `IsElementDefinition=true` to the GLTF model. However, in the case that a type did create 
DESCRIPTION:
- blocks adding `IsElementDefinition=true` elements to the GLTF via the `TryToGraphicsBuffers` pathway.

TESTING:
- I tried making a function (Residential Units) that was creating instances of `ModelLines`. I verified that the instances did display but the base definition did not.

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/891)
<!-- Reviewable:end -->
