### PR TITLE
AdaptiveGraphRouting simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,24 @@
 - `AdaptiveGrid.AddVerticesWithCustomExtension(IList<Vector3> points, double extendDistance)`
 - `AdaptiveGrid.HintExtendDistance`
 - `Obstacle.Orientation`
+- `Elements.Spatial.AdaptiveGrid.EdgeInfo`
 
 ### Changed
 
 - `Line.PointOnLine` - added `tolerance` parameter.
 - `AdaptiveGrid.AddVertices` with `ConnectCutAndExtend` how extends only up to `HintExtendDistance` distance.
 -  Created `EdgeInfo` structure in `AdaptiveGraphRouting` instead of a value pair. Added `HasVerticalChange` parameter to it.
+- Moved `BranchSide`, `RoutingVertex`, `RoutingConfiguration`, `RoutingHintLine`, `TreeOrder` from `AdaptiveGraphRouting` to their own files.
+- `RoutingVertex` - removed `Guides`.
+- `AdaptiveGraphRouting.BuildSpanningTree` functions are simplified. Also, they use only single `tailPoint` now.
+- `AdaptiveGraphRouting.BuildSpanningTree` no longer require to have at least one hint line. 
+
 
 ### Fixed
 
 - `Line.Intersects` for `BBox3` - better detection of line with one intersection that just touches box corner.
 - `Obstacle.FromWall` and `Obstacle.FromLine` produced wrong `Points` when diagonal.
+- `AdaptiveGridRouting.BuildSimpleNetwork` now correctly uses `RoutingVertex.IsolationRadius`.
 
 ## 1.2.0
 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -42,7 +42,7 @@ namespace Elements.Spatial.AdaptiveGrid
 
         /// <summary>
         /// Routing supports checking if a Vertex can be added to the path.
-        /// New vertex must pass all filter functions to be accepted. 
+        /// New vertex must pass all filter functions to be accepted.
         /// </summary>
         /// <param name="f">New filter function.</param>
         public void AddRoutingFilter(RoutingFilter f)
@@ -75,7 +75,7 @@ namespace Elements.Spatial.AdaptiveGrid
             foreach (var edge in _grid.GetEdges())
             {
                 //There is only one edge for vertex pair, if this is changed -
-                //we will need to check edges for uniqueness, 
+                //we will need to check edges for uniqueness,
                 var v0 = _grid.GetVertex(edge.StartId);
                 var v1 = _grid.GetVertex(edge.EndId);
                 Line l = new Line(v0.Point, v1.Point);
@@ -176,7 +176,7 @@ namespace Elements.Spatial.AdaptiveGrid
             List<ulong> collectorTerminals = leafVertices.Select(lv => lv.Id).ToList();
 
             //Join all individual pieces together. We start from a single connection
-            //path from droppipe and a set of connection points from the previous step.
+            //path from trunk and a set of connection points from the previous step.
             //One at a time we choose the connection point that is cheapest to travel to existing
             //network and its path is added to the network until all are added.
             HashSet<ulong> magnetTerminals = new HashSet<ulong>() { trunkVertex };
@@ -228,18 +228,18 @@ namespace Elements.Spatial.AdaptiveGrid
         /// hint lines and local end Vertex, and the exit Vertex.
         /// Route is created by using Dijkstra algorithm locally on different segments.
         /// Segments are merged together to form a single trunk. Starting from end, point by point,
-        /// segments are connected. Then, Vertices in each segments are connected as well, 
+        /// segments are connected. Then, Vertices in each segments are connected as well,
         /// forming a local trunk, connected with the main one.
         /// All parameter except "trunkPathVertices" are provided per section in the same order.
         /// </summary>
         /// <param name="leafVertices">Vertices to connect into the system with extra information attached.</param>
-        /// <param name="trunkVerex">End vertex id.</param>
+        /// <param name="trunkVertex">End vertex id.</param>
         /// <param name="hintLines">Collection of lines that routes are attracted to. At least one hint line per group is required.</param>
         /// <param name="order">In which order tree is constructed</param>
         /// <returns>Travel routes from inputVertices to the last of tailVertices.</returns>
         public IDictionary<ulong, ulong?> BuildSpanningTree(
             IList<List<RoutingVertex>> leafVertices,
-            ulong trunkVerex,
+            ulong trunkVertex,
             IList<List<RoutingHintLine>> hintLines,
             TreeOrder order)
         {
@@ -262,7 +262,7 @@ namespace Elements.Spatial.AdaptiveGrid
             allExcluded.ExceptWith(nearbyHints.Select(nh => nh.Id));
 
             var vertexTree = new Dictionary<ulong, ulong?>();
-            vertexTree[trunkVerex] = null;
+            vertexTree[trunkVertex] = null;
             foreach (var inlets in leafVertices)
             {
                 foreach (var inlet in inlets)
@@ -270,7 +270,7 @@ namespace Elements.Spatial.AdaptiveGrid
                     vertexTree[inlet.Id] = null;
                 }
             }
- 
+
             //Next steps are repeated independently for each input section
             for (int i = 0; i < leafVertices.Count; i++)
             {
@@ -281,7 +281,7 @@ namespace Elements.Spatial.AdaptiveGrid
                 //path from droppipe and a set of connection points from the previous step.
                 //One at a time we choose the connection point that is cheapest to travel to existing
                 //network and its path is added to the network until all are added.
-                HashSet<ulong> magnetTerminals = new HashSet<ulong> { trunkVerex };
+                HashSet<ulong> magnetTerminals = new HashSet<ulong> { trunkVertex };
 
                 var terminalInfo = new Dictionary<ulong, (
                     Dictionary<ulong, ((ulong, BranchSide), (ulong, BranchSide))> Connections,
@@ -784,7 +784,7 @@ namespace Elements.Spatial.AdaptiveGrid
 
             //Minimum factor makes algorithm prefer edges inside of hint lines even if they
             //have several turns but don't give advantage for the tiny edges that are
-            //fully inside hint line influence area. 
+            //fully inside hint line influence area.
             return _configuration.TurnCost * Math.Min(edgeInfo.Factor, otherWeight.Factor);
         }
 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -339,7 +339,7 @@ namespace Elements.Spatial.AdaptiveGrid
         public IDictionary<ulong, ulong?> BuildSimpleNetwork(
             IList<RoutingVertex> leafVertices,
             IList<ulong> exits,
-            IEnumerable<RoutingHintLine> hintLines)
+            IEnumerable<RoutingHintLine> hintLines = null)
         {
             //Excluded vertices includes inlets and vertices in certain distance around these inlets.
             //Sometimes it's not desirable for routing to go through them.
@@ -374,7 +374,9 @@ namespace Elements.Spatial.AdaptiveGrid
 
             foreach (var inlet in leafVertices)
             {
-                var connections = ShortestPathDijkstra(inlet.Id, weights, out var travelCost);
+                var excluded = FilteredSet(allExcluded, excludedVertices[inlet.Id]);
+                var connections = ShortestPathDijkstra(
+                    inlet.Id, weights, out var travelCost, excluded: excluded);
                 var exit = FindConnectionPoint(exits, travelCost);
                 var path = GetPathTo(connections, exit);
                 AddPathToTree(inlet.Id, path, vertexTree);

--- a/Elements/src/Spatial/AdaptiveGrid/BranchSide.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/BranchSide.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elements.Spatial.AdaptiveGrid
+{
+    /// <summary>
+    /// Enumeration that indicates one of two possible paths in routing.
+    /// There are cases when we need to collect more than one path and
+    /// only after some time we can decide which one is better.
+    /// </summary>
+    public enum BranchSide
+    {
+        /// <summary>
+        /// Indicator that first, "left", path is preferred.
+        /// </summary>
+        Left,
+
+        /// <summary>
+        /// Indicator that second, "right" path is preferred.
+       /// </summary>
+        Right
+    }
+}

--- a/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elements.Spatial.AdaptiveGrid
+{
+    /// <summary>
+    /// Precalculated information about the edge.
+    /// </summary>
+    public struct EdgeInfo
+    {
+        /// <summary>
+        /// Construct new EdgeInfo structure.
+        /// </summary>
+        /// <param name="grid">Grid, edge belongs to.</param>
+        /// <param name="edge">The edge.</param>
+        /// <param name="factor">Edge traveling factor.</param>
+        public EdgeInfo(AdaptiveGrid grid, Edge edge, double factor = 1)
+        {
+            Edge = edge;
+            var v0 = grid.GetVertex(edge.StartId);
+            var v1 = grid.GetVertex(edge.EndId);
+            var vector = (v1.Point - v0.Point);
+            Length = vector.Length();
+            Factor = factor;
+            HasVerticalChange = Math.Abs(v0.Point.Z - v1.Point.Z) > grid.Tolerance;
+        }
+
+        /// <summary>
+        /// The Edge.
+        /// </summary>
+        public readonly Edge Edge;
+
+        /// <summary>
+        /// Length of the edge.
+        /// </summary>
+        public readonly double Length;
+
+        /// <summary>
+        /// Edge traveling factor.
+        /// </summary>
+        public readonly double Factor;
+
+        /// <summary>
+        /// Are edge end points on different elevations.
+        /// </summary>
+        public readonly bool HasVerticalChange;
+    }
+}

--- a/Elements/src/Spatial/AdaptiveGrid/RoutingConfiguration.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/RoutingConfiguration.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elements.Spatial.AdaptiveGrid
+{
+    /// <summary>
+    /// Object that holds common parameters that affect routing.
+    /// </summary>
+    public struct RoutingConfiguration
+    {
+        /// <summary>
+        /// Construct new RoutingConfiguration structure.
+        /// </summary>
+        /// <param name="turnCost">Travel cost penalty if route changes it's direction.</param>
+        /// <param name="mainLayer">Elevation at which route prefers to travel.</param>
+        /// <param name="layerPenalty">Penalty if route travels through an elevation different from MainLayer.</param>
+        /// <param name="supportedAngles">List of angles route can turn.</param>
+        public RoutingConfiguration(double turnCost = 0,
+                                    double mainLayer = 0,
+                                    double layerPenalty = 1,
+                                    List<double> supportedAngles = null)
+        {
+            TurnCost = turnCost;
+            MainLayer = mainLayer;
+            LayerPenalty = layerPenalty;
+            SupportedAngles = supportedAngles;
+            if (SupportedAngles != null && !SupportedAngles.Contains(0))
+            {
+                SupportedAngles.Add(0);
+            }
+        }
+
+        /// <summary>
+        /// Travel cost penalty if route changes it's direction.
+        /// </summary>
+        public readonly double TurnCost;
+
+        /// <summary>
+        /// Elevation at which route prefers to travel.
+        /// </summary>
+        public readonly double MainLayer;
+
+        /// <summary>
+        /// Travel cost penalty if route travels through an elevation different from MainLayer.
+        /// </summary>
+        public readonly double LayerPenalty;
+
+        /// <summary>
+        /// List of angles route can turn. Angles are between 0 and 90. 0 is auto-included.
+        /// For turn angle bigger than 90 degrees - 180 degrees minus angle is checked.
+        /// For example, 135 is the same as 45.
+        /// </summary>
+        public readonly List<double> SupportedAngles;
+    }
+}

--- a/Elements/src/Spatial/AdaptiveGrid/RoutingHintLine.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/RoutingHintLine.cs
@@ -1,0 +1,51 @@
+﻿using Elements.Geometry;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elements.Spatial.AdaptiveGrid
+{
+    /// <summary>
+    /// Structure that holds information about polylines that are used to guide routing.
+    /// </summary>
+    public struct RoutingHintLine
+    {
+        /// <summary>
+        /// Construct new RoutingHintLine structure.
+        /// </summary>
+        /// <param name="polyline">Geometry of HintLine.</param>
+        /// <param name="factor">Cost multiplier.</param>
+        /// <param name="influence">How far it affects.</param>
+        /// <param name="userDefined">Is user defined.</param>
+        public RoutingHintLine(
+            Polyline polyline, double factor, double influence, bool userDefined)
+        {
+            Polyline = polyline;
+            Factor = factor;
+            InfluenceDistance = influence;
+            UserDefined = userDefined;
+        }
+
+        /// <summary>
+        /// 2D Polyline geometry representation with an influence that is extended on both sides in Z direction.
+        /// </summary>
+        public readonly Polyline Polyline;
+
+        /// <summary>
+        /// Cost multiplier for edges that lie within the Influence distance to the line.
+        /// </summary>
+        public readonly double Factor;
+
+        /// <summary>
+        /// How far away from the line, edge travel cost is affected.
+        /// Both sides of an edge and its middle point should be within influence range.
+        /// </summary>
+        public readonly double InfluenceDistance;
+
+        /// <summary>
+        /// Is line created by the user or from internal parameters?
+        /// User defined lines are preferred for input Vertex connection.
+        /// </summary>
+        public readonly bool UserDefined;
+    }
+}

--- a/Elements/src/Spatial/AdaptiveGrid/RoutingVertex.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/RoutingVertex.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elements.Spatial.AdaptiveGrid
+{
+    /// <summary>
+    /// Structure that holds additional information about inlet vertex
+    /// </summary>
+    public struct RoutingVertex
+    {
+        /// <summary>
+        /// Construct new RoutingVertex structure.
+        /// </summary>
+        /// <param name="id">Id of the vertex in the grid.</param>
+        /// <param name="isolationRadius"> Distance, other sections of the route can't travel near this vertex.</param>
+        public RoutingVertex(
+            ulong id, double isolationRadius)
+        {
+            Id = id;
+            IsolationRadius = isolationRadius;
+        }
+
+        /// <summary>
+        /// Id of the vertex in the grid.
+        /// </summary>
+        public ulong Id;
+
+        /// <summary>
+        /// Distance closer than which, other sections of the route can't travel near this vertex. 
+        /// Distance is in base plane of the gird, without elevation.
+        /// </summary>
+        public double IsolationRadius;
+    }
+}

--- a/Elements/src/Spatial/AdaptiveGrid/TreeOrder.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/TreeOrder.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elements.Spatial.AdaptiveGrid
+{
+    /// <summary>
+    /// Order at which leaf terminal are connected into the tree.
+    /// </summary>
+    public enum TreeOrder
+    {
+        /// <summary>
+        /// Closest from remaining terminals is routed first.
+        /// </summary>
+        ClosestToFurthest,
+
+        /// <summary>
+        /// Furthest from remaining terminals is routed first.
+        /// </summary>
+        FurthestToClosest
+    }
+}

--- a/Elements/test/AdaptiveGraphRoutingTests.cs
+++ b/Elements/test/AdaptiveGraphRoutingTests.cs
@@ -39,7 +39,7 @@ namespace Elements.Tests
             grid.SubtractObstacle(obstacle);
 
             //Each turn cost 1 additional "meter"
-            var configuration = new AdaptiveGraphRouting.RoutingConfiguration(turnCost: 1);
+            var configuration = new RoutingConfiguration(turnCost: 1);
             AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, configuration);
             grid.TryGetVertexIndex(new Vector3(0, 4, 0), out var inV, grid.Tolerance);
 
@@ -213,16 +213,11 @@ namespace Elements.Tests
                 new Vector3(5, 8, 3)
             };
 
-            var tailPoints = new List<Vector3>()
-            {
-                new Vector3(5, 10, 0),
-                new Vector3(5, 10, 2),
-                new Vector3(6, 10, 2)
-            };
+            var tailPoint = new Vector3(5, 10, 0);
 
             var keyPoints = new List<Vector3>();
             keyPoints.AddRange(inputPoints);
-            keyPoints.AddRange(tailPoints);
+            keyPoints.Add(tailPoint);
 
             var hintPolyline = new Polyline(new List<Vector3>()
             {
@@ -238,14 +233,15 @@ namespace Elements.Tests
             var offsetPolyline = new Polyline(new List<Vector3>()
             {
                 new Vector3(6, 2),
-                new Vector3(6, 10)
+                new Vector3(6, 10),
+                new Vector3(5, 10)
             });
             keyPoints.AddRange(offsetPolyline.Vertices.Select(
                 v => new Vector3(v.X, v.Y, configuration.MainLayer)));
 
             var hints = new List<RoutingHintLine>();
-            hints.Add(new RoutingHintLine(hintPolyline, 0.1, 0.2, true));
-            hints.Add(new RoutingHintLine(offsetPolyline, 0.5, 0.1, false));
+            hints.Add(new RoutingHintLine(hintPolyline, 0.01, 0.2, true));
+            hints.Add(new RoutingHintLine(offsetPolyline, 0.1, 0.1, false));
 
             var box = new BBox3(new Vector3(3, 6, 0), new Vector3(7, 7, 3));
             var obstacle = Obstacle.FromBBox(box);
@@ -270,22 +266,32 @@ namespace Elements.Tests
                     inputVertices.Add(new RoutingVertex(id, 0.5));
                 }
             }
-            List<ulong> tailVertices = new List<ulong>();
-            foreach (var tail in tailPoints)
-            {
-                Assert.True(grid.TryGetVertexIndex(tail, out ulong id, grid.Tolerance));
-                {
-                    tailVertices.Add(id);
-                }
-            }
+
+            Assert.True(grid.TryGetVertexIndex(tailPoint, out ulong tailVertex, grid.Tolerance));
 
             AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, configuration);
-            var tree = alg.BuildSpanningTree(inputVertices, tailVertices, hints, TreeOrder.ClosestToFurthest);
+            var tree = alg.BuildSpanningTree(inputVertices, tailVertex, hints, TreeOrder.ClosestToFurthest);
 
             List<Vector3> expectedPath = new List<Vector3>()
             {
                 new Vector3(5, 8, 3),
                 new Vector3(5, 8, 2),
+                new Vector3(6, 8, 2),
+                new Vector3(6, 10, 2),
+                new Vector3(5, 10, 2),
+                new Vector3(5, 10, 1),
+                new Vector3(5, 10, 0)
+            };
+
+            CheckTree(grid, inputVertices[2].Id, tree, expectedPath);
+
+            expectedPath = new List<Vector3>()
+            {
+                new Vector3(5, 5, 3),
+                new Vector3(5, 5, 2),
+                new Vector3(5, 6, 2),
+                new Vector3(3, 6, 2),
+                new Vector3(3, 7, 2),
                 new Vector3(5, 7, 2),
                 new Vector3(6, 7, 2),
                 new Vector3(6, 8, 2),
@@ -295,7 +301,7 @@ namespace Elements.Tests
                 new Vector3(5, 10, 0)
             };
 
-            CheckTree(grid, inputVertices[2].Id, tree, expectedPath);
+            CheckTree(grid, inputVertices[1].Id, tree, expectedPath);
 
             expectedPath = new List<Vector3>()
             {
@@ -343,17 +349,13 @@ namespace Elements.Tests
                 new Vector3(11, 12, 0),
             };
 
-            //3. Define end points. Last should go first.
-            var tailPoints = new List<Vector3>()
-            {
-                new Vector3(12, 20, 0),
-                new Vector3(10, 20, 0)
-            };
+            //3. Define end point.
+            var tailPoint = new Vector3(12, 20, 0);
 
             //4. All significant points must be added as key points.
             var keyPoints = new List<Vector3>();
             keyPoints.AddRange(inputPoints);
-            keyPoints.AddRange(tailPoints);
+            keyPoints.Add(tailPoint);
 
             //5. Define hint and offset lines.
             var firstOffsetPolyline = new Polyline(new List<Vector3>(){
@@ -397,14 +399,7 @@ namespace Elements.Tests
                 }
             }
 
-            List<ulong> tailVertices = new List<ulong>();
-            foreach (var tail in tailPoints)
-            {
-                Assert.True(grid.TryGetVertexIndex(tail, out ulong id, grid.Tolerance));
-                {
-                    tailVertices.Add(id);
-                }
-            }
+            Assert.True(grid.TryGetVertexIndex(tailPoint, out ulong tailVertex, grid.Tolerance));
 
             //9. Set configurations for hint and offset lines.
             var hint = new RoutingHintLine(hintPolyline, 0.01, 0.1, true);
@@ -415,11 +410,10 @@ namespace Elements.Tests
             //10. Run algorithm
             var config = new RoutingConfiguration(turnCost: 1);
             AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, config);
-            var tree = alg.BuildSpanningTree(inputVertices, tailVertices, hints, TreeOrder.ClosestToFurthest);
+            var tree = alg.BuildSpanningTree(inputVertices, tailVertex, hints, TreeOrder.ClosestToFurthest);
 
-            //Throws if no hint lines
-            Assert.Throws<ArgumentException>(() =>
-                alg.BuildSpanningTree(inputVertices, tailVertices, new List<RoutingHintLine>(), TreeOrder.ClosestToFurthest));
+            //Not throws if no hint lines
+            alg.BuildSpanningTree(inputVertices, tailVertex, new List<RoutingHintLine>(), TreeOrder.ClosestToFurthest);
 
             //Results visualization
             List<Line> lines = new List<Line>();
@@ -463,25 +457,13 @@ namespace Elements.Tests
                 new Vector3(11, 12, 0),
             };
 
-            //3. Define end points. Last should go first.
-            var tailPoints = new List<Vector3>()
-            {
-                new Vector3(12, 20, 0),
-                new Vector3(10, 20, 0)
-            };
-
-            //3a. Define local tail points, one per group
-            var localTailPoints = new List<Vector3>()
-            {
-                new Vector3(5, 16, 0),
-                new Vector3(15, 13, 0)
-            };
+            //3. Define end point.
+            var tailPoint = new Vector3(12, 20, 0);
 
             //4. All significant points must be added as key points.
             var keyPoints = new List<Vector3>();
             keyPoints.AddRange(inputPoints);
-            keyPoints.AddRange(localTailPoints);
-            keyPoints.AddRange(tailPoints);
+            keyPoints.Add(tailPoint);
 
             //5. Define hint and offset lines.
             var firstOffsetPolyline = new Polyline(new List<Vector3>(){
@@ -535,23 +517,7 @@ namespace Elements.Tests
                 }
             }
 
-            List<ulong> localTailVertices = new List<ulong>();
-            foreach (var tail in localTailPoints)
-            {
-                Assert.True(grid.TryGetVertexIndex(tail, out ulong id, grid.Tolerance));
-                {
-                    localTailVertices.Add(id);
-                }
-            }
-
-            List<ulong> tailVertices = new List<ulong>();
-            foreach (var tail in tailPoints)
-            {
-                Assert.True(grid.TryGetVertexIndex(tail, out ulong id, grid.Tolerance));
-                {
-                    tailVertices.Add(id);
-                }
-            }
+            Assert.True(grid.TryGetVertexIndex(tailPoint, out ulong tailVertex, grid.Tolerance));
 
             //9. Set configurations for hint and offset lines. Split them into groups.
             var hint = new RoutingHintLine(hintPolyline, 0.01, 0.1, true);
@@ -567,11 +533,11 @@ namespace Elements.Tests
             var config = new RoutingConfiguration(turnCost: 1);
             AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, config);
             var tree = alg.BuildSpanningTree(
-                inputVertices, localTailVertices, tailVertices, hints, TreeOrder.ClosestToFurthest);
+                inputVertices, tailVertex, hints, TreeOrder.ClosestToFurthest);
 
-            //Throws if no hint lines
-            Assert.Throws<ArgumentException>(() => alg.BuildSpanningTree(
-                    inputVertices, localTailVertices, tailVertices, new List<List<RoutingHintLine>>(), TreeOrder.ClosestToFurthest));
+            //No throws if no hint lines
+            alg.BuildSpanningTree(
+                inputVertices, tailVertex, new List<List<RoutingHintLine>>(), TreeOrder.ClosestToFurthest);
 
             //Result visualization
             List<Line> lines = new List<Line>();


### PR DESCRIPTION
BACKGROUND:
- BuildSpanningTree is building a route in two stages. First to the closest hint line and then to the exit. This causes inefficient path in some cases but also makes function slower and harder to understand in general.
- There were other refactoring requests that are done here.

DESCRIPTION:
- Moved `EdgeInfo`, `BranchSide`, `RoutingVertex`, `RoutingConfiguration`, `RoutingHintLine`, `TreeOrder` from `AdaptiveGraphRouting` to their own files.
- Removed concepts that were not used: Guides from RoutingVertex. BuildSpanningTree functions use only single `tailPoint` now.
- BuildSpanningTree functions are greatly simplified. They call ShortestBranchesDijkstra only once per input vertex now. This improves performance, make things easier to understand and behaves better in some 3D graphs.
- BuildSpanningTree functions  no longer require to have at least one hint line. 

TESTING:
- Tests updated to new API.
- Added AdaptiveGraphRoutingIsolationRadiusCheck test.
  
FUTURE WORK:
Next improvement are expected to be done further:
- Improve readability of unit tests for AdaptiveGrid and AdaptiveGraphRouting.
- Maybe rename AdaptiveGrid into AdaptiveGraph for consistancy (?) 
- Instead of ClosestToFurhest / FurthestToClosest use balanced algorith.
- Better error information from AdaptiveGraphRouting
- Better support of 3D hint lines and inserting of 3D polylines into the graph by AddVertinces.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/896)
<!-- Reviewable:end -->
