### PR TITLE
simplified polyline offset logic

### DIFF
--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1315,7 +1315,7 @@ namespace Elements.Geometry
             var heg = HalfEdgeGraph2d.Construct(lines, true);
             var polylines = heg.Polylinize();
             var offsets = polylines.SelectMany(l => l.OffsetWithAcuteAngle(distance / 2)).ToList();
-            
+
             return offsets;
         }
     }

--- a/Elements/src/Spatial/HalfEdgeGraph2d.cs
+++ b/Elements/src/Spatial/HalfEdgeGraph2d.cs
@@ -360,41 +360,69 @@ namespace Elements.Spatial
         /// <summary>
         /// Return edge list using picking the next segment forming the largest counter-clockwise angle with edge opposite
         /// </summary>
-        private List<(int from, int to, int? tag)> GetEdgeList(List<List<(int from, int to, int? tag)>> edgesPerVertex, List<Vector3> vertices, Vector3 normal = default, bool mergePolygons = false)
+        private List<(int from, int to, int? tag)> GetEdgeList(List<List<(int from, int to, int? tag)>> edgesPerVertex, List<Vector3> vertices, Vector3 normal = default, bool polyline = false)
         {
             var currentEdgeList = new List<(int from, int to, int? tag)>();
             // pick a starting point
             var startingSet = edgesPerVertex.First(l => l.Count > 0);
             var currentSegment = startingSet[0];
-            startingSet.RemoveAt(0);
-            var initialFrom = currentSegment.from;
 
             // loop until we reach the point at which we started for this polygon loop.
             // Since we have a finite set of edges, and we consume / remove every edge we traverse,
             // we must eventually either find an edge that points back to our start, or hit
             // a dead end where no more edges are available (in which case we throw an exception) 
-            while (currentSegment.to != initialFrom)
+            while (true)
             {
                 currentEdgeList.Add(currentSegment);
+
+                if (!polyline && currentSegment.to == startingSet[0].from)
+                {
+                    break;
+                }
                 var toVertex = vertices[currentSegment.to];
                 var fromVertex = vertices[currentSegment.from];
 
                 var vectorToTest = fromVertex - toVertex;
                 // get all segments pointing outwards from our "to" vertex
                 var possibleNextSegments = edgesPerVertex[currentSegment.to];
+                if (!polyline)
+                {
+                    // for polyline tracing, we want to look ahead to the next
+                    // segment, and only terminate if the next segment is the
+                    // first segment, so we don't exclude it.
+                    possibleNextSegments = possibleNextSegments.Except(currentEdgeList).ToList();
+                }
                 if (possibleNextSegments.Count == 0)
                 {
-                    // this should never happen.
-                    throw new Exception("Something went wrong building polygons from split results. Unable to proceed.");
+                    // we may have come to a dead end or the end of a loop.
+                    break;
                 }
                 // at every node, we pick the next segment forming the largest counter-clockwise angle with our opposite.
                 var n = normal == default ? Vector3.ZAxis : normal;
-                var nextSegment = possibleNextSegments.OrderBy(cand => vectorToTest.PlaneAngleTo(vertices[cand.to] - vertices[cand.from], n)).Last();
-
-                possibleNextSegments.Remove(nextSegment);
+                var nextSegment = possibleNextSegments.OrderBy(cand =>
+                {
+                    var ccwAngle = vectorToTest.PlaneAngleTo(vertices[cand.to] - vertices[cand.from], n);
+                    if (!polyline)
+                    {
+                        return ccwAngle;
+                    }
+                    if (ccwAngle < Vector3.EPSILON)
+                    {
+                        ccwAngle = 360;
+                    }
+                    return 360 - ccwAngle;
+                }).Last();
                 currentSegment = nextSegment;
+                if (currentSegment == startingSet[0])
+                {
+                    break;
+                }
             }
-            currentEdgeList.Add(currentSegment);
+
+            foreach (var segment in currentEdgeList)
+            {
+                edgesPerVertex[segment.from].Remove(segment);
+            }
 
             return currentEdgeList;
         }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -886,5 +886,21 @@ namespace Elements.Geometry.Tests
 
             Assert.Equal(3, offset.Count());
         }
+
+        [Fact]
+        public void LinesOffset_ClosedShape()
+        {
+            var lines = new List<Line> {
+                new Line((-0.015494, -18.985642, 0), (-1.76639, 24.869265, 0)),
+                new Line((-1.76639, 24.869265, 0), (9.866722, -13.880061, 0)),
+                new Line((24.806017, 6.880776, 0), (86.757219, -32.955245, 0)),
+                new Line((86.757219, -32.955245, 0), (51.313489, 62.054296, 0)),
+                new Line((51.313489, 62.054296, 0), (24.806017, 6.880776, 0))
+            };
+
+            var offset = lines.Offset(3);
+
+            Assert.Equal(3, offset.Count());
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- There were still some cases where `Lines.Offset` didn't find the correct polygon, and the `GetEdgeList` code was overcomplicated.

DESCRIPTION:
- Simplifies `GetEdgeList` to behave more similarly between Polygon and Polyline. 

TESTING:
- I added several new tests and also tested in a function:
![image](https://user-images.githubusercontent.com/31935763/197888303-73ee5cb5-4b1d-436a-a20b-227daac146c2.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/910)
<!-- Reviewable:end -->
