### PR TITLE
set current culture to en-US so numbers are correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `Line.IsCollinear` - added `tolerance` parameter.
 - `Polygon.CollinearPointsRemoved` - added `tolerance` parameter.
 - `Line.TryGetOverlap` - added `tolerance` parameter.
+- `CatalogGenerator` always uses en-US culture.
 
 ### Fixed
 

--- a/Elements.CodeGeneration/src/CatalogGenerator.cs
+++ b/Elements.CodeGeneration/src/CatalogGenerator.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using Elements.Geometry;
 using System.Reflection;
 using Elements.Generate.StringUtils;
+using System.Globalization;
 
 namespace Elements.Generate
 {
@@ -65,6 +66,7 @@ namespace Elements.Generate
 
             var templateText = File.ReadAllText(CatalogTemplatePath);
             var template = DotLiquid.Template.Parse(templateText);
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
             var result = template.Render(Hash.FromAnonymousObject(new
             {
                 catalog = catalog


### PR DESCRIPTION
BACKGROUND:
- User in another country reported that content catalogs were being generated with invalid nubmer formatting where `,` is used instead of `.` 
![image](https://user-images.githubusercontent.com/5872187/199328290-12ff7b5a-0a82-4251-9eb0-c70e2b4395b7.png)

DESCRIPTION:
- Set the current culture to `en-US` so numbers are correctly formatted

TESTING:
- I tested this by setting the culture to one that would create this problem, for example "pl-PL" and seeing that this did indeed affect the outcome, so I presume that it will fix the issue in reverse.
  
FUTURE WORK:
- Other places in code taht need this same treatment?  it seems like it most places we don't have explicity values for numbers so this isn't really an issue.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/914)
<!-- Reviewable:end -->
