### PR TITLE
Validate the u parameter in PointAt methods with tolerance

### DIFF
--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -114,7 +114,7 @@ namespace Elements.Geometry
         /// <returns>A Vector3 representing the point along the arc.</returns>
         public override Vector3 PointAt(double u)
         {
-            if (u > 1.0 || u < 0.0)
+            if (u > 1.0 + Vector3.EPSILON || u < 0.0 - Vector3.EPSILON)
             {
                 throw new ArgumentOutOfRangeException($"The value provided for parameter u, {u}, must be between 0.0 and 1.0.");
             }

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -89,7 +89,7 @@ namespace Elements.Geometry
         /// <returns>A point on the curve at parameter u.</returns>
         public override Vector3 PointAt(double u)
         {
-            if (u > 1.0 || u < 0.0)
+            if (u > 1.0 + Vector3.EPSILON || u < 0.0 - Vector3.EPSILON)
             {
                 throw new Exception("The parameter t must be between 0.0 and 1.0.");
             }

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -2190,7 +2190,7 @@ namespace Elements.Geometry
         /// <returns>Returns a Vector3 indicating a point along the Polygon length from its start vertex.</returns>
         protected override Vector3 PointAtInternal(double u, out int segmentIndex)
         {
-            if (u < 0.0 || u > 1.0)
+            if (u < 0.0 - Vector3.EPSILON || u > 1.0 + Vector3.EPSILON)
             {
                 throw new Exception($"The value of u ({u}) must be between 0.0 and 1.0.");
             }

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -564,7 +564,7 @@ namespace Elements.Geometry
         /// <returns>Returns a Vector3 indicating a point along the Polygon length from its start vertex.</returns>
         protected virtual Vector3 PointAtInternal(double u, out int segmentIndex)
         {
-            if (u < 0.0 || u > 1.0)
+            if (u < 0.0 - Vector3.EPSILON || u > 1.0 + Vector3.EPSILON)
             {
                 throw new Exception($"The value of u ({u}) must be between 0.0 and 1.0.");
             }

--- a/Elements/test/ArcTests.cs
+++ b/Elements/test/ArcTests.cs
@@ -61,6 +61,7 @@ namespace Hypar.Tests
             Assert.Equal(new Vector3(-5, 0, 0), arc.PointAt(1.0));
             Assert.Equal(new Vector3(0, 5, 0), arc.PointAt(0.5));
             Assert.Equal(new Vector3(5, 0, 0), arc.PointAt(0.0));
+            Assert.Equal(new Vector3(5, 0, 0), arc.PointAt(-1e-15));
         }
 
         [Fact]

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -51,6 +51,7 @@ namespace Elements.Geometry.Tests
             var l = new Line(a, b);
             Assert.Equal(1.0, l.Length());
             Assert.Equal(new Vector3(0.5, 0), l.PointAt(0.5));
+            Assert.Equal(a, l.PointAt(-1e-10));
         }
 
         [Fact]

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -1121,6 +1121,9 @@ namespace Elements.Geometry.Tests
             // end of the polygon AND at the end of the polyline.
             Assert.True(polyCircle.PointAt(1.0).IsAlmostEqualTo(polyCircle.Start));
             Assert.True(polyline.PointAt(1.0).IsAlmostEqualTo(polyline.Vertices[polyline.Vertices.Count - 1]));
+            // Test value close to u=0.0 within tolerance
+            Assert.True(polyCircle.PointAt(-1e-15).IsAlmostEqualTo(polyCircle.End));
+            Assert.True(polyline.PointAt(-1e-15).IsAlmostEqualTo(polyline.Vertices[polyline.Vertices.Count - 1]));
 
             this.Model.AddElement(new ModelCurve(polyCircle));
 


### PR DESCRIPTION
BACKGROUND:
- `PointAt` methods throw an exception when `u` parameter is almost equals 0 or 1, but not exactly inside these bounds, such as -6e-15

DESCRIPTION:
- Validates the `u` parameter in `PointAt` methods to be between 0 and 1 with tolerance

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/903)
<!-- Reviewable:end -->
