### PR TITLE
Polyline Intersects bug and GetSubsegment behavior change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `RoutingVertex` - removed `Guides`.
 - `AdaptiveGraphRouting.BuildSpanningTree` functions are simplified. Also, they use only single `tailPoint` now.
 - `AdaptiveGraphRouting.BuildSpanningTree` no longer require to have at least one hint line. 
+- `Polyline.GetSubsegment` changes direction of output polyline when parameters reversed 
 
 
 ### Fixed
@@ -27,6 +28,7 @@
 - `Line.Intersects` for `BBox3` - better detection of line with one intersection that just touches box corner.
 - `Obstacle.FromWall` and `Obstacle.FromLine` produced wrong `Points` when diagonal.
 - `AdaptiveGridRouting.BuildSimpleNetwork` now correctly uses `RoutingVertex.IsolationRadius`.
+- `Polyline.Intersects(Polygon polygon, out List<Polyline> sharedSegments)` fix bug when odd number of intersections between polyline and polygon
 
 ## 1.2.0
 

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -1135,36 +1135,37 @@ namespace Elements.Geometry
                 return null;
             }
 
-            var firstParameter = 0d;
-            var lastParameter = 0d;
-            var vertices = new List<Vector3>();
-            var lastVertex = Vector3.Origin;
-
-            if (startParameter < endParameter)
+            if (startParameter > endParameter)
             {
-                firstParameter = startParameter;
-                lastParameter = endParameter;
-                vertices.Add(start);
-                lastVertex = end;
+                var vertices = Vertices
+                    .Where(x =>
+                    {
+                        var parameter = GetParameterAt(x);
+                        return parameter < startParameter && parameter > endParameter;
+                    })
+                    .Reverse()
+                    .ToList();
+                
+                vertices.Insert(0, start);
+                vertices.Add(end);
+                
+                return new Polyline(vertices);
             }
             else
             {
-                firstParameter = endParameter;
-                lastParameter = startParameter;
+                var vertices = Vertices
+                    .Where(x =>
+                    {
+                        var parameter = GetParameterAt(x);
+                        return parameter > startParameter && parameter < endParameter;
+                    })
+                    .ToList();
+
+                vertices.Insert(0, start);
                 vertices.Add(end);
-                lastVertex = start;
+
+                return new Polyline(vertices);
             }
-
-            var verticesToAdd = Vertices.Where(x =>
-            {
-                var parameter = GetParameterAt(x);
-                return parameter > firstParameter && parameter < lastParameter;
-            });
-
-            vertices.AddRange(verticesToAdd);
-            vertices.Add(lastVertex);
-
-            return new Polyline(vertices);
         }
     }
 

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -1135,9 +1135,11 @@ namespace Elements.Geometry
                 return null;
             }
 
+            List<Vector3> filteredVertices;
+            
             if (startParameter > endParameter)
             {
-                var vertices = Vertices
+                filteredVertices = Vertices
                     .Where(x =>
                     {
                         var parameter = GetParameterAt(x);
@@ -1145,27 +1147,22 @@ namespace Elements.Geometry
                     })
                     .Reverse()
                     .ToList();
-                
-                vertices.Insert(0, start);
-                vertices.Add(end);
-                
-                return new Polyline(vertices);
             }
             else
             {
-                var vertices = Vertices
+                filteredVertices = Vertices
                     .Where(x =>
                     {
                         var parameter = GetParameterAt(x);
                         return parameter > startParameter && parameter < endParameter;
                     })
                     .ToList();
-
-                vertices.Insert(0, start);
-                vertices.Add(end);
-
-                return new Polyline(vertices);
             }
+            
+            filteredVertices.Insert(0, start);
+            filteredVertices.Add(end);
+
+            return new Polyline(filteredVertices);
         }
     }
 

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -1067,7 +1067,6 @@ namespace Elements.Geometry
         public bool Intersects(Polygon polygon, out List<Polyline> sharedSegments)
         {
             sharedSegments = new List<Polyline>();
-            var polygonSegments = polygon.Segments();
 
             var intersections = polygon.Segments()
                 .SelectMany(x =>
@@ -1075,7 +1074,8 @@ namespace Elements.Geometry
                     Intersects(x, out var result, includeEnds: true);
                     return result;
                 })
-                .OrderBy(x => GetParameterAt(x))
+                .UniqueWithinTolerance()
+                .OrderBy(GetParameterAt)
                 .ToList();
 
             if (intersections.Count == 0)
@@ -1086,28 +1086,18 @@ namespace Elements.Geometry
                 }
                 return sharedSegments.Any();
             }
-
-            var filteredIntersections = new List<Vector3>();
-            foreach(var intersection in intersections)
-            {
-                if(filteredIntersections.Any(x => x.IsAlmostEqualTo(intersection)))
-                {
-                    continue;
-                }
-                filteredIntersections.Add(intersection);
-            }
-
+            
             if (polygon.Contains(Start))
             {
-                var intersection = filteredIntersections.First();
+                var intersection = intersections.First();
                 var startSegment = GetSubsegment(Start, intersection);
                 sharedSegments.Add(startSegment);
-                filteredIntersections.Remove(intersection);
+                intersections.Remove(intersection);
             }
 
-            for (int i = 1; i < filteredIntersections.Count; i += 2)
+            for (var i = 0; i < intersections.Count - 1; i ++)
             {
-                var subsegment = GetSubsegment(filteredIntersections[i - 1], filteredIntersections[i]);
+                var subsegment = GetSubsegment(intersections[i], intersections[i+1]);
                 if (polygon.Contains(subsegment.PointAt(0.5), out var containment) && containment == Containment.Inside)
                 {
                     sharedSegments.Add(subsegment);
@@ -1116,7 +1106,7 @@ namespace Elements.Geometry
 
             if (polygon.Contains(End))
             {
-                var intersection = filteredIntersections.Last();
+                var intersection = intersections.Last();
                 var endSegment = GetSubsegment(intersection, End);
                 sharedSegments.Add(endSegment);
             }

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -527,6 +527,23 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
+        public void PolygonIntersectsOfLShape()
+        {
+            var polygon = Polygon.L(10, 10, 3);
+            var polyline = new Polyline(new Vector3(6, -2),
+                new Vector3(6, 0),
+                new Vector3(2, 0),
+                new Vector3(2, 2),
+                new Vector3(0, 2),
+                new Vector3(0, 5),
+                new Vector3(-2, 5));
+
+            var result = polyline.Intersects(polygon, out var sharedSegments);
+            
+            Assert.True(result);
+        }
+
+        [Fact]
         public void GetSubsegment()
         {
             var polyline = new Polyline(

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -538,9 +538,12 @@ namespace Elements.Geometry.Tests
                 new Vector3(0, 5),
                 new Vector3(-2, 5));
 
+            var expectedSubsegment = new Polyline(new Vector3(2, 0), new Vector3(2, 2), new Vector3(0, 2));
+
             var result = polyline.Intersects(polygon, out var sharedSegments);
             
             Assert.True(result);
+            Assert.Collection(sharedSegments, sharedSegment => Assert.Equal(expectedSubsegment, sharedSegment));
         }
 
         [Fact]

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -552,28 +552,28 @@ namespace Elements.Geometry.Tests
                 new Vector3(5, 5),
                 new Vector3(5, -5));
 
-            var result = polyline.GetSubsegment(new Vector3(-5, -3), new Vector3(5, 3));
+            var start = new Vector3(-5, -3);
+            var end = new Vector3(5, 3);
+            
+            var result = polyline.GetSubsegment(start, end);
 
             var expectedResult = new Polyline(
-                new Vector3(-5, -3),
+                start,
                 new Vector3(-5, 5),
                 new Vector3(5, 5),
-                new Vector3(5, 3));
+                end);
 
             Assert.Equal(expectedResult, result);
 
-            var reversedResult = polyline.GetSubsegment(new Vector3(5, 3), new Vector3(-5, -3));
-            var reversedExpectedResult = new Polyline(
-                new Vector3(5, 3),
-                new Vector3(5, 5),
-                new Vector3(-5, 5),
-                new Vector3(-5, -3));
+            var reversedResult = polyline.GetSubsegment(end, start);
+            var reversedExpectedResult = expectedResult.Reversed();
+            
             Assert.Equal(reversedExpectedResult, reversedResult);
 
             var pointOutsidePolyline = Vector3.Origin;
             Assert.Equal(-1d, polyline.GetParameterAt(pointOutsidePolyline), 5);
-            Assert.Null(polyline.GetSubsegment(pointOutsidePolyline, new Vector3(-5, -3)));
-            Assert.Null(polyline.GetSubsegment(new Vector3(-5, -3), pointOutsidePolyline));
+            Assert.Null(polyline.GetSubsegment(pointOutsidePolyline, start));
+            Assert.Null(polyline.GetSubsegment(start, pointOutsidePolyline));
 
             var middlePoint = new Vector3(0, 5);
             var startSubsegment = polyline.GetSubsegment(polyline.Start, middlePoint);

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -554,7 +554,8 @@ namespace Elements.Geometry.Tests
 
             var result = polyline.GetSubsegment(new Vector3(-5, -3), new Vector3(5, 3));
 
-            var expectedResult = new Polyline(new Vector3(-5, -3),
+            var expectedResult = new Polyline(
+                new Vector3(-5, -3),
                 new Vector3(-5, 5),
                 new Vector3(5, 5),
                 new Vector3(5, 3));
@@ -562,7 +563,12 @@ namespace Elements.Geometry.Tests
             Assert.Equal(expectedResult, result);
 
             var reversedResult = polyline.GetSubsegment(new Vector3(5, 3), new Vector3(-5, -3));
-            Assert.Equal(expectedResult, reversedResult);
+            var reversedExpectedResult = new Polyline(
+                new Vector3(5, 3),
+                new Vector3(5, 5),
+                new Vector3(-5, 5),
+                new Vector3(-5, -3));
+            Assert.Equal(reversedExpectedResult, reversedResult);
 
             var pointOutsidePolyline = Vector3.Origin;
             Assert.Equal(-1d, polyline.GetParameterAt(pointOutsidePolyline), 5);


### PR DESCRIPTION
BACKGROUND:
I found bug in `Polyline.Intersects(Polygon polygon, out var sharedSegments)` when there was odd number of intersections between polyline and polygon. 

I found also useful to revert output polyline direction when method input parameters are reversed.

DESCRIPTION:
In `Polyline.Intersects` method I was processing intersections in pairs, but when there was odd number of them, it led to wrong output. I fixed it by processing each intersection with following one. I also used `UniqueWithinTolerance()` extension method for  filtering vectors close to each other within tolerance.

Previously `GetSubsegment` method kept direction of `Polyline`. Now it will always traverse from start `Vector3` to end `Vector3` and will return path of that traverse.

TESTING:
Run unit tests 
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/901)
<!-- Reviewable:end -->
