### PR TITLE
Add extension method RemoveVectorsAtSamePlace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.0
+
+### Added
+- `IEnumerable<Vector3>.UniqueWithinTolerance(double tolerance = Vector3.EPSILON)`
+
+
 ## 1.2.0
 
 ### Added
@@ -26,7 +32,6 @@
                                out Dictionary<Guid, List<Polygon>> intersectionPolygons,
                                out Dictionary<Guid, List<Polygon>> beyondPolygons,
                                out Dictionary<Guid, List<Line>> lines)`
-- `IEnumerable<Vector3>.RemoveVectorsAtSamePlace(double tolerance = Vector3.EPSILON)`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
                                out Dictionary<Guid, List<Polygon>> intersectionPolygons,
                                out Dictionary<Guid, List<Polygon>> beyondPolygons,
                                out Dictionary<Guid, List<Line>> lines)`
+- `IEnumerable<Vector3>.RemoveVectorsAtSamePlace(double tolerance = Vector3.EPSILON)`
 
 ### Changed
 

--- a/Elements/src/Geometry/Vector3Extensions.cs
+++ b/Elements/src/Geometry/Vector3Extensions.cs
@@ -251,6 +251,27 @@ namespace Elements.Geometry
             }
             return normal.Unitized();
         }
+        
+        /// <summary>
+        /// Remove vectors at the same place
+        /// </summary>
+        /// <param name="vectors">List of vectors</param>
+        /// <param name="tolerance">Distance tolerance</param>
+        /// <returns>List without vectors at the same place</returns>
+        public static IEnumerable<Vector3> RemoveVectorsAtSamePlace(this IEnumerable<Vector3> vectors, double tolerance = Vector3.EPSILON)
+        {
+            var output = new List<Vector3>();
+            foreach (var vector in vectors)
+            {
+                if (output.Any(x => x.IsAlmostEqualTo(vector, tolerance)))
+                {
+                    continue;;
+                }
+                output.Add(vector);
+            }
+
+            return output;
+        }
     }
 
     /// <summary>

--- a/Elements/src/Geometry/Vector3Extensions.cs
+++ b/Elements/src/Geometry/Vector3Extensions.cs
@@ -253,12 +253,12 @@ namespace Elements.Geometry
         }
         
         /// <summary>
-        /// Remove vectors at the same place
+        /// De-duplicate a collection of Vectors, such that no two vectors in the result are within tolerance of each other.
         /// </summary>
         /// <param name="vectors">List of vectors</param>
         /// <param name="tolerance">Distance tolerance</param>
-        /// <returns>List without vectors at the same place</returns>
-        public static IEnumerable<Vector3> RemoveVectorsAtSamePlace(this IEnumerable<Vector3> vectors, double tolerance = Vector3.EPSILON)
+        /// <returns>A new collection of vectors with duplicates removed.</returns>
+        public static IEnumerable<Vector3> UniqueWithinTolerance(this IEnumerable<Vector3> vectors, double tolerance = Vector3.EPSILON)
         {
             var output = new List<Vector3>();
             foreach (var vector in vectors)

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -518,7 +518,7 @@ namespace Elements.Tests
         }
 
         [Fact]
-        public void RemoveVectorsAtTheSamePlace()
+        public void UniqueWithinToleranceReturnsNewCollection()
         {
             var vectorsList = new List<Vector3>
             {
@@ -531,7 +531,7 @@ namespace Elements.Tests
                 new Vector3(5,5)
             };
 
-            var result = vectorsList.RemoveVectorsAtSamePlace();
+            var result = vectorsList.UniqueWithinTolerance();
             
             Assert.Collection(result, 
                 x => x.IsAlmostEqualTo(Vector3.Origin),
@@ -539,7 +539,7 @@ namespace Elements.Tests
         }
         
         [Fact]
-        public void RemoveVectorsAtTheSamePlaceWithTolerance()
+        public void UniqueWithinToleranceReturnsNewCollectionWithTolerance()
         {
             var tolerance = 0.2;
             
@@ -554,7 +554,7 @@ namespace Elements.Tests
                 new Vector3(5,5)
             };
 
-            var result = vectorsList.RemoveVectorsAtSamePlace(tolerance);
+            var result = vectorsList.UniqueWithinTolerance(tolerance);
             
             Assert.Collection(result, 
                 x => x.IsAlmostEqualTo(Vector3.Origin, tolerance),

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -516,5 +516,49 @@ namespace Elements.Tests
             Assert.True(closestPointSegment.IsAlmostEqualTo(new Vector3(0, 0)));
             Assert.True(closestPointInfinite.IsAlmostEqualTo(new Vector3(-5, -5)));
         }
+
+        [Fact]
+        public void RemoveVectorsAtTheSamePlace()
+        {
+            var vectorsList = new List<Vector3>
+            {
+                Vector3.Origin,
+                new Vector3(0.000009, 0, 0),
+                new Vector3(0, -0.000009, 0),
+                new Vector3(5, 5),
+                new Vector3(5, 5, 0.000009),
+                Vector3.Origin, 
+                new Vector3(5,5)
+            };
+
+            var result = vectorsList.RemoveVectorsAtSamePlace();
+            
+            Assert.Collection(result, 
+                x => x.IsAlmostEqualTo(Vector3.Origin),
+                x => x.IsAlmostEqualTo(new Vector3(5, 5)));
+        }
+        
+        [Fact]
+        public void RemoveVectorsAtTheSamePlaceWithTolerance()
+        {
+            var tolerance = 0.2;
+            
+            var vectorsList = new List<Vector3>
+            {
+                new Vector3(0.1, 0, 0),
+                Vector3.Origin,
+                new Vector3(0, -0.1, 0),
+                new Vector3(5, 5, 0.1),
+                new Vector3(5, 5),
+                Vector3.Origin, 
+                new Vector3(5,5)
+            };
+
+            var result = vectorsList.RemoveVectorsAtSamePlace(tolerance);
+            
+            Assert.Collection(result, 
+                x => x.IsAlmostEqualTo(Vector3.Origin, tolerance),
+                x => x.IsAlmostEqualTo(new Vector3(5, 5), tolerance));
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
Very often I had to filter vectors list of those which are at the same places. Unfortunately I cannot use `Vector3Comparer` with LINQ `Distinct` method, because it uses `GetHashCode` to determine equality.

DESCRIPTION:
I added new extension method which iterates through list of vectors and checks if any of similar vector is already in list.

TESTING:
Run unit tests

FUTURE WORK:
None

REQUIRED:
- [x] All changes are up to date in CHANGELOG.md.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/895)
<!-- Reviewable:end -->
