### PR TITLE
Add ForceAngleCompliance method to Polyline

### DIFF
--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -751,7 +751,7 @@ namespace Elements.Geometry
 
             return polygons.ToArray();
         }
-        
+
         /// <summary>
         /// Return offset points for polyline
         /// </summary>
@@ -1129,7 +1129,7 @@ namespace Elements.Geometry
                 }
                 return sharedSegments.Any();
             }
-            
+
             if (polygon.Contains(Start))
             {
                 var intersection = intersections.First();
@@ -1138,9 +1138,9 @@ namespace Elements.Geometry
                 intersections.Remove(intersection);
             }
 
-            for (var i = 0; i < intersections.Count - 1; i ++)
+            for (var i = 0; i < intersections.Count - 1; i++)
             {
-                var subsegment = GetSubsegment(intersections[i], intersections[i+1]);
+                var subsegment = GetSubsegment(intersections[i], intersections[i + 1]);
                 if (polygon.Contains(subsegment.PointAt(0.5), out var containment) && containment == Containment.Inside)
                 {
                     sharedSegments.Add(subsegment);
@@ -1179,7 +1179,7 @@ namespace Elements.Geometry
             }
 
             List<Vector3> filteredVertices;
-            
+
             if (startParameter > endParameter)
             {
                 filteredVertices = Vertices
@@ -1201,11 +1201,199 @@ namespace Elements.Geometry
                     })
                     .ToList();
             }
-            
+
             filteredVertices.Insert(0, start);
             filteredVertices.Add(end);
 
             return new Polyline(filteredVertices);
+        }
+
+        /// <summary>
+        /// Make the polyline correspond to the supported angles by moving the vertices slightly.
+        /// The result polyline will have only allowed angles, but vertices positions can be changed.
+        /// </summary>
+        /// <param name="supportedAngles">List of supported angles that the returned polyline can have. Supported angles must be between 0 and 90.</param>
+        /// <param name="referenceVector">Vector to aling first segment of polyline with.</param>
+        /// <param name="pathType">
+        /// The path type.
+        /// For each 3 consecutive points A, B, C to make angle ABC be one of allowed angles:
+        /// - NormalizationType.Start: move B vertex
+        /// - NormalizationType.Middle: move both B and C vertices in approximately equivalent proportions
+        /// - NormalizationType.End : move C vertex
+        /// </param>
+        /// <param name="furthestDistancePointsMoved">The furthest distance that any point moved.</param>
+        /// <returns>The result polyline that has only allowed angles.</returns>
+        public Polyline ForceAngleCompliance(IEnumerable<double> supportedAngles,
+            Vector3 referenceVector, out double furthestDistancePointsMoved, NormalizationType pathType = NormalizationType.Start)
+        {
+            if (supportedAngles.Any(a => a > 90 || a < 0))
+            {
+                throw new ArgumentException("Supported angles must be between 0 and 90");
+            }
+
+            List<Vector3> normalized = Vertices.ToList();
+
+            for (int i = 0; i < normalized.Count - 1; i++)
+            {
+                NormalizationType localType = pathType;
+                if (i == 0)
+                {
+                    localType = NormalizationType.End;
+                }
+                else if (i == normalized.Count - 2)
+                {
+                    localType = NormalizationType.Start;
+                }
+
+                Vector3 incomingDirection = referenceVector;
+                if (i > 0)
+                {
+                    incomingDirection = (normalized[i] - normalized[i - 1]).Unitized();
+                    if (i > 1)
+                    {
+                        var before = (normalized[i - 1] - normalized[i - 2]).Unitized();
+                        referenceVector = before.Cross(incomingDirection);
+                    }
+                }
+
+                var direction = (normalized[i + 1] - normalized[i]).Unitized();
+                if (direction.Dot(incomingDirection).Equals(0) ||
+                    direction.ProjectOnto(incomingDirection).Length().ApproximatelyEquals(0))
+                {
+                    // When path drastically changes direction - (1, 2, 2) -> (1, 0, 2) -> (0, 0, 0) for example,
+                    // angle will the 90 degrees regardless if third point is (0, 0, 0), (0, 0, 1) or (0, 0, 1.5).
+                    // These points still need to be align to avoid bad angles further in the path.
+                    // Reference vector is used in this case as cross product of 3 previous points.
+                    if (i < normalized.Count - 2)
+                    {
+                        incomingDirection = referenceVector.Dot(direction) < 0 ? referenceVector.Negate() : referenceVector;
+                        localType = NormalizationType.End;
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+
+                double incomingAngle = direction.AngleTo(incomingDirection);
+                if (incomingAngle.ApproximatelyEquals(180, 0.1) || incomingAngle.ApproximatelyEquals(0, 0.1) ||
+                    supportedAngles.Any(a => incomingAngle.ApproximatelyEquals(a, 0.1) ||
+                                            (incomingAngle - 90).ApproximatelyEquals(a, 0.1)))
+                {
+                    continue;
+                }
+
+                double angleDelta = 180;
+                double bestFitAngle = -1;
+                foreach (var angle in supportedAngles)
+                {
+                    var delta = Math.Abs(angle - incomingAngle);
+                    if (delta < angleDelta)
+                    {
+                        bestFitAngle = angle;
+                        angleDelta = delta;
+                    }
+                }
+
+                double directionalDistance = AngleAlignedDistance(
+                    normalized[i], normalized[i + 1], incomingDirection, bestFitAngle, out var cornerPoint);
+                var directionalVector = normalized[i] - cornerPoint;
+
+                switch (localType)
+                {
+                    case NormalizationType.Start:
+                        {
+                            normalized[i] = cornerPoint + directionalVector.Unitized() * directionalDistance;
+                        }
+                        break;
+                    case NormalizationType.Middle:
+                        {
+                            var delta = (directionalDistance - directionalVector.Length()) / 2;
+                            normalized[i] = cornerPoint + directionalVector.Unitized() * (directionalDistance - delta);
+
+                            var point = DisplacementAlignedPoint(
+                                normalized[i], normalized[i + 1], normalized[i + 2], directionalVector.Unitized(), delta);
+                            if (point.HasValue)
+                            {
+                                normalized[i + 1] = point.Value;
+                            }
+                        }
+                        break;
+                    default:
+                    case NormalizationType.End:
+                        {
+                            var delta = directionalDistance - directionalVector.Length();
+                            var point = DisplacementAlignedPoint(
+                                normalized[i], normalized[i + 1], normalized[i + 2], directionalVector.Unitized(), delta);
+                            if (point.HasValue)
+                            {
+                                normalized[i + 1] = point.Value;
+                            }
+                        }
+                        break;
+                }
+            }
+
+            furthestDistancePointsMoved = normalized.Zip(Vertices, (a, b) => a.DistanceTo(b)).Max();
+            return new Polyline(normalized);
+        }
+
+        /// <summary>
+        /// Make the polyline correspond to the supported angles by moving the vertices slightly.
+        /// The result polyline will have only allowed angles, but vertices positions can be changed.
+        /// </summary>
+        /// <param name="supportedAngles">List of supported angles that the returned polyline can have. Supported angles must be between 0 and 90.</param>
+        /// <param name="referenceVector">Vector to aling first segment of polyline with.</param>
+        /// <param name="pathType">
+        /// The path type.
+        /// For each 3 consecutive points A, B, C to make angle ABC be one of allowed angles:
+        /// - NormalizationType.Start: move B vertex
+        /// - NormalizationType.Middle: move both B and C vertices in approximately equivalent proportions
+        /// - NormalizationType.End : move C vertex
+        /// </param>
+        /// <returns>The result polyline that has only allowed angles.</returns>
+        public Polyline ForceAngleCompliance(IEnumerable<double> supportedAngles,
+            Vector3 referenceVector, NormalizationType pathType = NormalizationType.Start)
+        {
+            return ForceAngleCompliance(supportedAngles, referenceVector, out _, pathType);
+        }
+
+        /// <summary>
+        /// Calculate distance from corner point, so point X = cornerPoint + incoming * D has needed angle (cornerPoint -> X -> end)
+        /// </summary>
+        private double AngleAlignedDistance(Vector3 start, Vector3 end, Vector3 incoming, double angle, out Vector3 cornerPoint)
+        {
+            var dot = (end - start).Dot(incoming);
+            cornerPoint = start + incoming * dot;
+            double directionalDistance = 0;
+
+            if (!angle.ApproximatelyEquals(90, 0.1))
+            {
+                var perdendicularDistance = (end - cornerPoint).Length();
+                directionalDistance = perdendicularDistance / Math.Tan(Units.DegreesToRadians(angle));
+            }
+
+            return directionalDistance;
+        }
+
+        /// <summary>
+        /// Calculate a point X on infinite B->C line, that intersects with A->(B+d) line, where d is displacement.
+        /// </summary>
+        private Vector3? DisplacementAlignedPoint(Vector3 a, Vector3 b, Vector3 c,
+            Vector3 displacementDirection, double displacementDistace)
+        {
+            var roughtEndPoint = b - displacementDirection * displacementDistace;
+            Plane plane = new Plane(a, roughtEndPoint, c);
+            var bcProjected = new Line(b, c).Projected(plane);
+            Line displacementLine = new Line(a, roughtEndPoint);
+            if (displacementLine.Intersects(bcProjected, out var position, infinite: true))
+            {
+                return position;
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 
@@ -1256,5 +1444,24 @@ namespace Elements.Geometry
         /// If open, ends are joined and treated as a closed polygon
         /// </summary>
         ClosedPolygon,
+    }
+
+    /// <summary>
+    /// Normalization type.
+    /// </summary>
+    public enum NormalizationType
+    {
+        /// <summary>
+        /// During normalization move start points of segments.
+        /// </summary>
+        Start,
+        /// <summary>
+        /// During normalization move end points of segments.
+        /// </summary>
+        End,
+        /// <summary>
+        /// During normalization move both start and end vertices in approximately equivalent proportions.
+        /// </summary>
+        Middle
     }
 }

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -1211,9 +1211,10 @@ namespace Elements.Geometry
         /// <summary>
         /// Make the polyline correspond to the supported angles by moving the vertices slightly.
         /// The result polyline will have only allowed angles, but vertices positions can be changed.
+        /// The first vertex is never moved.
         /// </summary>
         /// <param name="supportedAngles">List of supported angles that the returned polyline can have. Supported angles must be between 0 and 90.</param>
-        /// <param name="referenceVector">Vector to aling first segment of polyline with.</param>
+        /// <param name="referenceVector">Vector to align first segment of polyline with.</param>
         /// <param name="pathType">
         /// The path type.
         /// For each 3 consecutive points A, B, C to make angle ABC be one of allowed angles:
@@ -1261,8 +1262,8 @@ namespace Elements.Geometry
                     direction.ProjectOnto(incomingDirection).Length().ApproximatelyEquals(0))
                 {
                     // When path drastically changes direction - (1, 2, 2) -> (1, 0, 2) -> (0, 0, 0) for example,
-                    // angle will the 90 degrees regardless if third point is (0, 0, 0), (0, 0, 1) or (0, 0, 1.5).
-                    // These points still need to be align to avoid bad angles further in the path.
+                    // angle will be 90 degrees regardless if third point is (0, 0, 0), (0, 0, 1) or (0, 0, 1.5).
+                    // These points still need to be aligned to avoid bad angles further in the path.
                     // Reference vector is used in this case as cross product of 3 previous points.
                     if (i < normalized.Count - 2)
                     {
@@ -1343,7 +1344,7 @@ namespace Elements.Geometry
         /// The result polyline will have only allowed angles, but vertices positions can be changed.
         /// </summary>
         /// <param name="supportedAngles">List of supported angles that the returned polyline can have. Supported angles must be between 0 and 90.</param>
-        /// <param name="referenceVector">Vector to aling first segment of polyline with.</param>
+        /// <param name="referenceVector">Vector to align first segment of polyline with.</param>
         /// <param name="pathType">
         /// The path type.
         /// For each 3 consecutive points A, B, C to make angle ABC be one of allowed angles:
@@ -1380,12 +1381,12 @@ namespace Elements.Geometry
         /// Calculate a point X on infinite B->C line, that intersects with A->(B+d) line, where d is displacement.
         /// </summary>
         private Vector3? DisplacementAlignedPoint(Vector3 a, Vector3 b, Vector3 c,
-            Vector3 displacementDirection, double displacementDistace)
+            Vector3 displacementDirection, double displacementDistance)
         {
-            var roughtEndPoint = b - displacementDirection * displacementDistace;
-            Plane plane = new Plane(a, roughtEndPoint, c);
+            var roughEndPoint = b - displacementDirection * displacementDistance;
+            Plane plane = new Plane(a, roughEndPoint, c);
             var bcProjected = new Line(b, c).Projected(plane);
-            Line displacementLine = new Line(a, roughtEndPoint);
+            Line displacementLine = new Line(a, roughEndPoint);
             if (displacementLine.Intersects(bcProjected, out var position, infinite: true))
             {
                 return position;

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -339,66 +339,66 @@ namespace Elements.Geometry.Tests
         public static IEnumerable<object[]> GetPolygonIntersectsTestData()
         {
             //Polyline is inside boundary
-            yield return new object[] 
-            { 
+            yield return new object[]
+            {
                 new Polyline(new Vector3(2, 0), new Vector3(-2, 0), new Vector3(-2, 1)),
-                new Polyline(new Vector3(2, 0), new Vector3(-2, 0), new Vector3(-2, 1)) 
+                new Polyline(new Vector3(2, 0), new Vector3(-2, 0), new Vector3(-2, 1))
             };
 
             //Polyline both ends outside boundary
-            yield return new object[] 
-            { 
+            yield return new object[]
+            {
                 new Polyline(new Vector3(-1, 5), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -5)),
-                new Polyline(new Vector3(-1, 2), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -2)) 
+                new Polyline(new Vector3(-1, 2), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -2))
             };
 
             //Polyline end is on polygon boundary
-            yield return new object[] 
-            { 
+            yield return new object[]
+            {
                 new Polyline(new Vector3(-1, 5), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -2)),
-                new Polyline(new Vector3(-1, 2), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -2)) 
+                new Polyline(new Vector3(-1, 2), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, -2))
             };
 
             //Polyline start is on polygon boundary
-            yield return new object[] 
-            { 
+            yield return new object[]
+            {
                 new Polyline(new Vector3(-1, -5), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, 2)),
-                new Polyline(new Vector3(-1, -2), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, 2)) 
+                new Polyline(new Vector3(-1, -2), new Vector3(-1, 0), Vector3.Origin, new Vector3(0, 2))
             };
 
             //Polyline end is inside boundary
-            yield return new object[] 
-            { 
+            yield return new object[]
+            {
                 new Polyline(new Vector3(1, 5), new Vector3(1,0), Vector3.Origin),
-                new Polyline(new Vector3(1, 2), new Vector3(1, 0), Vector3.Origin) 
+                new Polyline(new Vector3(1, 2), new Vector3(1, 0), Vector3.Origin)
             };
 
             //Polyline start is inside boundary
-            yield return new object[] 
-            { 
+            yield return new object[]
+            {
                 new Polyline(new Vector3(-1, -5), new Vector3(-1, 0), Vector3.Origin),
-                new Polyline(new Vector3(-1, -2), new Vector3(-1, 0), Vector3.Origin) 
+                new Polyline(new Vector3(-1, -2), new Vector3(-1, 0), Vector3.Origin)
             };
 
             //Polyline end is boundary vertex
-            yield return new object[] 
-            { 
+            yield return new object[]
+            {
                 new Polyline(new Vector3(-1, -5), new Vector3(-1, 0), new Vector3(3, 2)),
-                new Polyline(new Vector3(-1, -2), new Vector3(-1, 0), new Vector3(3, 2)) 
+                new Polyline(new Vector3(-1, -2), new Vector3(-1, 0), new Vector3(3, 2))
             };
 
             //Polyline start is boundary vertex
-            yield return new object[] 
-            { 
+            yield return new object[]
+            {
                 new Polyline(new Vector3(-3, -2), new Vector3(-1, 0), new Vector3(-1, 5)),
-                new Polyline(new Vector3(-3, -2), new Vector3(-1, 0), new Vector3(-1, 2)) 
+                new Polyline(new Vector3(-3, -2), new Vector3(-1, 0), new Vector3(-1, 2))
             };
 
             //Polyline segment is part of boundary
-            yield return new object[] 
-            { 
+            yield return new object[]
+            {
                 new Polyline(new Vector3(-1, 5), new Vector3(-1, 0), new Vector3(3, 0), new Vector3(3, 1)),
-                new Polyline(new Vector3(-1, 2), new Vector3(-1, 0), new Vector3(3, 0)) 
+                new Polyline(new Vector3(-1, 2), new Vector3(-1, 0), new Vector3(3, 0))
             };
         }
 
@@ -541,7 +541,7 @@ namespace Elements.Geometry.Tests
             var expectedSubsegment = new Polyline(new Vector3(2, 0), new Vector3(2, 2), new Vector3(0, 2));
 
             var result = polyline.Intersects(polygon, out var sharedSegments);
-            
+
             Assert.True(result);
             Assert.Collection(sharedSegments, sharedSegment => Assert.Equal(expectedSubsegment, sharedSegment));
         }
@@ -557,7 +557,7 @@ namespace Elements.Geometry.Tests
 
             var start = new Vector3(-5, -3);
             var end = new Vector3(5, 3);
-            
+
             var result = polyline.GetSubsegment(start, end);
 
             var expectedResult = new Polyline(
@@ -570,7 +570,7 @@ namespace Elements.Geometry.Tests
 
             var reversedResult = polyline.GetSubsegment(end, start);
             var reversedExpectedResult = expectedResult.Reversed();
-            
+
             Assert.Equal(reversedExpectedResult, reversedResult);
 
             var pointOutsidePolyline = Vector3.Origin;
@@ -631,6 +631,122 @@ namespace Elements.Geometry.Tests
             Model.AddElement(curve);
             Model.AddElement(movedCrv);
             Model.AddElement(bezier);
+        }
+
+        [Fact]
+        public void PolylineForceAngleCompliance()
+        {
+            var path = new List<Vector3>
+            {
+                new Vector3(0, 10, 2),
+                new Vector3(0, 8, 2),
+                new Vector3(4, 5, 2),
+                new Vector3(4, 3, 2),
+                new Vector3(1, 2, 2),
+                new Vector3(1, 0, 2),
+                new Vector3(0, 0, 1.1),
+                new Vector3(0, 0, 0)
+            };
+            var polyline = new Polyline(path);
+            var angles = new List<double> { 90, 45 };
+            var normalizedPathStart = polyline.ForceAngleCompliance(angles, Vector3.ZAxis, out var distanceStart, NormalizationType.Start);
+            var normalizedPathMiddle = polyline.ForceAngleCompliance(angles, Vector3.ZAxis, out var distanceMiddle, NormalizationType.Middle);
+            var normalizedPathEnd = polyline.ForceAngleCompliance(angles, Vector3.ZAxis, out var distanceEnd, NormalizationType.End);
+
+            Assert.True(CheckPolylineAngles(angles, normalizedPathStart));
+            Assert.True(CheckPolylineAngles(angles, normalizedPathMiddle));
+            Assert.True(CheckPolylineAngles(angles, normalizedPathEnd));
+
+            // Get 45 degree between first, second and third segments.
+            var pathStartSegments = normalizedPathStart.Segments();
+            Assert.True(pathStartSegments[1].Direction().AngleTo(pathStartSegments[0].Direction()).ApproximatelyEquals(45));
+            Assert.True(pathStartSegments[2].Direction().AngleTo(pathStartSegments[1].Direction()).ApproximatelyEquals(45));
+            Assert.Equal(new Vector3(0, 9, 2), pathStartSegments[1].Start);
+            Assert.Equal(new Vector3(4, 5, 2), pathStartSegments[1].End);
+
+            var pathMiddleSegments = normalizedPathMiddle.Segments();
+            Assert.True(pathMiddleSegments[1].Direction().AngleTo(pathMiddleSegments[0].Direction()).ApproximatelyEquals(45));
+            Assert.True(pathMiddleSegments[2].Direction().AngleTo(pathMiddleSegments[1].Direction()).ApproximatelyEquals(45));
+            Assert.Equal(new Vector3(0, 8.5, 2), pathMiddleSegments[1].Start);
+            Assert.Equal(new Vector3(4, 4.5, 2), pathMiddleSegments[1].End);
+
+            var pathEndSegments = normalizedPathEnd.Segments();
+            Assert.True(pathEndSegments[1].Direction().AngleTo(pathEndSegments[0].Direction()).ApproximatelyEquals(45));
+            Assert.True(pathEndSegments[2].Direction().AngleTo(pathEndSegments[1].Direction()).ApproximatelyEquals(45));
+            Assert.Equal(new Vector3(0, 8, 2), pathEndSegments[1].Start);
+            Assert.Equal(new Vector3(4, 4, 2), pathEndSegments[1].End);
+        }
+
+        private static bool CheckPolylineAngles(List<double> angles, Polyline polyline)
+        {
+            for (var i = 1; i < polyline.Vertices.Count - 1; i++)
+            {
+                var a = polyline.Vertices[i - 1];
+                var b = polyline.Vertices[i];
+                var c = polyline.Vertices[i + 1];
+                var angle = (b - a).AngleTo((c - b));
+                if (!angle.ApproximatelyEquals(180, 0.1) && !angle.ApproximatelyEquals(0, 0.1)
+                    && !angles.Any(ang => angle.ApproximatelyEquals(ang, 0.1)
+                                          ||  (angle - 90).ApproximatelyEquals(ang, 0.1)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        [Fact]
+        public void PolylineForceAngleCompliance3dPath()
+        {
+            Name = nameof(PolylineForceAngleCompliance3dPath);
+            var path = new List<Vector3>
+            {
+                new Vector3(2, 1, 2),
+                new Vector3(2, 3, 2),
+                new Vector3(4, 4.5, 2),
+                new Vector3(4, 5, 3),
+                new Vector3(4, 7, 3),
+                new Vector3(7, 8, 3),
+                new Vector3(7, 5, 3),
+                new Vector3(7, 2, 5)
+            };
+
+            var polyline = new Polyline(path);
+            var angles = new List<double> { 90, 45 };
+            var normalizedPathStart = polyline.ForceAngleCompliance(angles, Vector3.ZAxis, NormalizationType.Start);
+            var normalizedPathMiddle = polyline.ForceAngleCompliance(angles, Vector3.ZAxis, NormalizationType.Middle);
+            var normalizedPathEnd = polyline.ForceAngleCompliance(angles, Vector3.ZAxis, NormalizationType.End);
+            Model.AddElement(new ModelCurve(polyline, BuiltInMaterials.Black));
+            Model.AddElement(new ModelCurve(normalizedPathStart, BuiltInMaterials.XAxis));
+            Model.AddElement(new ModelCurve(normalizedPathMiddle, BuiltInMaterials.YAxis));
+            Model.AddElement(new ModelCurve(normalizedPathEnd, BuiltInMaterials.ZAxis));
+
+            Assert.True(CheckPolylineAngles(angles, normalizedPathStart));
+            Assert.True(CheckPolylineAngles(angles, normalizedPathMiddle));
+            Assert.True(CheckPolylineAngles(angles, normalizedPathEnd));
+        }
+
+        [Fact]
+        public void PolylineForceAngleComplianceWithCollinearPoints()
+        {
+            Name = nameof(PolylineForceAngleComplianceWithCollinearPoints);
+            var angles = new List<double> { 90, 45 };
+            var polyline = new Polyline(new List<Vector3> { new Vector3(), new Vector3(1, 3), new Vector3(5, 3), new Vector3(10, 3) });
+
+            var normalizedPathMiddle = polyline.ForceAngleCompliance(angles, Vector3.ZAxis, out var distanceMiddle, NormalizationType.Middle);
+            var normalizedPathEnd = polyline.ForceAngleCompliance(angles, Vector3.ZAxis, out var distanceEnd, NormalizationType.End);
+            var normalizedPathEndYAxisReferenceVector = polyline.ForceAngleCompliance(angles, new Vector3(0, 1), out var distanceStartYAxis, NormalizationType.End);
+
+            Model.AddElement(new ModelCurve(polyline, BuiltInMaterials.Black));
+            Model.AddElement(new ModelCurve(normalizedPathMiddle, BuiltInMaterials.XAxis));
+            Model.AddElement(new ModelCurve(normalizedPathEnd, BuiltInMaterials.YAxis));
+            Model.AddElement(new ModelCurve(normalizedPathEndYAxisReferenceVector, BuiltInMaterials.ZAxis));
+
+            Assert.True(CheckPolylineAngles(angles, normalizedPathMiddle));
+            // TODO This case is currently not working. Fix ForceAngleCompliance to handle this.
+            Assert.False(CheckPolylineAngles(angles, normalizedPathEnd));
+            Assert.True(CheckPolylineAngles(angles, normalizedPathEndYAxisReferenceVector));
         }
     }
 }

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -644,8 +644,7 @@ namespace Elements.Geometry.Tests
                 new Vector3(4, 3, 2),
                 new Vector3(1, 2, 2),
                 new Vector3(1, 0, 2),
-                new Vector3(0, 0, 1.1),
-                new Vector3(0, 0, 0)
+                new Vector3(0, 0, 2)
             };
             var polyline = new Polyline(path);
             var angles = new List<double> { 90, 45 };
@@ -657,7 +656,7 @@ namespace Elements.Geometry.Tests
             Assert.True(CheckPolylineAngles(angles, normalizedPathMiddle));
             Assert.True(CheckPolylineAngles(angles, normalizedPathEnd));
 
-            // Get 45 degree between first, second and third segments.
+            // Get 45 degree between first, second and third segments. All other angles of the polyline are 90 degrees.
             var pathStartSegments = normalizedPathStart.Segments();
             Assert.True(pathStartSegments[1].Direction().AngleTo(pathStartSegments[0].Direction()).ApproximatelyEquals(45));
             Assert.True(pathStartSegments[2].Direction().AngleTo(pathStartSegments[1].Direction()).ApproximatelyEquals(45));
@@ -675,9 +674,14 @@ namespace Elements.Geometry.Tests
             Assert.True(pathEndSegments[2].Direction().AngleTo(pathEndSegments[1].Direction()).ApproximatelyEquals(45));
             Assert.Equal(new Vector3(0, 8, 2), pathEndSegments[1].Start);
             Assert.Equal(new Vector3(4, 4, 2), pathEndSegments[1].End);
+
+            // Check that the first vertex has not changed.
+            Assert.Equal(polyline.Start, normalizedPathStart.Start);
+            Assert.Equal(polyline.Start, normalizedPathMiddle.Start);
+            Assert.Equal(polyline.Start, normalizedPathEnd.Start);
         }
 
-        private static bool CheckPolylineAngles(List<double> angles, Polyline polyline)
+        private static bool CheckPolylineAngles(List<double> supportedAngles, Polyline polyline)
         {
             for (var i = 1; i < polyline.Vertices.Count - 1; i++)
             {
@@ -685,9 +689,10 @@ namespace Elements.Geometry.Tests
                 var b = polyline.Vertices[i];
                 var c = polyline.Vertices[i + 1];
                 var angle = (b - a).AngleTo((c - b));
-                if (!angle.ApproximatelyEquals(180, 0.1) && !angle.ApproximatelyEquals(0, 0.1)
-                    && !angles.Any(ang => angle.ApproximatelyEquals(ang, 0.1)
-                                          ||  (angle - 90).ApproximatelyEquals(ang, 0.1)))
+                var isAngleSupported = supportedAngles.Any(ang => angle.ApproximatelyEquals(ang, 0.1) || (angle - 90).ApproximatelyEquals(ang, 0.1));
+                if (!angle.ApproximatelyEquals(180, 0.1)
+                    && !angle.ApproximatelyEquals(0, 0.1)
+                    && !isAngleSupported)
                 {
                     return false;
                 }


### PR DESCRIPTION
DESCRIPTION:
- Make the polyline correspond to the supported angles by moving the vertices slightly. The result polyline will have only allowed angles, but vertices positions will change.
- For each 3 consecutive points A, B, C to make angle ABC be one of allowed angles:
  - NormalizationType.Start: move B vertex
  - NormalizationType.Middle: move both B and C vertices in approximately equivalent proportions
  - NormalizationType.End : move C vertex

TESTING:
- Added `PolylineForceAngleCompliance`, `PolylineForceAngleCompliance3dPath`, `PolylineForceAngleComplianceWithCollinearPoints` tests to `PolylineTests`
  
FUTURE WORK:
- This method doesn't always work right for polylines with collinear points. See `PolylineForceAngleComplianceWithCollinearPoints` test

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/912)
<!-- Reviewable:end -->
