### PR TITLE
add xy, yz, and xz default planes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
                                out Dictionary<Guid, List<Polygon>> intersectionPolygons,
                                out Dictionary<Guid, List<Polygon>> beyondPolygons,
                                out Dictionary<Guid, List<Line>> lines)`
+- `Plane.XY`, `Plane.XZ`, and `Plane.YZ` static properties
 
 ### Changed
 

--- a/Elements/src/Geometry/Plane.cs
+++ b/Elements/src/Geometry/Plane.cs
@@ -176,5 +176,21 @@ namespace Elements.Geometry
             result = default;
             return false;
         }
+
+        /// <summary>
+        /// The world XY Plane.
+        /// </summary>
+        public static Plane XY => new Plane(Vector3.Origin, Vector3.ZAxis);
+
+        /// <summary>
+        /// The world YZ Plane.
+        /// </summary>
+        public static Plane YZ => new Plane(Vector3.Origin, Vector3.XAxis);
+
+        /// <summary>
+        /// The world XZ Plane.
+        /// </summary>
+        public static Plane XZ => new Plane(Vector3.Origin, Vector3.YAxis);
+
     }
 }


### PR DESCRIPTION
BACKGROUND:
- I wind up re-creating the XY plane all over my code all the time. it should just be available like Vector3.XAxis etc.

DESCRIPTION:
- Adds built-in static planes for XY, YZ, and XZ.
 
REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/894)
<!-- Reviewable:end -->
