### PR TITLE
Add 3D hint line support to AdaptiveGraphRouting, AdaptiveGrid and RoutingHintLine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `AdaptiveGrid.HintExtendDistance`
 - `AdaptiveGrid.SnapshotEdgesOnPlane(Plane plane, IEnumerable<Edge> edgesToCheck)`
 - `AdaptiveGrid.InsertSnapshot(List<(Vector3 Start, Vector3 End)> storedEdges, Transform transform, bool connect)`
+- `RoutingHintLine.Is2D`
 - `Obstacle.Orientation`
 - `Elements.Spatial.AdaptiveGrid.EdgeInfo`
 - `IEnumerable<Vector3>.UniqueWithinTolerance(double tolerance = Vector3.EPSILON)`
@@ -16,7 +17,7 @@
 ### Changed
 
 - `Line.PointOnLine` - added `tolerance` parameter.
-- `AdaptiveGrid.AddVertices` with `ConnectCutAndExtend` how extends only up to `HintExtendDistance` distance.
+- `AdaptiveGrid.AddVertices` with `ConnectCutAndExtend` now extends only up to `HintExtendDistance` distance and inserts not exttended points as is otherwise ever if they are not touching the grid.
 - Created `EdgeInfo` structure in `AdaptiveGraphRouting` instead of a value pair. Added `HasVerticalChange` parameter to it.
 - Moved `BranchSide`, `RoutingVertex`, `RoutingConfiguration`, `RoutingHintLine`, `TreeOrder` from `AdaptiveGraphRouting` to their own files.
 - `RoutingVertex` - removed `Guides`.

--- a/Elements/src/Spatial/AdaptiveGrid/RoutingHintLine.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/RoutingHintLine.cs
@@ -17,13 +17,15 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <param name="factor">Cost multiplier.</param>
         /// <param name="influence">How far it affects.</param>
         /// <param name="userDefined">Is user defined.</param>
+        /// <param name="is2D">Should polyline be virtually extended by Z coordinate.</param>
         public RoutingHintLine(
-            Polyline polyline, double factor, double influence, bool userDefined)
+            Polyline polyline, double factor, double influence, bool userDefined, bool is2D)
         {
             Polyline = polyline;
             Factor = factor;
             InfluenceDistance = influence;
             UserDefined = userDefined;
+            Is2D = is2D;
         }
 
         /// <summary>
@@ -47,5 +49,10 @@ namespace Elements.Spatial.AdaptiveGrid
         /// User defined lines are preferred for input Vertex connection.
         /// </summary>
         public readonly bool UserDefined;
+
+        /// <summary>
+        /// Should polyline be virtually extended by Z coordinate.
+        /// </summary>
+        public readonly bool Is2D;
     }
 }

--- a/Elements/src/Spatial/AdaptiveGrid/RoutingHintLine.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/RoutingHintLine.cs
@@ -1,7 +1,7 @@
 ﻿using Elements.Geometry;
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 
 namespace Elements.Spatial.AdaptiveGrid
 {
@@ -21,11 +21,18 @@ namespace Elements.Spatial.AdaptiveGrid
         public RoutingHintLine(
             Polyline polyline, double factor, double influence, bool userDefined, bool is2D)
         {
-            Polyline = polyline;
             Factor = factor;
             InfluenceDistance = influence;
             UserDefined = userDefined;
             Is2D = is2D;
+            if (Is2D)
+            {
+                Polyline = new Polyline(polyline.Vertices.Select(v => new Vector3(v.X, v.Y)).ToList());
+            }
+            else
+            {
+                Polyline = polyline;
+            }
         }
 
         /// <summary>

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -677,6 +677,54 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void Add3DVerticesWithCustomExtension()
+        {
+            var grid = new AdaptiveGrid();
+            grid.AddFromPolygon(Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10)),
+                                new List<Vector3> { new Vector3(2, 2), new Vector3(5, 5), new Vector3(8, 8) });
+
+            var toInsert = new Vector3[] {
+                new Vector3(2, 5, 0),
+                new Vector3(3, 5, 0),
+                new Vector3(4, 5, 1),
+                new Vector3(5, 5, 1),
+                new Vector3(6, 5, 0),
+                new Vector3(7, 5, 0)
+            };
+
+            var verticesBefore = grid.GetVertices().Count;
+            grid.AddVerticesWithCustomExtension(toInsert, 2);
+            //Start point already exist and the last one is snapped.
+            Assert.Equal(verticesBefore + 4, grid.GetVertices().Count);
+
+            Assert.True(grid.TryGetVertexIndex(new Vector3(3, 5, 0), out var id, grid.Tolerance));
+            var vertex = grid.GetVertex(id);
+            Assert.Equal(3, vertex.Edges.Count);
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(4, 5, 1)));
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(2, 5, 0)));
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(5, 5, 0)));
+
+            Assert.True(grid.TryGetVertexIndex(new Vector3(4, 5, 1), out id, grid.Tolerance));
+            vertex = grid.GetVertex(id);
+            Assert.Equal(2, vertex.Edges.Count);
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(3, 5, 0)));
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(5, 5, 1)));
+
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 5, 1), out id, grid.Tolerance));
+            vertex = grid.GetVertex(id);
+            Assert.Equal(2, vertex.Edges.Count);
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(4, 5, 1)));
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(6, 5, 0)));
+
+            Assert.True(grid.TryGetVertexIndex(new Vector3(6, 5, 0), out id, grid.Tolerance));
+            vertex = grid.GetVertex(id);
+            Assert.Equal(3, vertex.Edges.Count);
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(5, 5, 1)));
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(5, 5, 0)));
+            Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(8, 5, 0)));
+        }
+
+        [Fact]
         public void AdaptiveGridVertexGetEdgeOtherVertexId()
         {
             var grid = SampleGrid();


### PR DESCRIPTION
BACKGROUND:
- AdaptiveGraphRouting needed support of 3D hint lines for 3D routing.

DESCRIPTION:
Added Is2D property to RoutingHintLine. Based on this property edge factors are calculated in a different way in AdaptiveGraphRouting.
AddVerticesWithCustomExtension always insert vertices to the grid:
- Before, segments where just inserted only if it was "inside" the grid - extended segment must have hit at lest one edge on both sides.
- This is inconsistent with other cases of AddVertices and too confusing.
- Now points are always added to the grid and connected.
- The responsibilities for polyline correctness is shifted to the end user.

TESTING:
Added Add3DVerticesWithCustomExtension and AdaptiveGraphRouting3DHintLineCheck tests.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/911)
<!-- Reviewable:end -->
