### PR TITLE
Add layer duplication functions to AdaptiveGrid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - `AdaptiveGrid.AddVerticesWithCustomExtension(IList<Vector3> points, double extendDistance)`
 - `AdaptiveGrid.HintExtendDistance`
+- `AdaptiveGrid.SnapshotEdgesOnPlane(Plane plane, IEnumerable<Edge> edgesToCheck)`
+- `AdaptiveGrid.InsertSnapshot(List<(Vector3 Start, Vector3 End)> storedEdges, Transform transform, bool connect)`
 - `Obstacle.Orientation`
 - `Elements.Spatial.AdaptiveGrid.EdgeInfo`
 - `IEnumerable<Vector3>.UniqueWithinTolerance(double tolerance = Vector3.EPSILON)`

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -703,8 +703,10 @@ namespace Elements.Spatial.AdaptiveGrid
 
         /// <summary>
         /// Store points of edges both vertices of which are located at the given plane.
+        /// Use with InsertSnapshot to duplicate vertices to a new elevation,
+        /// while allowing modification of the original edges before duplication takes place.
         /// </summary>
-        /// <param name="plane">Plane to store edges at.</param>
+        /// <param name="plane">Plane to retrieve edges from.</param>
         /// <param name="edgesToCheck">Optional. Edges to check, all by default .</param>
         /// <returns>Position pair for each edge stored.</returns>
         public List<(Vector3 Start, Vector3 End)> SnapshotEdgesOnPlane(
@@ -731,14 +733,16 @@ namespace Elements.Spatial.AdaptiveGrid
 
         /// <summary>
         /// Duplicate stored edges with transformation applied.
+        /// Use with InsertSnapshot to move a list of existing or previously existed edges to the new location,
+        /// for example, copy edges from one elevation to another.
         /// </summary>
         /// <param name="storedEdges">Edge positions to duplicate.</param>
-        /// <param name="transform">Transformation to apply to </param>
+        /// <param name="transform">Transformation to apply to all of the new edges.</param>
         /// <param name="connect">Optional. Connect each new vertex with it's original vertex if it still exist.</param>
         public void InsertSnapshot(
             List<(Vector3 Start, Vector3 End)> storedEdges, Transform transform, bool connect = true)
         {
-            HashSet<ulong> connected = new HashSet<ulong>();
+            HashSet<ulong> alreadyConnected = new HashSet<ulong>();
 
             foreach (var (Start, End) in storedEdges)
             {
@@ -750,18 +754,18 @@ namespace Elements.Spatial.AdaptiveGrid
                 {
                     // The same vertex can be part of multiple edges.
                     // Cache to avoid expensive cut operations.
-                    if (!connected.Contains(newSV.Id) && 
+                    if (!alreadyConnected.Contains(newSV.Id) && 
                         TryGetVertexIndex(Start, out var id, Tolerance))
                     {
                         AddEdge(newSV.Id, id);
-                        connected.Add(newSV.Id);
+                        alreadyConnected.Add(newSV.Id);
                     }
 
-                    if (!connected.Contains(newEV.Id) &&
+                    if (!alreadyConnected.Contains(newEV.Id) &&
                         TryGetVertexIndex(End, out id, Tolerance))
                     {
                         AddEdge(newEV.Id, id);
-                        connected.Add(newEV.Id);
+                        alreadyConnected.Add(newEV.Id);
                     }
                 }
             }

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -161,6 +161,7 @@ namespace Elements.Tests
             Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(5, 4.9, 1), out _));
 
             Assert.Equal(numEdges, borderV.Edges.Count);
+            //There are 3 elevations: extrusion is done from 0 to 2 and split points are at  1.
             //On each elevation one vertex is removed and 8 added as box perimeter.
             //TODO: elevations are not connected!!!
             Assert.Equal(numVertices + (3 * 7), adaptiveGrid.GetVertices().Count);

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -131,6 +131,13 @@ namespace Elements.Tests
 
             v = Vector3.Origin;
             Assert.Equal(0.0, v.DistanceTo(p));
+
+            p = new Plane(new Vector3(2, 3, 5), Vector3.XAxis);
+            v = new Vector3(2, 1.0, 0.5);
+            Assert.Equal(0.0, v.DistanceTo(p));
+
+            v = new Vector3(2.5, 1.0, 0.5);
+            Assert.Equal(0.5, v.DistanceTo(p));
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
- AdaptiveGrid routing requires more 3D oriented tools for manipulation. One is to be able to duplicate edges from one plane and create another one.

DESCRIPTION:
- Added SnapshotEdgesOnPlane and InsertSnapshot to AdaptiveGrid.
- Using Plane and Transform allow having different configurations.
- Pair of Vector3 is used so snapshot is valid even if some edges are removed between storing and inserting a duplicate.

TESTING:
- Added AdaptiveGridStoreAndDuplicateElevation test.
  
FUTURE WORK:
- Add support of 3D hint lines.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Added AdaptiveGridSubtractBoxAddPerimeter that was not submitted last time by mistake.
- Added test case to DistanceToPlane test making sure it works with non zero origin.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/909)
<!-- Reviewable:end -->
