### PR TITLE
Tolerance for several collinearity methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,21 +10,21 @@
 - `Elements.Spatial.AdaptiveGrid.EdgeInfo`
 - `IEnumerable<Vector3>.UniqueWithinTolerance(double tolerance = Vector3.EPSILON)`
 
-
 ### Changed
 
 - `Line.PointOnLine` - added `tolerance` parameter.
 - `AdaptiveGrid.AddVertices` with `ConnectCutAndExtend` how extends only up to `HintExtendDistance` distance.
--  Created `EdgeInfo` structure in `AdaptiveGraphRouting` instead of a value pair. Added `HasVerticalChange` parameter to it.
+- Created `EdgeInfo` structure in `AdaptiveGraphRouting` instead of a value pair. Added `HasVerticalChange` parameter to it.
 - Moved `BranchSide`, `RoutingVertex`, `RoutingConfiguration`, `RoutingHintLine`, `TreeOrder` from `AdaptiveGraphRouting` to their own files.
 - `RoutingVertex` - removed `Guides`.
 - `AdaptiveGraphRouting.BuildSpanningTree` functions are simplified. Also, they use only single `tailPoint` now.
-- `AdaptiveGraphRouting.BuildSpanningTree` no longer require to have at least one hint line. 
+- `AdaptiveGraphRouting.BuildSpanningTree` no longer require to have at least one hint line.
 - `AdaptiveGraphRouting.BuildSpanningTree` no longer require to have at least one hint line.
 - Don't log all vertex creation actions during Debug mode geometry generation.
-- `Polyline.GetSubsegment` changes direction of output polyline when parameters reversed 
-
-
+- `Polyline.GetSubsegment` changes direction of output polyline when parameters reversed
+- `Line.IsCollinear` - added `tolerance` parameter.
+- `Polygon.CollinearPointsRemoved` - added `tolerance` parameter.
+- `Line.TryGetOverlap` - added `tolerance` parameter.
 
 ### Fixed
 
@@ -33,7 +33,6 @@
 - `AdaptiveGridRouting.BuildSimpleNetwork` now correctly uses `RoutingVertex.IsolationRadius`.
 - Fix #898
 - `Polyline.Intersects(Polygon polygon, out List<Polyline> sharedSegments)` fix bug when odd number of intersections between polyline and polygon
-
 
 ## 1.2.0
 
@@ -54,14 +53,8 @@
 - `Elements.SVG.SvgSection.CreatePlanFromFromModels(IList<Model> models, double elevation, SvgContext frontContext, SvgContext backContext, string path, bool showGrid = true, double gridHeadExtension = 2.0, double gridHeadRadius = 0.5, PlanRotation planRotation = PlanRotation.Angle, double planRotationDegrees = 0.0)`
 - `Polygons.U`
 - `Network.FindAllClosedRegions(List<Vector3> allNodeLocations)`
-- `Network.TraverseSmallestPlaneAngle((int currentIndex, int previousIndex, IEnumerable<int> edgeIndices) traversalData,
-                                               List<Vector3> allNodeLocations,
-                                               List<LocalEdge> visitedEdges,
-                                               Network<T> network)`
-- `GeometricElement.Intersects(Plane plane,
-                               out Dictionary<Guid, List<Polygon>> intersectionPolygons,
-                               out Dictionary<Guid, List<Polygon>> beyondPolygons,
-                               out Dictionary<Guid, List<Line>> lines)`
+- `Network.TraverseSmallestPlaneAngle((int currentIndex, int previousIndex, IEnumerable<int> edgeIndices) traversalData, List<Vector3> allNodeLocations, List<LocalEdge> visitedEdges, Network<T> network)`
+- `GeometricElement.Intersects(Plane plane, out Dictionary<Guid, List<Polygon>> intersectionPolygons, out Dictionary<Guid, List<Polygon>> beyondPolygons, out Dictionary<Guid, List<Line>> lines)`
 
 ### Changed
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1035,30 +1035,43 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Check if this line is collinear with other line
+        /// Check if this line is collinear with another line.
         /// </summary>
-        /// <param name="line">Line to check</param>
+        /// <param name="line">Line to check.</param>
+        /// <param name="tolerance">If points are within this distance of a fit line, they will be considered collinear.</param>
         /// <returns></returns>
-        public bool IsCollinear(Line line)
+        public bool IsCollinear(Line line, double tolerance = Vector3.EPSILON)
         {
             var vectors = new Vector3[] { Start, End, line.Start, line.End };
-            return vectors.AreCollinearByDistance();
+            return vectors.AreCollinearByDistance(tolerance);
         }
 
         /// <summary>
-        /// Check if line overlap with other line
+        /// Check if this line overlaps with another line.
+        /// </summary>
+        /// <param name="line">Line to check.</param>
+        /// <param name="overlap">Overlapping line or null when lines do not overlap.</param>
+        /// <returns>Returns true when lines overlap and false when they do not.</returns>
+        public bool TryGetOverlap(Line line, out Line overlap)
+        {
+            return TryGetOverlap(line, Vector3.EPSILON, out overlap);
+        }
+
+        /// <summary>
+        /// Check if this line overlaps with another line.
         /// </summary>
         /// <param name="line">Line to check</param>
-        /// <param name="overlap">Overlapping line or null when lines do not overlap</param>
-        /// <returns>Returns true when lines overlap and false when they do not</returns>
-        public bool TryGetOverlap(Line line, out Line overlap)
+        /// <param name="tolerance">Tolerance for distance-based checks.</param>
+        /// <param name="overlap">Overlapping line or null when lines do not overlap.</param>
+        /// <returns>Returns true when lines overlap and false when they do not.</returns>
+        public bool TryGetOverlap(Line line, double tolerance, out Line overlap)
         {
             overlap = null;
 
             if (line == null)
                 return false;
 
-            if (!IsCollinear(line))
+            if (!IsCollinear(line, tolerance))
                 return false;
 
             //order vertices of lines
@@ -1067,21 +1080,21 @@ namespace Elements.Geometry
             var orderedVectors = vectors.OrderBy(v => (v - Start).Dot(direction)).ToList();
 
             //check if 2nd point lies on both lines
-            if (!PointOnLine(orderedVectors[1], Start, End, true) || !PointOnLine(orderedVectors[1], line.Start, line.End, true))
+            if (!PointOnLine(orderedVectors[1], Start, End, true, tolerance) || !PointOnLine(orderedVectors[1], line.Start, line.End, true, tolerance))
                 return false;
 
             //check if 3rd point lies on both lines
-            if (!PointOnLine(orderedVectors[2], Start, End, true) || !PointOnLine(orderedVectors[2], line.Start, line.End, true))
+            if (!PointOnLine(orderedVectors[2], Start, End, true, tolerance) || !PointOnLine(orderedVectors[2], line.Start, line.End, true, tolerance))
                 return false;
 
             //edge case when lines share only point
-            if (orderedVectors[1].IsAlmostEqualTo(orderedVectors[2]))
+            if (orderedVectors[1].IsAlmostEqualTo(orderedVectors[2], tolerance))
                 return false;
 
             var overlappingLine = new Line(orderedVectors[1], orderedVectors[2]);
 
             //keep the same direction as original line
-            overlap = direction.IsAlmostEqualTo(overlappingLine.Direction())
+            overlap = direction.IsAlmostEqualTo(overlappingLine.Direction(), tolerance)
                 ? overlappingLine
                 : overlappingLine.Reversed();
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1094,7 +1094,7 @@ namespace Elements.Geometry
             var overlappingLine = new Line(orderedVectors[1], orderedVectors[2]);
 
             //keep the same direction as original line
-            overlap = direction.IsAlmostEqualTo(overlappingLine.Direction(), tolerance)
+            overlap = direction.Dot(overlappingLine.Direction()) > 0
                 ? overlappingLine
                 : overlappingLine.Reversed();
 

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -2009,21 +2009,21 @@ namespace Elements.Geometry
         /// Remove collinear points from this Polygon.
         /// </summary>
         /// <returns>New Polygon without collinear points.</returns>
-        public Polygon CollinearPointsRemoved()
+        public Polygon CollinearPointsRemoved(double tolerance = Vector3.EPSILON)
         {
             int count = this.Vertices.Count;
             var unique = new List<Vector3>(count);
 
-            if (!Vector3.AreCollinearByDistance(Vertices[count - 1], Vertices[0], Vertices[1]))
+            if (!Vector3.AreCollinearByDistance(Vertices[count - 1], Vertices[0], Vertices[1], tolerance))
                 unique.Add(Vertices[0]);
 
             for (int i = 1; i < count - 1; i++)
             {
-                if (!Vector3.AreCollinearByDistance(Vertices[i - 1], Vertices[i], Vertices[i + 1]))
+                if (!Vector3.AreCollinearByDistance(Vertices[i - 1], Vertices[i], Vertices[i + 1], tolerance))
                     unique.Add(Vertices[i]);
             }
 
-            if (!Vector3.AreCollinearByDistance(Vertices[count - 2], Vertices[count - 1], Vertices[0]))
+            if (!Vector3.AreCollinearByDistance(Vertices[count - 2], Vertices[count - 1], Vertices[0], tolerance))
                 unique.Add(Vertices[count - 1]);
 
             return new Polygon(unique);

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -2024,8 +2024,13 @@ namespace Elements.Geometry
             }
 
             if (!Vector3.AreCollinearByDistance(Vertices[count - 2], Vertices[count - 1], Vertices[0], tolerance))
+            {
                 unique.Add(Vertices[count - 1]);
-
+            }
+            if (unique.Count < 3)
+            {
+                return this;
+            }
             return new Polygon(unique);
         }
 

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -607,9 +607,14 @@ namespace Elements.Geometry.Tests
 
             // TryGetOverlap within tolerance
             var line1 = new Line(new Vector3(0, 0, 0), new Vector3(10, 0, 0));
+            // consistently off
             var line2 = new Line(new Vector3(5, 0.01, 0), new Vector3(15, 0.01, 0));
             Assert.False(line1.TryGetOverlap(line2, out _));
             Assert.True(line1.TryGetOverlap(line2, 0.1, out _));
+            // at an angle
+            var line3 = new Line(new Vector3(5, 0, 0), new Vector3(15, 0.01, 0));
+            Assert.True(line1.TryGetOverlap(line3, 0.1, out var overlap));
+            Assert.Equal(new Line((5, 0, 0), (10, 0, 0)), overlap);
         }
 
 

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -555,6 +555,12 @@ namespace Elements.Geometry.Tests
             var longLine = new Line(new Vector3(458.8830, -118.7170, 13.8152), new Vector3(458.8830, -80.4465, 13.8152));
             var nearlySameLine = new Line(new Vector3(458.9005, 29.6573, 13.7977), new Vector3(458.9005, 33.5632, 13.7977));
             Assert.False(longLine.IsCollinear(nearlySameLine));
+
+            // collinear within tolerance
+            var line1 = new Line(new Vector3(0, 0, 0), new Vector3(10, 0, 0));
+            var line2 = new Line(new Vector3(5, 0.01, 0), new Vector3(15, 0.01, 0));
+            Assert.False(line1.IsCollinear(line2));
+            Assert.True(line1.IsCollinear(line2, 0.1));
         }
 
         [Fact]
@@ -598,6 +604,12 @@ namespace Elements.Geometry.Tests
             var firstLineWihNearZeroSum = new Line(new Vector3(-3, 3, 0), new Vector3(-1, 1.00000002, 0));
             var secondLineWihNearZeroSum = new Line(new Vector3(-2, 2.00000001, 0), new Vector3(0, 0, 0));
             Assert.True(firstLineWihNearZeroSum.TryGetOverlap(secondLineWihNearZeroSum, out _));
+
+            // TryGetOverlap within tolerance
+            var line1 = new Line(new Vector3(0, 0, 0), new Vector3(10, 0, 0));
+            var line2 = new Line(new Vector3(5, 0.01, 0), new Vector3(15, 0.01, 0));
+            Assert.False(line1.TryGetOverlap(line2, out _));
+            Assert.True(line1.TryGetOverlap(line2, 0.1, out _));
         }
 
 

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -1881,6 +1881,18 @@ namespace Elements.Geometry.Tests
             var polygon = new Polygon(points);
             polygon = polygon.CollinearPointsRemoved();
             Assert.Equal(4, polygon.Vertices.Count());
+
+            var points2 = new Vector3[] {
+                (0, 0, 0),
+                (10, 0.0001, 0),
+                (20, 0, 0),
+                (20, 20, 0),
+                (10, 20.0001, 0),
+                (0, 20, 0)
+            };
+            var polygon2 = new Polygon(points2);
+            Assert.NotEqual(4, polygon2.CollinearPointsRemoved().Vertices.Count());
+            Assert.Equal(4, polygon2.CollinearPointsRemoved(0.001).Vertices.Count());
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
- I needed several geometric operations to be "fuzzier."

DESCRIPTION:
- `Line.IsCollinear` - added `tolerance` parameter.
- `Polygon.CollinearPointsRemoved` - added `tolerance` parameter.
- `Line.TryGetOverlap` - added `tolerance` parameter.

TESTING:
- I have tested this in a function, and added/updated 3 tests to ensure this works as expected.
  
FUTURE WORK:
- We should consider making this a "rule" for elements: if a method relies on distance based checks, it should expose its tolerance parameters. (and documenting said rule, eg in the PR template)

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/906)
<!-- Reviewable:end -->
