### PR TITLE
Make vertex console writing optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 - Moved `BranchSide`, `RoutingVertex`, `RoutingConfiguration`, `RoutingHintLine`, `TreeOrder` from `AdaptiveGraphRouting` to their own files.
 - `RoutingVertex` - removed `Guides`.
 - `AdaptiveGraphRouting.BuildSpanningTree` functions are simplified. Also, they use only single `tailPoint` now.
-- `AdaptiveGraphRouting.BuildSpanningTree` no longer require to have at least one hint line. 
+- `AdaptiveGraphRouting.BuildSpanningTree` no longer require to have at least one hint line.
+- Don't log all vertex creation actions during Debug mode geometry generation.
 
 
 ### Fixed

--- a/Elements/src/Geometry/Tessellation/Tessellation.cs
+++ b/Elements/src/Geometry/Tessellation/Tessellation.cs
@@ -13,7 +13,10 @@ namespace Elements.Geometry.Tessellation
     /// </summary>
     internal static class Tessellation
     {
-        private static bool LOG_TESSELATION = false;
+        // TODO remove this when we have a logging system with more granular control over logging levels.
+        // Switch this to true to see the tessellation progress of all elements.
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static bool LOG_TESSELATION = false;
 
         /// <summary>
         /// Triangulate a collection of CSGs and pack the triangulated data into

--- a/Elements/src/Geometry/Tessellation/Tessellation.cs
+++ b/Elements/src/Geometry/Tessellation/Tessellation.cs
@@ -13,9 +13,11 @@ namespace Elements.Geometry.Tessellation
     /// </summary>
     internal static class Tessellation
     {
+        private static bool LOG_TESSELATION = false;
+
         /// <summary>
         /// Triangulate a collection of CSGs and pack the triangulated data into
-        /// a supplied buffers object. 
+        /// a supplied buffers object.
         /// </summary>
         internal static T Tessellate<T>(IEnumerable<ITessellationTargetProvider> providers,
                                         bool mergeVertices = false,
@@ -44,8 +46,8 @@ namespace Elements.Geometry.Tessellation
                                               IGraphicsBuffers buffers,
                                               Func<(Vector3, Vector3, UV, Color?), (Vector3, Vector3, UV, Color?)> modifyVertexAttributes)
         {
-            // The vertex map enables us to re-use vertices. Csgs and solid faces 
-            // create vertices which store the face id, the vertex id, and for csgs, the uv. 
+            // The vertex map enables us to re-use vertices. Csgs and solid faces
+            // create vertices which store the face id, the vertex id, and for csgs, the uv.
             // We can use the tag as the key to lookup the index of the vertex to avoid re-creating it.
             var vertexMap = new Dictionary<(int tag, long faceId), ushort>();
             var vertices = new List<(Vector3 position, Vector3 normal, UV uv, Color? color)>();
@@ -83,21 +85,21 @@ namespace Elements.Geometry.Tessellation
                     var v = tess.Vertices[localIndex];
                     var tessIndex = tessOffset + localIndex;
 
-                    // This is an optimization to use pre-existing csg vertex 
-                    // data to match vertices. 
+                    // This is an optimization to use pre-existing csg vertex
+                    // data to match vertices.
 
                     var (uv, tag, faceId) = ((UV uv, int tag, int faceId))v.Data;
 
                     if (vertexMap.ContainsKey((tag, faceId)))
                     {
-                        Debug.WriteLine($"Resuing vertex (tag:{tag},faceId:{faceId}");
+                        Debug.WriteLineIf(LOG_TESSELATION, $"Reusing vertex (tag:{tag},faceId:{faceId}");
                         // Reference an existing vertex from csg
                         indices.Add(vertexMap[(tag, faceId)]);
                         continue;
                     }
                     else if (vertexMap.ContainsKey((index, 0)))
                     {
-                        Debug.WriteLine($"Resuing vertex (tag:{tag},faceId:{faceId}");
+                        Debug.WriteLineIf(LOG_TESSELATION, $"Reusing vertex (tag:{tag},faceId:{faceId}");
                         // Reference an existing vertex created
                         // earlier here.
                         indices.Add(vertexMap[(index, 0)]);

--- a/Elements/src/Geometry/Tessellation/Tessellation.cs
+++ b/Elements/src/Geometry/Tessellation/Tessellation.cs
@@ -128,7 +128,7 @@ namespace Elements.Geometry.Tessellation
                         {
                             vertices.Add((v1, n, uv, c1));
                         }
-                        Debug.WriteLine($"Adding vertex (tag:{tag},faceId:{faceId}):{index}");
+                        Debug.WriteLineIf(LOG_TESSELATION, $"Adding vertex (tag:{tag},faceId:{faceId}):{index}");
                         indices.Add((ushort)index);
                         vertexMap.Add((tag, faceId), (ushort)index);
                         newVerts++;
@@ -136,7 +136,7 @@ namespace Elements.Geometry.Tessellation
                     }
                 }
                 tessOffset += newVerts;
-                Debug.WriteLine($"----------{tessOffset}");
+                Debug.WriteLineIf(LOG_TESSELATION, $"----------{tessOffset}");
             }
 
             buffers.AddIndices(indices);


### PR DESCRIPTION
BACKGROUND:
- When using elements library and in debug mode geometry generation can be very slow because we get a load of logging about vertex management.  
![image](https://user-images.githubusercontent.com/5872187/194651288-c6ce4805-64b2-4e73-8d2f-3155508553b3.png)

DESCRIPTION:
- Make the logging of vertex data an explicit flag that needs to be set, intended for use while debugging.

TESTING:
- When using elements in a test for example this should change the default behavior so that it doesn't show all of these logs.
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/897)
<!-- Reviewable:end -->
