### PR TITLE
Routing Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@
 - `Obstacle` properties `Points`, `Offset`, `Perimeter` and `Transform` can be modified from outside.
 - `LinearDimension`s now support `IOverrideLinked` behavior.
 - `Line.PointOnLine` - added `tolerance` parameter.
-- `AdaptiveGraphRouting.AddExtendVertices` - cut extended edges at end points of each segment
+- `AdaptiveGrid.AddExtendVertices` - cut extended edges at end points of each segment.
+-  Created `EdgeInfo` structure in `AdaptiveGraphRouting` instead of a value pair. Added `HasVerticalChange` parameter to it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `AdaptiveGrid.Boundary` can be left null.
 - `Obstacle` properties `Points`, `Offset`, `Perimeter` and `Transform` can be modified from outside.
 - `LinearDimension`s now support `IOverrideLinked` behavior.
+- `Line.PointOnLine` - added `tolerance` parameter.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `Obstacle` properties `Points`, `Offset`, `Perimeter` and `Transform` can be modified from outside.
 - `LinearDimension`s now support `IOverrideLinked` behavior.
 - `Line.PointOnLine` - added `tolerance` parameter.
+- `AdaptiveGraphRouting.AddExtendVertices` - cut extended edges at end points of each segment
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,28 @@
 # Changelog
 
+## 1.3.0
+
+### Added
+
+- `AdaptiveGrid.AddVerticesWithCustomExtension(IList<Vector3> points, double extendDistance)`
+- `AdaptiveGrid.HintExtendDistance`
+- `Obstacle.Orientation`
+
+### Changed
+
+- `Line.PointOnLine` - added `tolerance` parameter.
+- `AdaptiveGrid.AddVertices` with `ConnectCutAndExtend` how extends only up to `HintExtendDistance` distance.
+-  Created `EdgeInfo` structure in `AdaptiveGraphRouting` instead of a value pair. Added `HasVerticalChange` parameter to it.
+
+### Fixed
+
+- `Line.Intersects` for `BBox3` - better detection of line with one intersection that just touches box corner.
+- `Obstacle.FromWall` and `Obstacle.FromLine` produced wrong `Points` when diagonal.
+
 ## 1.2.0
 
 ### Added
+
 - `Polygon(IList<Vector3> @vertices, bool disableValidation = false)`
 - `Polygon(bool disableValidation, params Vector3[] vertices)`
 - `Polyline(IList<Vector3> @vertices, bool disableValidation = false)`
@@ -26,8 +46,6 @@
                                out Dictionary<Guid, List<Polygon>> intersectionPolygons,
                                out Dictionary<Guid, List<Polygon>> beyondPolygons,
                                out Dictionary<Guid, List<Line>> lines)`
-- `AdaptiveGrid.AddVerticesWithCustomExtension(IList<Vector3> points, double extendDistance)`
-- `AdaptiveGrid.HintExtendDistance`
 
 ### Changed
 
@@ -37,9 +55,6 @@
 - `AdaptiveGrid.Boundary` can be left null.
 - `Obstacle` properties `Points`, `Offset`, `Perimeter` and `Transform` can be modified from outside.
 - `LinearDimension`s now support `IOverrideLinked` behavior.
-- `Line.PointOnLine` - added `tolerance` parameter.
-- `AdaptiveGrid.AddVertices` with `ConnectCutAndExtend` how extends only up to `HintExtendDistance` distance.
--  Created `EdgeInfo` structure in `AdaptiveGraphRouting` instead of a value pair. Added `HasVerticalChange` parameter to it.
 
 ### Fixed
 
@@ -48,10 +63,8 @@
 - `AdaptiveGrid.SubtractObstacle` worked incorrectly in `AdaptiveGrid.Boundary` had elevation.
 - #805
 - `Polyline.Intersects(Polygon polygon, out List<Polyline> sharedSegments)` bug when polyline start/end is on polygon perimeter
-- `Profile.Split` would fail if the perimeter was clockwise-wound.
 - `GltfBufferExtensions.CombineBufferAndFixRefs` bug when combining buffers from multiple gltf files.
 - `Obstacle.FromWall` was failing when producing a polygon.
-- GLTF creation does not include elements with custom buffers if they are `IsElementDefinition=true`.
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
                                out Dictionary<Guid, List<Polygon>> intersectionPolygons,
                                out Dictionary<Guid, List<Polygon>> beyondPolygons,
                                out Dictionary<Guid, List<Line>> lines)`
+- `AdaptiveGrid.AddVerticesWithCustomExtension(IList<Vector3> points, double extendDistance)`
+- `AdaptiveGrid.HintExtendDistance`
 
 ### Changed
 
@@ -36,7 +38,7 @@
 - `Obstacle` properties `Points`, `Offset`, `Perimeter` and `Transform` can be modified from outside.
 - `LinearDimension`s now support `IOverrideLinked` behavior.
 - `Line.PointOnLine` - added `tolerance` parameter.
-- `AdaptiveGrid.AddExtendVertices` - cut extended edges at end points of each segment.
+- `AdaptiveGrid.AddVertices` with `ConnectCutAndExtend` how extends only up to `HintExtendDistance` distance.
 -  Created `EdgeInfo` structure in `AdaptiveGraphRouting` instead of a value pair. Added `HasVerticalChange` parameter to it.
 
 ### Fixed

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -388,7 +388,8 @@ namespace Elements.Geometry
 
             // If max hit of one coordinate is smaller then min hit of other - line hits planes outside the box.
             // In other words line just goes by.
-            if (t0x > t1y || t0y > t1x)
+            var length = d.Length();
+            if ((t0x - t1y) * length > tolerance || (t0y - t1x) * length > tolerance)
             {
                 return false;
             }
@@ -420,7 +421,6 @@ namespace Elements.Geometry
                 return false;
             }
 
-            var length = d.Length();
             var dMin = tMin * length;
             var dMax = tMax * length;
 
@@ -483,7 +483,7 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="point">The point to test.</param>
         /// <param name="includeEnds">Consider a point at the endpoint as on the line.</param>
-        /// <param name="tolerance">An optional distance tolerance.</param>
+        /// <param name="tolerance">An optional distance tolerance.
         /// When true, any point within tolerance of the end points will be considered on the line.
         /// When false, points precisely at the ends of the line will not be considered on the line.</param>
         public bool PointOnLine(Vector3 point, bool includeEnds = false, double tolerance = Vector3.EPSILON)
@@ -498,7 +498,7 @@ namespace Elements.Geometry
         /// <param name="start">The start point of the line segment.</param>
         /// <param name="end">The end point of the line segment.</param>
         /// <param name="includeEnds">Consider a point at the endpoint as on the line.</param>
-        /// <param name="tolerance">An optional distance tolerance.</param>
+        /// <param name="tolerance">An optional distance tolerance.
         /// When true, any point within tolerance of the end points will be considered on the line.
         /// When false, points precisely at the ends of the line will not be considered on the line.</param>
         public static bool PointOnLine(Vector3 point, Vector3 start, Vector3 end, bool includeEnds = false, double tolerance = Vector3.EPSILON)

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -482,12 +482,13 @@ namespace Elements.Geometry
         /// Test if a point lies within tolerance of this line segment.
         /// </summary>
         /// <param name="point">The point to test.</param>
-        /// <param name="includeEnds">Consider a point at the endpoint as on the line.
+        /// <param name="includeEnds">Consider a point at the endpoint as on the line.</param>
+        /// <param name="tolerance">An optional distance tolerance.</param>
         /// When true, any point within tolerance of the end points will be considered on the line.
         /// When false, points precisely at the ends of the line will not be considered on the line.</param>
-        public bool PointOnLine(Vector3 point, bool includeEnds = false)
+        public bool PointOnLine(Vector3 point, bool includeEnds = false, double tolerance = Vector3.EPSILON)
         {
-            return Line.PointOnLine(point, Start, End, includeEnds);
+            return Line.PointOnLine(point, Start, End, includeEnds, tolerance);
         }
 
         /// <summary>
@@ -496,12 +497,13 @@ namespace Elements.Geometry
         /// <param name="point">The point to test.</param>
         /// <param name="start">The start point of the line segment.</param>
         /// <param name="end">The end point of the line segment.</param>
-        /// <param name="includeEnds">Consider a point at the endpoint as on the line.
+        /// <param name="includeEnds">Consider a point at the endpoint as on the line.</param>
+        /// <param name="tolerance">An optional distance tolerance.</param>
         /// When true, any point within tolerance of the end points will be considered on the line.
         /// When false, points precisely at the ends of the line will not be considered on the line.</param>
-        public static bool PointOnLine(Vector3 point, Vector3 start, Vector3 end, bool includeEnds = false)
+        public static bool PointOnLine(Vector3 point, Vector3 start, Vector3 end, bool includeEnds = false, double tolerance = Vector3.EPSILON)
         {
-            if (includeEnds && (point.IsAlmostEqualTo(start) || point.IsAlmostEqualTo(end)))
+            if (includeEnds && (point.IsAlmostEqualTo(start, tolerance) || point.IsAlmostEqualTo(end, tolerance)))
             {
                 return true;
             }
@@ -511,7 +513,7 @@ namespace Elements.Geometry
             if (lambda > 0 && lambda < 1)
             {
                 var pointOnLine = start + lambda * delta;
-                return pointOnLine.IsAlmostEqualTo(point);
+                return pointOnLine.IsAlmostEqualTo(point, tolerance);
             }
             return false;
         }

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -180,6 +180,40 @@ namespace Elements.Spatial.AdaptiveGrid
         }
 
         /// <summary>
+        /// Precalculated information about the edge.
+        /// </summary>
+        public struct EdgeInfo
+        {
+            /// <summary>
+            /// Construct new EdgeInfo structure.
+            /// </summary>
+            /// <param name="length">Length of the edge.</param>
+            /// <param name="factor">Edge traveling factor.</param>
+            /// <param name="hasVerticalChange">Are edge end points on different elevations.</param>
+            public EdgeInfo(double length, double factor, bool hasVerticalChange)
+            {
+                Length = length;
+                Factor = factor;
+                HasVerticalChange = hasVerticalChange;
+            }
+
+            /// <summary>
+            /// Length of the edge.
+            /// </summary>
+            public readonly double Length;
+
+            /// <summary>
+            /// Edge traveling factor.
+            /// </summary>
+            public readonly double Factor;
+
+            /// <summary>
+            /// Are edge end points on different elevations.
+            /// </summary>
+            public readonly bool HasVerticalChange;
+        }
+
+        /// <summary>
         /// Filter function definition.
         /// </summary>
         /// <param name="start">Last Vertex in the route.</param>
@@ -835,11 +869,11 @@ namespace Elements.Spatial.AdaptiveGrid
         /// Also some edges are not allowed at all by setting factor to infinity.
         /// </summary>
         /// <param name="hintLines">Lines that affect travel factor for edges</param>
-        /// <returns>For each edge - its length and extra traveling factor</returns>
-        private Dictionary<ulong, (double Length, double Factor)> CalculateWeights(
+        /// <returns>For each edge - its precalculated additional information.</returns>
+        private Dictionary<ulong, EdgeInfo> CalculateWeights(
             IEnumerable<RoutingHintLine> hintLines)
         {
-            var weights = new Dictionary<ulong, (double Length, double Factor)>();
+            var weights = new Dictionary<ulong, EdgeInfo>();
             var mainAxis = _grid.Transform.XAxis;
             foreach (var e in _grid.GetEdges())
             {
@@ -847,6 +881,8 @@ namespace Elements.Spatial.AdaptiveGrid
                 var v1 = _grid.GetVertex(e.EndId);
                 var vector = (v1.Point - v0.Point);
                 var w = vector.Length();
+
+                bool hasVerticalChange = Math.Abs(v0.Point.Z - v1.Point.Z) > _grid.Tolerance;
 
                 var angle = vector.AngleTo(mainAxis);
                 if (angle > 90)
@@ -857,7 +893,7 @@ namespace Elements.Spatial.AdaptiveGrid
                 if (_configuration.SupportedAngles != null &&
                     !_configuration.SupportedAngles.Any(a => a.ApproximatelyEquals(angle, 0.01)))
                 {
-                    weights[e.Id] = (w, double.PositiveInfinity);
+                    weights[e.Id] = new EdgeInfo(w, double.PositiveInfinity, hasVerticalChange);
                 }
                 else
                 {
@@ -890,7 +926,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         }
                     }
 
-                    weights[e.Id] = (w, hintFactor * offsetFactor * layerFactor);
+                    weights[e.Id] = new EdgeInfo(w, hintFactor * offsetFactor * layerFactor, hasVerticalChange);
                 }
             }
 
@@ -940,7 +976,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <param name="pathDirections">Next Vertex dictionary for Vertices that are already part of the route</param>
         /// <returns>Dictionary that have travel routes from each Vertex back to start Vertex.</returns>
         public Dictionary<ulong, ulong> ShortestPathDijkstra(
-            ulong start, Dictionary<ulong, (double Length, double Factor)> edgeWeights,
+            ulong start, Dictionary<ulong, EdgeInfo> edgeWeights,
             out Dictionary<ulong, double> travelCost,
             ulong? startDirection = null, HashSet<ulong> excluded = null,
             Dictionary<ulong, ulong?> pathDirections = null)
@@ -1008,7 +1044,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         if (startDirection.HasValue &&
                             !Vector3.AreCollinearByAngle(_grid.GetVertex(startDirection.Value).Point, vertex.Point, v.Point))
                         {
-                            newWeight += CalculateTurnCost(edgeWeight.Factor, vertex, startDirection.Value, edgeWeights);
+                            newWeight += CalculateTurnCost(edgeWeight, vertex, startDirection.Value, edgeWeights);
                         }
                     }
                     else
@@ -1016,13 +1052,13 @@ namespace Elements.Spatial.AdaptiveGrid
                         var vertexBefore = _grid.GetVertex(beforeId);
                         if (!Vector3.AreCollinearByAngle(vertexBefore.Point, vertex.Point, v.Point))
                         {
-                            newWeight += CalculateTurnCost(edgeWeight.Factor, vertex, vertexBefore.Id, edgeWeights);
+                            newWeight += CalculateTurnCost(edgeWeight, vertex, vertexBefore.Id, edgeWeights);
                         }
                         if (pathDirections != null &&
                             pathDirections.TryGetValue(v.Id, out var vertexAfter) && vertexAfter.HasValue &&
                             !Vector3.AreCollinearByAngle(vertex.Point, v.Point, _grid.GetVertex(vertexAfter.Value).Point))
                         {
-                            newWeight += CalculateTurnCost(edgeWeight.Factor, v, vertexAfter.Value, edgeWeights);
+                            newWeight += CalculateTurnCost(edgeWeight, v, vertexAfter.Value, edgeWeights);
                         }
                     }
 
@@ -1052,7 +1088,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <param name="excluded">Vertices that are not allowed to visit</param>
         /// <returns>Dictionary that have two travel routes from each Vertex back to start Vertex.</returns>
         public Dictionary<ulong, ((ulong, BranchSide), (ulong, BranchSide))> ShortestBranchesDijkstra(
-            ulong start, Dictionary<ulong, (double Length, double Factor)> edgeWeights,
+            ulong start, Dictionary<ulong, EdgeInfo> edgeWeights,
             out Dictionary<ulong, (double, double)> travelCost,
             ulong? startDirection = null, HashSet<ulong> excluded = null)
         {
@@ -1121,7 +1157,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         if (startDirection.HasValue &&
                             !Vector3.AreCollinearByAngle(_grid.GetVertex(startDirection.Value).Point, vertex.Point, v.Point))
                         {
-                            newWeight += CalculateTurnCost(edgeWeight.Factor, vertex, startDirection.Value, edgeWeights);
+                            newWeight += CalculateTurnCost(edgeWeight, vertex, startDirection.Value, edgeWeights);
                         }
                     }
                     else
@@ -1133,8 +1169,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         var leftCost = cost.Item1 + newWeight;
                         if (!leftCollinear)
                         {
-                            leftCost += CalculateTurnCost(
-                                edgeWeight.Factor, vertex, leftBefore.Id, edgeWeights);
+                            leftCost += CalculateTurnCost(edgeWeight, vertex, leftBefore.Id, edgeWeights);
                         }
 
                         var rigthCost = Double.MaxValue;
@@ -1144,8 +1179,7 @@ namespace Elements.Spatial.AdaptiveGrid
                             rigthCost = cost.Item2 + newWeight;
                             if (!Vector3.AreCollinearByAngle(rigthBefore.Point, vertex.Point, v.Point))
                             {
-                                rigthCost += CalculateTurnCost(
-                                    edgeWeight.Factor, vertex, rigthBefore.Id, edgeWeights);
+                                rigthCost += CalculateTurnCost(edgeWeight, vertex, rigthBefore.Id, edgeWeights);
                             }
                         }
 
@@ -1197,26 +1231,34 @@ namespace Elements.Spatial.AdaptiveGrid
 
         /// <summary>
         /// Calculate turn cost between two edges.
-        /// Turn cost should take into account cost factor of given edges.
+        /// If turn is not vertical, turn cost should take into account cost factor of given edges.
         /// Otherwise hint paths with several turns would be ignored because of extra cost.
         /// The turn factor is multiplied by minimum of two edges factor.
         /// </summary>
-        /// <param name="edgeFactor">Edge factor of the first edge</param>
+        /// <param name="edgeInfo">Edge informations for the first edge</param>
         /// <param name="sharedVertex">Id of the vertex, common for two edges</param>
         /// <param name="thirdVertexId">Third vertex Id</param>
         /// <param name="edgeWeights">Precalculated length and factor for each edge</param>
         /// <returns></returns>
         private double CalculateTurnCost(
-            double edgeFactor, Vertex sharedVertex, ulong thirdVertexId,
-            IDictionary<ulong, (double Lenght, double Factor)> edgeWeights)
+            EdgeInfo edgeInfo, Vertex sharedVertex, ulong thirdVertexId,
+            IDictionary<ulong, EdgeInfo> edgeWeights)
         {
             var otherEdge = sharedVertex.Edges.Where(
                 edge => edge.StartId == thirdVertexId || edge.EndId == thirdVertexId).FirstOrDefault();
             var otherWeight = edgeWeights[otherEdge.Id];
+
+            //Do not modify turn cost if either of edges is not horizontal.
+            //This prevents "free to travel" loops under 2d hint lines.
+            if (edgeInfo.HasVerticalChange || otherWeight.HasVerticalChange)
+            {
+                return _configuration.TurnCost;
+            }
+
             //Minimum factor makes algorithm prefer edges inside of hint lines even if they
             //have several turns but don't give advantage for the tiny edges that are
             //fully inside hint line influence area. 
-            return _configuration.TurnCost * Math.Min(edgeFactor, otherWeight.Factor);
+            return _configuration.TurnCost * Math.Min(edgeInfo.Factor, otherWeight.Factor);
         }
 
         private PriorityQueue<ulong> PreparePriorityQueue(ulong start,
@@ -1453,7 +1495,7 @@ namespace Elements.Spatial.AdaptiveGrid
             IDictionary<ulong, (double, double)> travelCost,
             IDictionary<ulong, ((ulong, BranchSide), (ulong, BranchSide))> connections,
             IDictionary<ulong, ulong?> tree,
-            IDictionary<ulong, (double Length, double Factor)> weights)
+            IDictionary<ulong, EdgeInfo> weights)
 
         {
             ulong bestIndex = 0;
@@ -1482,7 +1524,7 @@ namespace Elements.Spatial.AdaptiveGrid
                                 var edge = activeV.Edges.Where(
                                     e => e.StartId == beforeV1.Id || e.EndId == beforeV1.Id).First();
                                 var edgeWeight = weights[edge.Id];
-                                cost1 += CalculateTurnCost(edgeWeight.Factor, activeV, nextV.Id, weights);
+                                cost1 += CalculateTurnCost(edgeWeight, activeV, nextV.Id, weights);
                             }
                         }
 
@@ -1494,7 +1536,7 @@ namespace Elements.Spatial.AdaptiveGrid
                                 var edge = activeV.Edges.Where(
                                     e => e.StartId == beforeV2.Id || e.EndId == beforeV2.Id).First();
                                 var edgeWeight = weights[edge.Id];
-                                cost2 += CalculateTurnCost(edgeWeight.Factor, activeV, nextV.Id, weights);
+                                cost2 += CalculateTurnCost(edgeWeight, activeV, nextV.Id, weights);
                             }
 
                         }

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -187,15 +187,24 @@ namespace Elements.Spatial.AdaptiveGrid
             /// <summary>
             /// Construct new EdgeInfo structure.
             /// </summary>
-            /// <param name="length">Length of the edge.</param>
+            /// <param name="grid">Grid, edge belongs to.</param>
+            /// <param name="edge">The edge.</param>
             /// <param name="factor">Edge traveling factor.</param>
-            /// <param name="hasVerticalChange">Are edge end points on different elevations.</param>
-            public EdgeInfo(double length, double factor, bool hasVerticalChange)
+            public EdgeInfo(AdaptiveGrid grid, Edge edge, double factor = 1)
             {
-                Length = length;
+                Edge = edge;
+                var v0 = grid.GetVertex(edge.StartId);
+                var v1 = grid.GetVertex(edge.EndId);
+                var vector = (v1.Point - v0.Point);
+                Length = vector.Length();
                 Factor = factor;
-                HasVerticalChange = hasVerticalChange;
+                HasVerticalChange = Math.Abs(v0.Point.Z - v1.Point.Z) > grid.Tolerance;
             }
+
+            /// <summary>
+            /// The Edge.
+            /// </summary>
+            public readonly Edge Edge;
 
             /// <summary>
             /// Length of the edge.
@@ -880,10 +889,6 @@ namespace Elements.Spatial.AdaptiveGrid
                 var v0 = _grid.GetVertex(e.StartId);
                 var v1 = _grid.GetVertex(e.EndId);
                 var vector = (v1.Point - v0.Point);
-                var w = vector.Length();
-
-                bool hasVerticalChange = Math.Abs(v0.Point.Z - v1.Point.Z) > _grid.Tolerance;
-
                 var angle = vector.AngleTo(mainAxis);
                 if (angle > 90)
                 {
@@ -893,7 +898,7 @@ namespace Elements.Spatial.AdaptiveGrid
                 if (_configuration.SupportedAngles != null &&
                     !_configuration.SupportedAngles.Any(a => a.ApproximatelyEquals(angle, 0.01)))
                 {
-                    weights[e.Id] = new EdgeInfo(w, double.PositiveInfinity, hasVerticalChange);
+                    weights[e.Id] = new EdgeInfo(_grid, e, double.PositiveInfinity);
                 }
                 else
                 {
@@ -926,7 +931,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         }
                     }
 
-                    weights[e.Id] = new EdgeInfo(w, hintFactor * offsetFactor * layerFactor, hasVerticalChange);
+                    weights[e.Id] = new EdgeInfo(_grid, e, hintFactor * offsetFactor * layerFactor);
                 }
             }
 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -209,7 +209,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <returns>True if obstacle intersects with any edge on the grid.</returns>
         public bool SubtractObstacle(Obstacle obstacle)
         {
-            var frame = obstacle.Transform == null ? Transform : obstacle.Transform;
+            var frame = obstacle.Orientation == null ? Transform : obstacle.Orientation;
             var toGrid = frame.Inverted();
             List<Vector3> localPoints = obstacle.Points.Select(p => toGrid.OfPoint(p)).ToList();
             BBox3 localBox = new BBox3(localPoints).Offset(obstacle.Offset);
@@ -274,6 +274,7 @@ namespace Elements.Spatial.AdaptiveGrid
                 }
             }
 
+            //TODO: this code builds perimeters, elevation by elevation, but do not connect them vertically.
             if (obstacle.AddPerimeterEdges && edgesToAdd.Any())
             {
                 var corners = localBox.Corners().Take(4).Select(c => frame.OfPoint(c)).ToList();

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -800,7 +800,27 @@ namespace Elements.Spatial.AdaptiveGrid
 
                 var newEdgeLine = new Line(sp, ep);
                 var oldEdgeLine = new Line(edgeV0.Point, edgeV1.Point);
-                if (newEdgeLine.Intersects(oldEdgeLine, out var intersectionPoint, includeEnds: true))
+                if (oldEdgeLine.PointOnLine(sp, tolerance: Tolerance))
+                {
+                    intersectionPoints.Add(sp);
+                    if (edge.StartId != startVertex.Id && edge.EndId != startVertex.Id)
+                    {
+                        AddInsertEdge(edge.StartId, startVertex.Id);
+                        AddInsertEdge(edge.EndId, startVertex.Id);
+                        edgesToRemove.Add(edge);
+                    }
+                }
+                else if (oldEdgeLine.PointOnLine(ep, tolerance: Tolerance))
+                {
+                    intersectionPoints.Add(ep);
+                    if (edge.StartId != endVertex.Id && edge.EndId != endVertex.Id)
+                    {
+                        AddInsertEdge(edge.StartId, endVertex.Id);
+                        AddInsertEdge(edge.EndId, endVertex.Id);
+                        edgesToRemove.Add(edge);
+                    }
+                }
+                else if (newEdgeLine.Intersects(oldEdgeLine, out var intersectionPoint, includeEnds: true))
                 {
                     intersectionPoints.Add(intersectionPoint);
                     var newVertex = AddVertex(intersectionPoint);

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -1050,20 +1050,7 @@ namespace Elements.Spatial.AdaptiveGrid
 
                 if (index < hits.Count && !hits[index - 1].DistanceAlongLine.ApproximatelyEquals(segmentLength, Tolerance))
                 {
-                    Vertex finalCut;
-                    if (hits[index].DistanceAlongLine > segmentLength + extendDistance)
-                    {
-                        finalCut = AddVertex(points[i + 1]);
-                        if (finalCut.Id != lastCut.Id)
-                        {
-                            AddInsertEdge(lastCut.Id, finalCut.Id);
-                        }
-                    }
-                    else
-                    {
-                        finalCut = InsertHit(hits[index], lastCut);
-                    }
-
+                    var finalCut = InsertFinalCut(hits[index], lastCut, points[i + 1], segmentLength + extendDistance);
                     if (finalCut != null)
                     {
                         vertices.Add(finalCut);
@@ -1072,6 +1059,8 @@ namespace Elements.Spatial.AdaptiveGrid
             }
             return vertices;
         }
+
+        #region AddVerticesWithCustomExtension helper functions
 
         private List<(Edge Edge, double DistanceAlongLine, double DistanceAlongEdge, double EdgeLength)> IntersectGraph(
             Vector3 start, Vector3 end)
@@ -1167,6 +1156,28 @@ namespace Elements.Spatial.AdaptiveGrid
             }
             return newCut;
         }
+
+        private Vertex InsertFinalCut(
+            (Edge Edge, double DistanceAlongLine, double DistanceAlongEdge, double EdgeLength) hit,
+            Vertex lastCut, Vector3 endPoint, double maxDistance)
+        {
+            Vertex finalCut;
+            if (hit.DistanceAlongLine > maxDistance)
+            {
+                finalCut = AddVertex(endPoint);
+                if (finalCut.Id != lastCut.Id)
+                {
+                    AddInsertEdge(lastCut.Id, finalCut.Id);
+                }
+            }
+            else
+            {
+                finalCut = InsertHit(hit, lastCut);
+            }
+            return finalCut;
+        }
+
+        #endregion
 
         private void DeleteVertex(ulong id)
         {

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -1040,6 +1040,9 @@ namespace Elements.Spatial.AdaptiveGrid
                     var cutPoint = startPoint + hits[index].EdgeParam * (endPoint - startPoint).Unitized();
                     lastCut = CutEdge(hits[index].Edge, cutPoint);
                 }
+
+                double lastLineParam = hits[index].LineParam;
+
                 index++;
                 vertices.Add(lastCut);
 
@@ -1049,7 +1052,17 @@ namespace Elements.Spatial.AdaptiveGrid
                     if (newCut != null)
                     {
                         vertices.Add(newCut);
+                        if (lastLineParam < -Tolerance && hits[index].LineParam > Tolerance)
+                        {
+                            var delta = newCut.Point - lastCut.Point;
+                            var t = (points[i] - lastCut.Point).Dot(delta.Unitized());
+                            if (t > 1e-3 && t < delta.Length() - 1e-3)
+                            {
+                                CutEdge(newCut.GetEdge(lastCut.Id), points[i]);
+                            }
+                        }
                         lastCut = newCut;
+                        lastLineParam = hits[index].LineParam;
                     }
                     index++;
                 }
@@ -1060,6 +1073,15 @@ namespace Elements.Spatial.AdaptiveGrid
                     if (newCut != null)
                     {
                         vertices.Add(newCut);
+                        if (lastLineParam < segmentLength - Tolerance && hits[index].LineParam > segmentLength + Tolerance)
+                        {
+                            var delta = newCut.Point - lastCut.Point;
+                            var t = (points[i + 1] - lastCut.Point).Dot(delta.Unitized());
+                            if (t > 1e-3 && t < delta.Length() - 1e-3)
+                            {
+                                CutEdge(newCut.GetEdge(lastCut.Id), points[i + 1]);
+                            }
+                        }
                     }
                 }
             }

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -212,7 +212,7 @@ namespace Elements.Spatial.AdaptiveGrid
             var frame = obstacle.Orientation == null ? Transform : obstacle.Orientation;
             var toGrid = frame.Inverted();
             List<Vector3> localPoints = obstacle.Points.Select(p => toGrid.OfPoint(p)).ToList();
-            BBox3 localBox = new BBox3(localPoints).Offset(obstacle.Offset);
+            BBox3 localBox = new BBox3(localPoints);
 
             var edgesToDelete = new List<Edge>();
             var edgesToAdd = new List<(Vertex Anchor, Edge Edge, Vector3 New)>();

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -997,7 +997,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <param name="points">Points to add and connect to the grid.</param>
         /// <param name="extendDistance">Distance at which lines are extended to existing edges.</param>
         /// <returns></returns>
-        private List<Vertex> AddVerticesWithCustomExtension(IList<Vector3> points, double extendDistance)
+        public List<Vertex> AddVerticesWithCustomExtension(IList<Vector3> points, double extendDistance)
         {
             List<Vertex> vertices = new List<Vertex>();
 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -1014,15 +1014,15 @@ namespace Elements.Spatial.AdaptiveGrid
                 }
 
                 Vertex lastCut;
-                if (hits[index].LineParam < -extendDistance)
+                if (hits[index].DistanceAlongLine < -extendDistance)
                 {
                     lastCut = AddVertex(points[i]);
                 }
-                else if (hits[index].EdgeParam.ApproximatelyEquals(0, Tolerance))
+                else if (hits[index].DistanceAlongEdge.ApproximatelyEquals(0, Tolerance))
                 {
                     lastCut = GetVertex(hits[index].Edge.StartId);
                 }
-                else if (hits[index].EdgeParam.ApproximatelyEquals(hits[index].EdgeLength, Tolerance))
+                else if (hits[index].DistanceAlongEdge.ApproximatelyEquals(hits[index].EdgeLength, Tolerance))
                 {
                     lastCut = GetVertex(hits[index].Edge.EndId);
                 }
@@ -1030,14 +1030,14 @@ namespace Elements.Spatial.AdaptiveGrid
                 {
                     var startPoint = GetVertex(hits[index].Edge.StartId).Point;
                     var endPoint = GetVertex(hits[index].Edge.EndId).Point;
-                    var cutPoint = startPoint + hits[index].EdgeParam * (endPoint - startPoint).Unitized();
+                    var cutPoint = startPoint + hits[index].DistanceAlongEdge * (endPoint - startPoint).Unitized();
                     lastCut = CutEdge(hits[index].Edge, cutPoint);
                 }
 
                 index++;
                 vertices.Add(lastCut);
 
-                while (index < hits.Count && hits[index].LineParam < segmentLength + Tolerance)
+                while (index < hits.Count && hits[index].DistanceAlongLine < segmentLength + Tolerance)
                 {
                     var newCut = InsertHit(hits[index], lastCut);
                     if (newCut != null)
@@ -1048,10 +1048,10 @@ namespace Elements.Spatial.AdaptiveGrid
                     index++;
                 }
 
-                if (index < hits.Count && !hits[index - 1].LineParam.ApproximatelyEquals(segmentLength, Tolerance))
+                if (index < hits.Count && !hits[index - 1].DistanceAlongLine.ApproximatelyEquals(segmentLength, Tolerance))
                 {
                     Vertex finalCut;
-                    if (hits[index].LineParam > segmentLength + extendDistance)
+                    if (hits[index].DistanceAlongLine > segmentLength + extendDistance)
                     {
                         finalCut = AddVertex(points[i + 1]);
                         if (finalCut.Id != lastCut.Id)
@@ -1073,7 +1073,7 @@ namespace Elements.Spatial.AdaptiveGrid
             return vertices;
         }
 
-        private List<(Edge Edge, double LineParam, double EdgeParam, double EdgeLength)> IntersectGraph(
+        private List<(Edge Edge, double DistanceAlongLine, double DistanceAlongEdge, double EdgeLength)> IntersectGraph(
             Vector3 start, Vector3 end)
         {
             var hits = new List<(Edge Edge, double D1, double D2, double L2)>();

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -800,27 +800,7 @@ namespace Elements.Spatial.AdaptiveGrid
 
                 var newEdgeLine = new Line(sp, ep);
                 var oldEdgeLine = new Line(edgeV0.Point, edgeV1.Point);
-                if (oldEdgeLine.PointOnLine(sp, tolerance: Tolerance))
-                {
-                    intersectionPoints.Add(sp);
-                    if (edge.StartId != startVertex.Id && edge.EndId != startVertex.Id)
-                    {
-                        AddInsertEdge(edge.StartId, startVertex.Id);
-                        AddInsertEdge(edge.EndId, startVertex.Id);
-                        edgesToRemove.Add(edge);
-                    }
-                }
-                else if (oldEdgeLine.PointOnLine(ep, tolerance: Tolerance))
-                {
-                    intersectionPoints.Add(ep);
-                    if (edge.StartId != endVertex.Id && edge.EndId != endVertex.Id)
-                    {
-                        AddInsertEdge(edge.StartId, endVertex.Id);
-                        AddInsertEdge(edge.EndId, endVertex.Id);
-                        edgesToRemove.Add(edge);
-                    }
-                }
-                else if (newEdgeLine.Intersects(oldEdgeLine, out var intersectionPoint, includeEnds: true))
+                if (newEdgeLine.Intersects(oldEdgeLine, out var intersectionPoint, includeEnds: true))
                 {
                     intersectionPoints.Add(intersectionPoint);
                     var newVertex = AddVertex(intersectionPoint);

--- a/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
@@ -157,8 +157,9 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// List of points defining obstacle.
         /// </summary>
-        public List<Vector3> Points => _primaryPolygons?
-            .SelectMany(x => x.Vertices)
+        public List<Vector3> Points => Boundary?
+            .Vertices
+            .SelectMany(x => new List<Vector3> { x, x + Boundary.Normal().Negate() * Height })
             .ToList() ?? new List<Vector3>();
 
         /// <summary>
@@ -300,6 +301,11 @@ namespace Elements.Spatial.AdaptiveGrid
             if (Boundary == null)
             {
                 return;
+            }
+
+            if (!_boundary.IsClockWise())
+            {
+                _boundary = _boundary.Reversed();
             }
 
             _secondaryPolygons.Clear();

--- a/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
@@ -53,10 +53,8 @@ namespace Elements.Spatial.AdaptiveGrid
                 wall.CenterLine.End - ortho * wall.Thickness / 2,
                 wall.CenterLine.Start - ortho * wall.Thickness / 2
             );
-            var transfrom = new Transform(Vector3.Origin,
-                wall.CenterLine.Direction(), ortho, Vector3.ZAxis);
 
-            return new Obstacle(polygon, wall.Height, offset, addPerimeterEdges, allowOutsideBoundary, transfrom);
+            return new Obstacle(polygon, wall.Height, offset, addPerimeterEdges, allowOutsideBoundary, null);
         }
 
         /// <summary>
@@ -138,9 +136,8 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// List of points defining obstacle.
         /// </summary>
-        public List<Vector3> Points => Boundary?
-            .Vertices
-            .SelectMany(x => new List<Vector3> { x, x + new Vector3(0, 0, Height) })
+        public List<Vector3> Points => _primaryPolygons?
+            .SelectMany(x => x.Vertices)
             .ToList() ?? new List<Vector3>();
 
         /// <summary>

--- a/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/Obstacle.cs
@@ -139,15 +139,15 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <param name="offset">Extra space around obstacle bounding box.</param>
         /// <param name="addPerimeterEdges">Should edges be created around obstacle.</param>
         /// <param name="allowOutsideBoundary">Should edges be created when obstacle is outside of <see cref="AdaptiveGrid.Boundaries"/></param>
-        /// <param name="transformation">Transformation of the obstacle.</param>
-        public Obstacle(Polygon boudary, double height, double offset, bool addPerimeterEdges, bool allowOutsideBoundary, Transform transformation)
+        /// <param name="orienatation">Orientation of the obstacle in space. Helpful for better bounding box creation.</param>
+        public Obstacle(Polygon boudary, double height, double offset, bool addPerimeterEdges, bool allowOutsideBoundary, Transform orienatation)
         {
             Boundary = boudary;
             Height = height;
             Offset = offset;
             AddPerimeterEdges = addPerimeterEdges;
             AllowOutsideBoudary = allowOutsideBoundary;
-            Orientation = transformation;
+            Orientation = orienatation;
 
             Material = BuiltInMaterials.Mass;
 
@@ -157,10 +157,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// List of points defining obstacle.
         /// </summary>
-        public List<Vector3> Points => Boundary?
-            .Vertices
-            .SelectMany(x => new List<Vector3> { x, x + Boundary.Normal().Negate() * Height })
-            .ToList() ?? new List<Vector3>();
+        public List<Vector3> Points => _primaryPolygons?.SelectMany(x => x.Vertices).ToList() ?? new List<Vector3>();
 
         /// <summary>
         /// Perimeter defining obstacle.
@@ -301,11 +298,6 @@ namespace Elements.Spatial.AdaptiveGrid
             if (Boundary == null)
             {
                 return;
-            }
-
-            if (!_boundary.IsClockWise())
-            {
-                _boundary = _boundary.Reversed();
             }
 
             _secondaryPolygons.Clear();

--- a/Elements/test/AdaptiveGraphRoutingTests.cs
+++ b/Elements/test/AdaptiveGraphRoutingTests.cs
@@ -47,11 +47,7 @@ namespace Elements.Tests
             var edgeCosts = new Dictionary<ulong, EdgeInfo>();
             foreach (var e in grid.GetEdges())
             {
-                var sp = grid.GetVertex(e.StartId).Point;
-                var ep = grid.GetVertex(e.EndId).Point;
-                var w = (sp - ep).Length();
-                var hasVerticalChange = Math.Abs(sp.Z - ep.Z) > grid.Tolerance; 
-                edgeCosts[e.Id] = new EdgeInfo(w, 1, hasVerticalChange);
+                edgeCosts[e.Id] = new EdgeInfo(grid, e);
             }
 
             //Calculate all path from point (0, 4) to all other accessible points.
@@ -134,14 +130,10 @@ namespace Elements.Tests
             {
                 //Set travel cost for each edge equal to it's length.
                 //Except (5, 2) -> (8, 2) for which it's 0.9 of length.
-                var sp = grid.GetVertex(e.StartId).Point;
-                var ep = grid.GetVertex(e.EndId).Point;
-                var w = (sp - ep).Length();
-                var hasVerticalChange = Math.Abs(sp.Z - ep.Z) > grid.Tolerance;
                 bool startMatch = e.StartId == ev0 || e.StartId == ev1;
                 bool endMatch = e.EndId == ev0 || e.EndId == ev1;
                 var factor = startMatch && endMatch ? 0.9 : 1;
-                edgeCosts[e.Id] = new EdgeInfo(w, factor, hasVerticalChange);
+                edgeCosts[e.Id] = new EdgeInfo(grid, e, factor);
             }
 
             Assert.True(grid.TryGetVertexIndex(new Vector3(2, 3, 0), out var preV, grid.Tolerance));

--- a/Elements/test/AdaptiveGraphRoutingTests.cs
+++ b/Elements/test/AdaptiveGraphRoutingTests.cs
@@ -44,11 +44,14 @@ namespace Elements.Tests
             grid.TryGetVertexIndex(new Vector3(0, 4, 0), out var inV, grid.Tolerance);
 
             //Set travel cost for each edge equal to it's length
-            var edgeCosts = new Dictionary<ulong, (double Length, double Factor)>();
+            var edgeCosts = new Dictionary<ulong, EdgeInfo>();
             foreach (var e in grid.GetEdges())
             {
-                var w = (grid.GetVertex(e.StartId).Point - grid.GetVertex(e.EndId).Point).Length();
-                edgeCosts[e.Id] = (w, 1);
+                var sp = grid.GetVertex(e.StartId).Point;
+                var ep = grid.GetVertex(e.EndId).Point;
+                var w = (sp - ep).Length();
+                var hasVerticalChange = Math.Abs(sp.Z - ep.Z) > grid.Tolerance; 
+                edgeCosts[e.Id] = new EdgeInfo(w, 1, hasVerticalChange);
             }
 
             //Calculate all path from point (0, 4) to all other accessible points.
@@ -125,17 +128,20 @@ namespace Elements.Tests
             Assert.True(grid.TryGetVertexIndex(new Vector3(5, 2, 0), out var ev0, grid.Tolerance));
             Assert.True(grid.TryGetVertexIndex(new Vector3(8, 2, 0), out var ev1, grid.Tolerance));
 
-            var edgeCosts = new Dictionary<ulong, (double Length, double Factor)>();
+            var edgeCosts = new Dictionary<ulong, EdgeInfo>();
 
             foreach (var e in grid.GetEdges())
             {
                 //Set travel cost for each edge equal to it's length.
                 //Except (5, 2) -> (8, 2) for which it's 0.9 of length.
-                var w = (grid.GetVertex(e.StartId).Point - grid.GetVertex(e.EndId).Point).Length();
+                var sp = grid.GetVertex(e.StartId).Point;
+                var ep = grid.GetVertex(e.EndId).Point;
+                var w = (sp - ep).Length();
+                var hasVerticalChange = Math.Abs(sp.Z - ep.Z) > grid.Tolerance;
                 bool startMatch = e.StartId == ev0 || e.StartId == ev1;
                 bool endMatch = e.EndId == ev0 || e.EndId == ev1;
                 var factor = startMatch && endMatch ? 0.9 : 1;
-                edgeCosts[e.Id] = (w, factor);
+                edgeCosts[e.Id] = new EdgeInfo(w, factor, hasVerticalChange);
             }
 
             Assert.True(grid.TryGetVertexIndex(new Vector3(2, 3, 0), out var preV, grid.Tolerance));

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -593,6 +593,39 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void AddVerticesWithCustomExtension()
+        {
+            var grid = new AdaptiveGrid();
+            grid.AddFromPolygon(Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10)),
+                                new List<Vector3> {});
+
+            //Default HintExtendDistance is 3.
+            var toExtend = new Vector3[] { new Vector3(1, 3), new Vector3(1, 6) };
+            var added = grid.AddVerticesWithCustomExtension(toExtend, grid.HintExtendDistance);
+            Assert.Equal(2, added.Count);
+            Assert.Equal(new Vector3(1, 0), added[0].Point);
+            Assert.Equal(new Vector3(1, 6), added[1].Point);
+            Assert.Equal(3, added[0].Edges.Count);
+            Assert.Single(added[1].Edges);
+
+            toExtend = new Vector3[] { new Vector3(5, 3), new Vector3(5, 6) };
+            added = grid.AddVerticesWithCustomExtension(toExtend, 4);
+            Assert.Equal(2, added.Count);
+            Assert.Equal(new Vector3(5, 0), added[0].Point);
+            Assert.Equal(new Vector3(5, 10), added[1].Point);
+            Assert.Equal(3, added[0].Edges.Count);
+            Assert.Equal(3, added[1].Edges.Count);
+
+            toExtend = new Vector3[] { new Vector3(8, 3), new Vector3(8, 6) };
+            added = grid.AddVerticesWithCustomExtension(toExtend, 2);
+            Assert.Equal(2, added.Count);
+            Assert.Equal(new Vector3(8, 3), added[0].Point);
+            Assert.Equal(new Vector3(8, 6), added[1].Point);
+            Assert.Single(added[0].Edges);
+            Assert.Single(added[1].Edges);
+        }
+
+        [Fact]
         public void AdaptiveGridVertexGetEdgeOtherVertexId()
         {
             var grid = SampleGrid();

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -278,7 +278,7 @@ namespace Elements.Tests
             //Forms small (6;6) -> (8;6) -> (8;8) -> (6;8) rectangle.
             bbox = new BBox3(new Vector3(6, 6), new Vector3(8, 8));
             var withTransform = Obstacle.FromBBox(bbox, addPerimeterEdges: true);
-            withTransform.Transform = new Transform();
+            withTransform.Orientation = new Transform();
             adaptiveGrid.SubtractObstacle(withTransform);
 
             Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(7, 7), out _, adaptiveGrid.Tolerance));
@@ -622,6 +622,22 @@ namespace Elements.Tests
             Assert.Equal(new Vector3(8, 3), added[0].Point);
             Assert.Equal(new Vector3(8, 6), added[1].Point);
             Assert.Single(added[0].Edges);
+            Assert.Single(added[1].Edges);
+        }
+
+        [Fact]
+        public void AddAngledVerticesWithCustomExtension()
+        {
+            var grid = new AdaptiveGrid();
+            grid.AddFromPolygon(Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10)),
+                                new List<Vector3> { });
+
+            var toExtend = new Vector3[] { new Vector3(1, 7), new Vector3(2, 8) };
+            var added = grid.AddVerticesWithCustomExtension(toExtend, 2);
+            Assert.Equal(2, added.Count);
+            Assert.Equal(new Vector3(0, 6), added[0].Point);
+            Assert.Equal(new Vector3(2, 8), added[1].Point);
+            Assert.Equal(3, added[0].Edges.Count);
             Assert.Single(added[1].Edges);
         }
 

--- a/Elements/test/ObstacleTests.cs
+++ b/Elements/test/ObstacleTests.cs
@@ -26,11 +26,10 @@ namespace Elements
 
         [Theory]
         [MemberData(nameof(GetIntersectsData))]
-        public void IntersectsTestDefaultConstructorWithOffsetAndTransform(Polyline polyline, bool expectedResult, int testNumber)
+        public void IntersectsTestDefaultConstructorWithOffset(Polyline polyline, bool expectedResult, int testNumber)
         {
-            var rectangle = Polygon.Rectangle(8, 8);
-            var transform = new Transform(0, 0, 1);
-            var obstacle = new Obstacle(rectangle, 8, 1, false, false, transform);
+            var rectangle = Polygon.Rectangle(8, 8).TransformedPolygon(new Transform(0, 0, 1));
+            var obstacle = new Obstacle(rectangle, 8, 1, false, false, null);
 
             var result = obstacle.Intersects(polyline);
 
@@ -140,6 +139,87 @@ namespace Elements
         }
 
         [Fact]
+        public void ObstacleFromWallHasCorrectOrientationInGrid()
+        {
+            var grid = new AdaptiveGrid();
+            grid.AddFromPolygon(Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10)),
+                                new List<Vector3> { });
+            Line centerLine = new Line(Vector3.Origin, new Vector3(10, 0));
+            var horizontalWall = new StandardWall(centerLine, 1, 3);
+            var horizontalObstacle = Obstacle.FromWall(horizontalWall, addPerimeterEdges: true);
+            var expectedPoints = new List<Vector3>()
+            {
+                new Vector3(0, -0.5, 0),
+                new Vector3(0, 0.5, 0),
+                new Vector3(10, -0.5, 0),
+                new Vector3(10, 0.5, 0),
+                new Vector3(0, -0.5, 3),
+                new Vector3(0, 0.5, 3),
+                new Vector3(10, -0.5, 3),
+                new Vector3(10, 0.5, 3),
+            };
+            Assert.Equal(horizontalObstacle.Points.Count, expectedPoints.Count);
+            Assert.True(horizontalObstacle.Points.All(p => expectedPoints.Any(e => e.IsAlmostEqualTo(p))));
+            grid.SubtractObstacle(horizontalObstacle);
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0.5, 0), out var id));
+            var vertex = grid.GetVertex(id);
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(new Vector3(10, 0.5, 0))));
+
+            grid = new AdaptiveGrid();
+            grid.AddFromPolygon(Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10)),
+                                new List<Vector3> { });
+            centerLine = new Line(Vector3.Origin, new Vector3(0, 10));
+            var verticalWall = new StandardWall(centerLine, 1, 3);
+            var verticalObstacle = Obstacle.FromWall(verticalWall, addPerimeterEdges: true);
+            expectedPoints = new List<Vector3>()
+            {
+                new Vector3(-0.5, 0, 0),
+                new Vector3(0.5, 0, 0),
+                new Vector3(-0.5, 10, 0),
+                new Vector3(0.5, 10, 0),
+                new Vector3(-0.5, 0, 3),
+                new Vector3(0.5, 0, 3),
+                new Vector3(-0.5, 10, 3),
+                new Vector3(0.5, 10, 3),
+            };
+            Assert.Equal(verticalObstacle.Points.Count, expectedPoints.Count);
+            Assert.True(verticalObstacle.Points.All(p => expectedPoints.Any(e => e.IsAlmostEqualTo(p))));
+            grid.SubtractObstacle(verticalObstacle);
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0.5, 0, 0), out id));
+            vertex = grid.GetVertex(id);
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(new Vector3(0.5, 10, 0))));
+
+            grid = new AdaptiveGrid();
+            grid.AddFromPolygon(Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10)),
+                                new List<Vector3> { });
+            centerLine = new Line(new Vector3(0.3535534, 0.3535534), new Vector3(9.64645, 9.64645));
+            var diagonalWall = new StandardWall(centerLine, 1, 3);
+            var diagonalObstacle = Obstacle.FromWall(diagonalWall, addPerimeterEdges: true);
+            expectedPoints = new List<Vector3>()
+            {
+                new Vector3(0, 0.70711, 0),
+                new Vector3(0.70711, 0, 0),
+                new Vector3(10, 9.292891, 0),
+                new Vector3(9.292891, 10, 0),
+                new Vector3(0, 0.70711, 3),
+                new Vector3(0.70711, 0, 3),
+                new Vector3(10, 9.292891, 3),
+                new Vector3(9.292891, 10, 3),
+            };
+            Assert.Equal(diagonalObstacle.Points.Count, expectedPoints.Count);
+            Assert.True(diagonalObstacle.Points.All(p => expectedPoints.Any(e => e.IsAlmostEqualTo(p))));
+            grid.SubtractObstacle(diagonalObstacle);
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0.70711, 0), out id, grid.Tolerance));
+            vertex = grid.GetVertex(id);
+            Assert.Equal(4, vertex.Edges.Count());
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(9.292891, 10, 0)));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0.70711, 0, 0), out id, grid.Tolerance));
+            vertex = grid.GetVertex(id);
+            Assert.Equal(4, vertex.Edges.Count());
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(10, 9.292891, 0)));
+        }
+
+        [Fact]
         public void IntersectsObstacleFromLine()
         {
             var offset = 0.1;
@@ -184,6 +264,109 @@ namespace Elements
 
             var offsetedLine = angledLine.TransformedLine(new Transform(offset, 0, 0));
             Assert.True(angledObstacle.Intersects(offsetedLine));
+        }
+
+        [Fact]
+        public void ObstacleFromLineHasCorrectOrientationInGrid()
+        {
+            var grid = new AdaptiveGrid();
+            grid.AddFromPolygon(Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10)),
+                                new List<Vector3> { });
+            Line centerLine = new Line(new Vector3(9, 0), new Vector3(1, 0));
+            var horizontalObstacle = Obstacle.FromLine(centerLine, 0.5, addPerimeterEdges: true);
+            var expectedPoints = new List<Vector3>()
+            {
+                new Vector3(0.5, -0.5, -0.5),
+                new Vector3(0.5, 0.5, -0.5),
+                new Vector3(9.5, -0.5, -0.5),
+                new Vector3(9.5, 0.5, -0.5),
+                new Vector3(0.5, -0.5, 0.5),
+                new Vector3(0.5, 0.5, 0.5),
+                new Vector3(9.5, -0.5, 0.5),
+                new Vector3(9.5, 0.5, 0.5)
+            };
+            Assert.Equal(horizontalObstacle.Points.Count, expectedPoints.Count);
+            Assert.True(horizontalObstacle.Points.All(p => expectedPoints.Any(e => e.IsAlmostEqualTo(p))));
+            grid.SubtractObstacle(horizontalObstacle);
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0.5, 0.5, 0), out var id));
+            var vertex = grid.GetVertex(id);
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(new Vector3(9.5, 0.5, 0))));
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(new Vector3(0.5, 0, 0))));
+
+            grid = new AdaptiveGrid();
+            grid.AddFromPolygon(Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10)),
+                                new List<Vector3> { });
+            centerLine = new Line(new Vector3(0, 1), new Vector3(0, 9));
+            var perpendicularObstacle = Obstacle.FromLine(centerLine, 0.5, addPerimeterEdges: true);
+            expectedPoints = new List<Vector3>()
+            {
+                new Vector3(-0.5, 0.5, -0.5),
+                new Vector3(0.5, 0.5, -0.5),
+                new Vector3(-0.5, 9.5, -0.5),
+                new Vector3(0.5, 9.5, -0.5),
+                new Vector3(-0.5, 0.5, 0.5),
+                new Vector3(0.5, 0.5, 0.5),
+                new Vector3(-0.5, 9.5, 0.5),
+                new Vector3(0.5, 9.5, 0.5),
+            };
+            Assert.Equal(perpendicularObstacle.Points.Count, expectedPoints.Count);
+            Assert.True(perpendicularObstacle.Points.All(p => expectedPoints.Any(e => e.IsAlmostEqualTo(p))));
+            grid.SubtractObstacle(perpendicularObstacle);
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0.5, 0.5, 0), out id));
+            vertex = grid.GetVertex(id);
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(new Vector3(0.5, 9.5, 0))));
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(new Vector3(0, 0.5, 0))));
+
+            grid = new AdaptiveGrid();
+            var boundary = Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10));
+            grid.AddFromPolygon(boundary, new List<Vector3> { });
+            grid.Boundaries = boundary;
+            centerLine = new Line(new Vector3(0, 0), new Vector3(10, 10));
+            var diagonalObstacle = Obstacle.FromLine(centerLine, 0.5, addPerimeterEdges: true, allowOutsideBoundary: false);
+            expectedPoints = new List<Vector3>()
+            {
+                new Vector3(0, -0.70711, -0.5),
+                new Vector3(-0.70711, 0, -0.5),
+                new Vector3(10, 10.70711, -0.5),
+                new Vector3(10.70711, 10, -0.5),
+                new Vector3(0, -0.70711, 0.5),
+                new Vector3(-0.70711, 0, 0.5),
+                new Vector3(10, 10.70711, 0.5),
+                new Vector3(10.70711, 10, 0.5),
+            };
+            Assert.Equal(diagonalObstacle.Points.Count, expectedPoints.Count);
+            Assert.True(diagonalObstacle.Points.All(p => expectedPoints.Any(e => e.IsAlmostEqualTo(p))));
+            grid.SubtractObstacle(diagonalObstacle);
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0.70711, 0), out id, grid.Tolerance));
+            vertex = grid.GetVertex(id);
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(9.292891, 10, 0)));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0.70711, 0, 0), out id, grid.Tolerance));
+            vertex = grid.GetVertex(id);
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(10, 9.292891, 0)));
+
+            grid = new AdaptiveGrid(new Transform().Rotated(Vector3.ZAxis, 45));
+            boundary = new Polygon(new List<Vector3> { new Vector3(0, 0), new Vector3(-5, 5), new Vector3(0, 10), new Vector3(5, 5) });
+            grid.AddFromExtrude(boundary, Vector3.ZAxis, 1, new List<Vector3> { new Vector3(0, 0) });
+            centerLine = new Line(new Vector3(0, 0), new Vector3(0, 0, 2));
+            var verticalObstacle = Obstacle.FromLine(centerLine, 0.5, addPerimeterEdges: true);
+            expectedPoints = new List<Vector3>()
+            {
+                new Vector3(0.5, 0.5, -0.5),
+                new Vector3(-0.5, 0.5, -0.5),
+                new Vector3(-0.5, -0.5, -0.5),
+                new Vector3(0.5, -0.5, -0.5),
+                new Vector3(0.5, 0.5, 2.5),
+                new Vector3(-0.5, 0.5, 2.5),
+                new Vector3(-0.5, -0.5, 2.5),
+                new Vector3(0.5, -0.5, 2.5),
+            };
+            Assert.Equal(verticalObstacle.Points.Count, expectedPoints.Count);
+            Assert.True(verticalObstacle.Points.All(p => expectedPoints.Any(e => e.IsAlmostEqualTo(p))));
+            grid.SubtractObstacle(verticalObstacle);
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0.5, 0.5, 0), out id, grid.Tolerance));
+            vertex = grid.GetVertex(id);
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(1, 0, 0)));
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(0, 1, 0)));
         }
     }
 }

--- a/Elements/test/ObstacleTests.cs
+++ b/Elements/test/ObstacleTests.cs
@@ -381,14 +381,14 @@ namespace Elements
             var obstacle = Obstacle.FromColumn(column, 0.1, addPerimeterEdges: true);
             var expectedPoints = new List<Vector3>()
             {
-                new Vector3(5.5, 5.5, 0),
-                new Vector3(5.5, 4.5, 0),
-                new Vector3(4.5, 4.5, 0),
-                new Vector3(4.5, 5.5, 0),
-                new Vector3(5.5, 5.5, 1),
-                new Vector3(5.5, 4.5, 1),
-                new Vector3(4.5, 4.5, 1),
-                new Vector3(4.5, 5.5, 1),
+                new Vector3(5.6, 5.6, -0.1),
+                new Vector3(5.6, 4.4, -0.1),
+                new Vector3(4.4, 4.4, -0.1),
+                new Vector3(4.4, 5.6, -0.1),
+                new Vector3(5.6, 5.6, 1.1),
+                new Vector3(5.6, 4.4, 1.1),
+                new Vector3(4.4, 4.4, 1.1),
+                new Vector3(4.4, 5.6, 1.1),
             };
 
             Assert.Equal(obstacle.Points.Count, expectedPoints.Count);

--- a/Elements/test/ObstacleTests.cs
+++ b/Elements/test/ObstacleTests.cs
@@ -368,5 +368,37 @@ namespace Elements
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(1, 0, 0)));
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(0, 1, 0)));
         }
+
+        [Fact]
+        public void ObstacleFromColumnHasCorrectOrientationInGrid()
+        {
+            var grid = new AdaptiveGrid();
+            grid.AddFromPolygon(Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10)),
+                                new List<Vector3> { new Vector3(5, 5) });
+            var center = new Vector3(5, 5);
+            var profile = Polygon.Rectangle(1, 1);
+            Column column = new Column(center, 1, null, profile);
+            var obstacle = Obstacle.FromColumn(column, 0.1, addPerimeterEdges: true);
+            var expectedPoints = new List<Vector3>()
+            {
+                new Vector3(5.5, 5.5, 0),
+                new Vector3(5.5, 4.5, 0),
+                new Vector3(4.5, 4.5, 0),
+                new Vector3(4.5, 5.5, 0),
+                new Vector3(5.5, 5.5, 1),
+                new Vector3(5.5, 4.5, 1),
+                new Vector3(4.5, 4.5, 1),
+                new Vector3(4.5, 5.5, 1),
+            };
+
+            Assert.Equal(obstacle.Points.Count, expectedPoints.Count);
+            Assert.True(obstacle.Points.All(p => expectedPoints.Any(e => e.IsAlmostEqualTo(p))));
+            grid.SubtractObstacle(obstacle);
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5.6, 5, 0), out var id));
+            var vertex = grid.GetVertex(id);
+            Assert.Equal(3, vertex.Edges.Count());
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(new Vector3(5.6, 5.6, 0))));
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(new Vector3(5.6, 4.4, 0))));
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- After few iteration of changes in AdaptiveGrid and AdaptiveGraph routing. Regressions and inconveniences were found during testing of different workflow.

DESCRIPTION:
- Done 2 fixes in newly updated AdaptiveGrid/Obstacle.
- `AdaptiveGrid.AddVertices` with `ConnectCutAndExtend` how extends only up to `HintExtendDistance` distance.
- Add HintSnapDistance with default value of 3
- Rename AddExtendVertices into AddVerticesWithCustomExtension, add a extendDistance parameter to it and make it public
- Created EdgeInfo structure in AdaptiveGraphRouting instead of a value pair. Added `HasVerticalChange` parameter to it. Is used to do not modify turn cost if either of two edges in turn point is not horizontal.  This prevents "free to travel" loops under 2d hint lines.

TESTING:
- AdaptiveGraphRoutingTests is adjusted to use EdgeInfo .
- Added AddVerticesWithCustomExtension test.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Tolerance parameter in Line.PointOnLine is not really used anywhere in final version but I see it to be very useful in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/892)
<!-- Reviewable:end -->
