### PR TITLE
Add TreeNode and use it for AdaptiveGraphRouting. Do additional step of leaf routing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `RoutingHintLine.Is2D`
 - `Obstacle.Orientation`
 - `Elements.Spatial.AdaptiveGrid.EdgeInfo`
+- `Elements.Spatial.AdaptiveGrid.TreeNode`
 - `IEnumerable<Vector3>.UniqueWithinTolerance(double tolerance = Vector3.EPSILON)`
 - `Plane.XY`, `Plane.XZ`, and `Plane.YZ` static properties
 
@@ -23,7 +24,7 @@
 - `RoutingVertex` - removed `Guides`.
 - `AdaptiveGraphRouting.BuildSpanningTree` functions are simplified. Also, they use only single `tailPoint` now.
 - `AdaptiveGraphRouting.BuildSpanningTree` no longer require to have at least one hint line.
-- `AdaptiveGraphRouting.BuildSpanningTree` no longer require to have at least one hint line.
+- `AdaptiveGraphRouting.BuildSpanningTree` and `AdaptiveGraphRouting.BuildSimpleNetwork` now return `IDictionary<ulong, TreeNode>`.
 - Don't log all vertex creation actions during Debug mode geometry generation.
 - `Polyline.GetSubsegment` changes direction of output polyline when parameters reversed
 - `Line.IsCollinear` - added `tolerance` parameter.

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -1038,11 +1038,15 @@ namespace Elements.Spatial.AdaptiveGrid
                         candidateBranch = BranchSide.Right;
                     }
 
+                    //Connection point with the lower cost is better. 
                     if (candidateCost > bestCost + Vector3.EPSILON)
                     {
                         continue;
                     }
 
+                    //If two ways to travel from point A to point B has the same cost,
+                    //the one is used that joins the tree without a turn. 
+                    //We both need/don't need a turn - first path is chosen.
                     if (costs.Item1.ApproximatelyEquals(costs.Item2) &&
                         tree.TryGetValue(index, out var node) && node.Trunk != null)
                     {
@@ -1074,6 +1078,8 @@ namespace Elements.Spatial.AdaptiveGrid
                         }
                     }
 
+                    //If several connection points on the tree have the same cost,
+                    //one is chosen that is closer to the end.
                     if (candidateCost.ApproximatelyEquals(bestCost))
                     {
                         if (bestCostToTrunk < 0)

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -622,8 +622,8 @@ namespace Elements.Spatial.AdaptiveGrid
                 var vertex = _grid.GetVertex(u);
                 foreach (var e in vertex.Edges)
                 {
-                    var edgeWeight = edgeInfos[e.Id];
-                    if (edgeWeight.Factor == double.PositiveInfinity)
+                    var edgeInfo = edgeInfos[e.Id];
+                    if (edgeInfo.Factor == double.PositiveInfinity)
                     {
                         continue;
                     }
@@ -658,7 +658,7 @@ namespace Elements.Spatial.AdaptiveGrid
                     }
 
                     //Compute cost of each its neighbors as cost of vertex we came from plus cost of edge.
-                    var newWeight = EdgeCost(edgeWeight);
+                    var newWeight = EdgeCost(edgeInfo);
                     BranchSide bestBranch = BranchSide.Left;
 
                     //We need as little change of direction as possible. A penalty is added if
@@ -670,7 +670,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         if (startDirection.HasValue &&
                             !Vector3.AreCollinearByAngle(_grid.GetVertex(startDirection.Value).Point, vertex.Point, v.Point))
                         {
-                            newWeight += TurnCost(edgeWeight, vertex, startDirection.Value, edgeInfos);
+                            newWeight += TurnCost(edgeInfo, vertex, startDirection.Value, edgeInfos);
                         }
                     }
                     else
@@ -682,7 +682,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         var leftCost = cost.Item1 + newWeight;
                         if (!leftCollinear)
                         {
-                            leftCost += TurnCost(edgeWeight, vertex, leftBefore.Id, edgeInfos);
+                            leftCost += TurnCost(edgeInfo, vertex, leftBefore.Id, edgeInfos);
                         }
 
                         var rigthCost = Double.MaxValue;
@@ -692,7 +692,7 @@ namespace Elements.Spatial.AdaptiveGrid
                             rigthCost = cost.Item2 + newWeight;
                             if (!Vector3.AreCollinearByAngle(rigthBefore.Point, vertex.Point, v.Point))
                             {
-                                rigthCost += TurnCost(edgeWeight, vertex, rigthBefore.Id, edgeInfos);
+                                rigthCost += TurnCost(edgeInfo, vertex, rigthBefore.Id, edgeInfos);
                             }
                         }
 
@@ -751,14 +751,14 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <param name="edgeInfo">Edge informations for the first edge</param>
         /// <param name="sharedVertex">Id of the vertex, common for two edges</param>
         /// <param name="thirdVertexId">Third vertex Id</param>
-        /// <param name="edgeWeights">Precalculated length and factor for each edge</param>
+        /// <param name="edgeInfos">Precalculated information for each edge</param>
         /// <returns></returns>
         private double TurnCost(
             EdgeInfo edgeInfo, Vertex sharedVertex, ulong thirdVertexId,
-            IDictionary<ulong, EdgeInfo> edgeWeights)
+            IDictionary<ulong, EdgeInfo> edgeInfos)
         {
             var otherEdge = sharedVertex.GetEdge(thirdVertexId);
-            var otherWeight = edgeWeights[otherEdge.Id];
+            var otherWeight = edgeInfos[otherEdge.Id];
 
             //Do not modify turn cost if either of edges is not horizontal.
             //This prevents "free to travel" loops under 2d hint lines.

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -480,14 +480,14 @@ namespace Elements.Spatial.AdaptiveGrid
         /// Higher level algorithm then decides which one of them to use as an end point.
         /// </summary>
         /// <param name="start">Start Vertex</param>
-        /// <param name="edgeWeights">Dictionary of Edge Id to the cost of traveling though it</param>
+        /// <param name="edgeInfos">Dictionary of Edge Id to precomputed information about it</param>
         /// <param name="travelCost">Output dictionary where traveling cost is stored per Vertex</param>
         /// <param name="startDirection">Previous Vertex, if start Vertex is already part of the Route</param>
         /// <param name="excluded">Vertices that are not allowed to visit</param>
         /// <param name="pathDirections">Next Vertex dictionary for Vertices that are already part of the route</param>
         /// <returns>Dictionary that have travel routes from each Vertex back to start Vertex.</returns>
         public Dictionary<ulong, ulong> ShortestPathDijkstra(
-            ulong start, Dictionary<ulong, EdgeInfo> edgeWeights,
+            ulong start, Dictionary<ulong, EdgeInfo> edgeInfos,
             out Dictionary<ulong, double> travelCost,
             ulong? startDirection = null, HashSet<ulong> excluded = null,
             Dictionary<ulong, ulong?> pathDirections = null)
@@ -519,7 +519,7 @@ namespace Elements.Spatial.AdaptiveGrid
 
                 foreach (var e in vertex.Edges)
                 {
-                    var edgeInfo = edgeWeights[e.Id];
+                    var edgeInfo = edgeInfos[e.Id];
                     if (edgeInfo.Factor == double.PositiveInfinity)
                     {
                         continue;
@@ -557,7 +557,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         if (startDirection.HasValue &&
                             !Vector3.AreCollinearByAngle(_grid.GetVertex(startDirection.Value).Point, vertex.Point, v.Point))
                         {
-                            newWeight += TurnCost(edgeInfo, vertex, startDirection.Value, edgeWeights);
+                            newWeight += TurnCost(edgeInfo, vertex, startDirection.Value, edgeInfos);
                         }
                     }
                     else
@@ -565,13 +565,13 @@ namespace Elements.Spatial.AdaptiveGrid
                         var vertexBefore = _grid.GetVertex(beforeId);
                         if (!Vector3.AreCollinearByAngle(vertexBefore.Point, vertex.Point, v.Point))
                         {
-                            newWeight += TurnCost(edgeInfo, vertex, vertexBefore.Id, edgeWeights);
+                            newWeight += TurnCost(edgeInfo, vertex, vertexBefore.Id, edgeInfos);
                         }
                         if (pathDirections != null &&
                             pathDirections.TryGetValue(v.Id, out var vertexAfter) && vertexAfter.HasValue &&
                             !Vector3.AreCollinearByAngle(vertex.Point, v.Point, _grid.GetVertex(vertexAfter.Value).Point))
                         {
-                            newWeight += TurnCost(edgeInfo, v, vertexAfter.Value, edgeWeights);
+                            newWeight += TurnCost(edgeInfo, v, vertexAfter.Value, edgeInfos);
                         }
                     }
 
@@ -1135,13 +1135,13 @@ namespace Elements.Spatial.AdaptiveGrid
             {
                 var edge = vertex.GetEdge(node.Trunk.Id);
                 Vertex next = _grid.GetVertex(node.Trunk.Id);
-                var edgeWeight = weights[edge.Id];
-                cost += EdgeCost(edgeWeight);
+                var edgeInfo = weights[edge.Id];
+                cost += EdgeCost(edgeInfo);
 
                 if (before != null &&
                     !Vector3.AreCollinearByAngle(before.Point, vertex.Point, next.Point))
                 {
-                    cost += TurnCost(edgeWeight, vertex, before.Id, weights);
+                    cost += TurnCost(edgeInfo, vertex, before.Id, weights);
                 }
 
                 before = vertex;

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -143,8 +143,8 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <param name="trunkVertex">End vertex id.</param>
         /// <param name="hintLines">Collection of lines that routes are attracted to. At least one hint line is required.</param>
         /// <param name="order">In which order tree is constructed</param>
-        /// <returns>Travel routes from inputVertices to the last of tailVertices.</returns>
-        public IDictionary<ulong, ulong?> BuildSpanningTree(
+        /// <returns>Travel tree from inputVertices to the trunkVertex.</returns>
+        public IDictionary<ulong, TreeNode> BuildSpanningTree(
             IList<RoutingVertex> leafVertices,
             ulong trunkVertex,
             IEnumerable<RoutingHintLine> hintLines,
@@ -161,66 +161,19 @@ namespace Elements.Spatial.AdaptiveGrid
 
             var weights = CalculateWeights(hintLines);
 
-            var leafToTrunkTree = new Dictionary<ulong, ulong?>();
-            leafToTrunkTree[trunkVertex] = null;
-            foreach (var inlet in leafVertices)
-            {
-                leafToTrunkTree[inlet.Id] = null;
-            }
+            var leafsToTrunkTree = new Dictionary<ulong, TreeNode>();
+            leafsToTrunkTree[trunkVertex] = new TreeNode(trunkVertex);
 
             var userHints = hintLines.Where(h => h.UserDefined);
             var hintVertices = NearbyVertices(userHints, leafVertices);
             //Hint lines can even go through excluded vertices
             allExcluded.ExceptWith(hintVertices.Select(hv => hv.Id));
 
-            List<ulong> collectorTerminals = leafVertices.Select(lv => lv.Id).ToList();
+            List<ulong> leafTerminals = leafVertices.Select(lv => lv.Id).ToList();
+            RouteBranch(leafTerminals, trunkVertex, allExcluded, excludedVertices,
+                weights, order, leafsToTrunkTree);
 
-            //Join all individual pieces together. We start from a single connection
-            //path from trunk and a set of connection points from the previous step.
-            //One at a time we choose the connection point that is cheapest to travel to existing
-            //network and its path is added to the network until all are added.
-            HashSet<ulong> magnetTerminals = new HashSet<ulong>() { trunkVertex };
-
-            var terminalInfo = new Dictionary<ulong, (
-                Dictionary<ulong, ((ulong, BranchSide), (ulong, BranchSide))> Connections,
-                Dictionary<ulong, (double, double)> Costs)>();
-            foreach (var inlet in collectorTerminals)
-            {
-                var otherExcluded = FilteredSet(allExcluded, excludedVertices[inlet]);
-                var branchConns = ShortestBranchesDijkstra(inlet, weights,
-                    out var travelCost, null, otherExcluded);
-                terminalInfo[inlet] = (branchConns, travelCost);
-            }
-
-            //Distances are precomputed beforehand to avoid square complexity on Dijkstra algorithm.
-            //When terminal is connected to the trunk - we can choose one of two routing options,
-            //considering also if any of them need extra turn when connected.
-            while (collectorTerminals.Any())
-            {
-                ulong bestTerminal = 0;
-                List<ulong> path = null;
-                double bestCost = order == TreeOrder.FurthestToClosest ? double.NegativeInfinity : double.PositiveInfinity;
-                foreach (var terminal in collectorTerminals)
-                {
-                    var info = terminalInfo[terminal];
-                    var (localClosest, branchSide) = FindConnectionPoint(
-                        magnetTerminals, info.Costs, info.Connections, leafToTrunkTree, weights);
-                    var costs = info.Costs[localClosest];
-                    var localBestCost = branchSide == BranchSide.Left ? costs.Item1 : costs.Item2;
-                    if (order == TreeOrder.FurthestToClosest ? localBestCost > bestCost : localBestCost < bestCost)
-                    {
-                        path = GetPathTo(info.Connections, localClosest, branchSide);
-                        bestTerminal = terminal;
-                        bestCost = localBestCost;
-                    }
-                }
-
-                path.ForEach(p => magnetTerminals.Add(p));
-                AddPathToTree(bestTerminal, path, leafToTrunkTree);
-                collectorTerminals.Remove(bestTerminal);
-            }
-
-            return leafToTrunkTree;
+            return leafsToTrunkTree;
         }
 
         /// <summary>
@@ -236,8 +189,8 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <param name="trunkVertex">End vertex id.</param>
         /// <param name="hintLines">Collection of lines that routes are attracted to. At least one hint line per group is required.</param>
         /// <param name="order">In which order tree is constructed</param>
-        /// <returns>Travel routes from inputVertices to the last of tailVertices.</returns>
-        public IDictionary<ulong, ulong?> BuildSpanningTree(
+        /// <returns>Travel tree from inputVertices to the trunkVertex.</returns>
+        public IDictionary<ulong, TreeNode> BuildSpanningTree(
             IList<List<RoutingVertex>> leafVertices,
             ulong trunkVertex,
             IList<List<RoutingHintLine>> hintLines,
@@ -261,70 +214,18 @@ namespace Elements.Spatial.AdaptiveGrid
             //Hint lines can even go through excluded vertices
             allExcluded.ExceptWith(nearbyHints.Select(nh => nh.Id));
 
-            var vertexTree = new Dictionary<ulong, ulong?>();
-            vertexTree[trunkVertex] = null;
-            foreach (var inlets in leafVertices)
-            {
-                foreach (var inlet in inlets)
-                {
-                    vertexTree[inlet.Id] = null;
-                }
-            }
+            var leafsToTrunkTree = new Dictionary<ulong, TreeNode>();
+            leafsToTrunkTree[trunkVertex] = new TreeNode(trunkVertex);
 
-            //Next steps are repeated independently for each input section
+            //Route tree branch independently for each input section
             for (int i = 0; i < leafVertices.Count; i++)
             {
-                List<ulong> collectorTerminals = leafVertices[i].Select(lv => lv.Id).ToList();
-                List<ulong> path = null;
-
-                //Join all individual pieces together. We start from a single connection
-                //path from droppipe and a set of connection points from the previous step.
-                //One at a time we choose the connection point that is cheapest to travel to existing
-                //network and its path is added to the network until all are added.
-                HashSet<ulong> magnetTerminals = new HashSet<ulong> { trunkVertex };
-
-                var terminalInfo = new Dictionary<ulong, (
-                    Dictionary<ulong, ((ulong, BranchSide), (ulong, BranchSide))> Connections,
-                    Dictionary<ulong, (double, double)> Costs)>();
-                foreach (var inlet in collectorTerminals)
-                {
-                    var excluded = FilteredSet(allExcluded, excludedVertices[inlet]);
-                    //Allow travel through excluded vertices of inlet only if it not yet left it's zone
-                    var connections = ShortestBranchesDijkstra(inlet, weights,
-                        out var travelCost, null, excluded);
-                    terminalInfo[inlet] = (connections, travelCost);
-                }
-
-                //Distances are precomputed beforehand to avoid square complexity on Dijkstra algorithm.
-                //When terminal is connected to the trunk - we can choose one of two routing options,
-                //considering also if any of them need extra turn when connected.
-                while (collectorTerminals.Any())
-                {
-                    ulong closestTerminal = 0;
-                    path = null;
-                    double bestCost = order == TreeOrder.FurthestToClosest ? double.NegativeInfinity : double.PositiveInfinity;
-                    foreach (var terminal in collectorTerminals)
-                    {
-                        var info = terminalInfo[terminal];
-                        var (localClosest, branch) = FindConnectionPoint(
-                            magnetTerminals, info.Costs, info.Connections, vertexTree, weights);
-                        var costs = info.Costs[localClosest];
-                        var localBestCost = branch == BranchSide.Left ? costs.Item1 : costs.Item2;
-                        if (order == TreeOrder.FurthestToClosest ? localBestCost > bestCost : localBestCost < bestCost)
-                        {
-                            path = GetPathTo(info.Connections, localClosest, branch);
-                            closestTerminal = terminal;
-                            bestCost = localBestCost;
-                        }
-                    }
-
-                    path.ForEach(p => magnetTerminals.Add(p));
-                    AddPathToTree(closestTerminal, path, vertexTree);
-                    collectorTerminals.Remove(closestTerminal);
-                }
+                List<ulong> leafTerminals = leafVertices[i].Select(lv => lv.Id).ToList();
+                RouteBranch(leafTerminals, trunkVertex, allExcluded, excludedVertices,
+                    weights, order, leafsToTrunkTree);
             }
 
-            return vertexTree;
+            return leafsToTrunkTree;
         }
 
         /// <summary>
@@ -335,8 +236,8 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <param name="leafVertices">Vertices to connect into the system with extra information attached.</param>
         /// <param name="exits">Possible exit vertices.</param>
         /// <param name="hintLines">Collection of lines that routes are attracted to.</param>
-        /// <returns>Travel routes from inputVertices to the last of tailVertices.</returns>
-        public IDictionary<ulong, ulong?> BuildSimpleNetwork(
+        /// <returns>Travel tree from inputVertices to one of the exits.</returns>
+        public IDictionary<ulong, TreeNode> BuildSimpleNetwork(
             IList<RoutingVertex> leafVertices,
             IList<ulong> exits,
             IEnumerable<RoutingHintLine> hintLines = null)
@@ -352,15 +253,10 @@ namespace Elements.Spatial.AdaptiveGrid
 
             var weights = CalculateWeights(hintLines);
 
-            var vertexTree = new Dictionary<ulong, ulong?>();
+            var leafsToTrunkTree = new Dictionary<ulong, TreeNode>();
             foreach (var trunk in exits)
             {
-                vertexTree[trunk] = null;
-            }
-
-            foreach (var inlet in leafVertices)
-            {
-                vertexTree[inlet.Id] = null;
+                leafsToTrunkTree[trunk] = new TreeNode(trunk);
             }
 
             if (hintLines != null && hintLines.Any())
@@ -379,10 +275,96 @@ namespace Elements.Spatial.AdaptiveGrid
                     inlet.Id, weights, out var travelCost, excluded: excluded);
                 var exit = FindConnectionPoint(exits, travelCost);
                 var path = GetPathTo(connections, exit);
-                AddPathToTree(inlet.Id, path, vertexTree);
+                AddPathToTree(inlet.Id, path, leafsToTrunkTree);
             }
 
-            return vertexTree;
+            return leafsToTrunkTree;
+        }
+
+        private void RouteBranch(
+            List<ulong> leafTerminals, ulong trunkTerminal,
+            HashSet<ulong> allExcluded, Dictionary<ulong, List<ulong>> excludedPerVertex,
+            Dictionary<ulong, EdgeInfo> weights,
+            TreeOrder order,
+            Dictionary<ulong, TreeNode> leafsToTrunkTree)
+        {
+            //Join all individual pieces together. We start from a single connection
+            //path from droppipe and a set of connection points from the previous step.
+            //One at a time we choose the connection point that is cheapest to travel to existing
+            //network and its path is added to the network until all are added.
+            HashSet<ulong> magnetTerminals = new HashSet<ulong> { trunkTerminal };
+
+            var terminalInfo = new Dictionary<ulong, (
+                Dictionary<ulong, ((ulong, BranchSide), (ulong, BranchSide))> Connections,
+                Dictionary<ulong, (double, double)> Costs)>();
+            foreach (var inlet in leafTerminals)
+            {
+                var excluded = FilteredSet(allExcluded, excludedPerVertex[inlet]);
+                //Allow travel through excluded vertices of inlet only if it not yet left it's zone
+                var connections = ShortestBranchesDijkstra(inlet, weights,
+                    out var travelCost, null, excluded);
+                terminalInfo[inlet] = (connections, travelCost);
+            }
+
+            List<ulong> appliedLeafs = new List<ulong>();
+
+            //Distances are precomputed beforehand to avoid square complexity on Dijkstra algorithm.
+            //When terminal is connected to the trunk - we can choose one of two routing options,
+            //considering also if any of them need extra turn when connected.
+            while (leafTerminals.Any())
+            {
+                ulong closestTerminal = 0;
+                List<ulong> path = null;
+                double bestCost = order == TreeOrder.FurthestToClosest ? double.NegativeInfinity : double.PositiveInfinity;
+                foreach (var terminal in leafTerminals)
+                {
+                    var info = terminalInfo[terminal];
+                    var (localClosest, branch) = FindConnectionPoint(
+                        magnetTerminals, info.Costs, info.Connections, leafsToTrunkTree, weights);
+                    var costs = info.Costs[localClosest];
+                    var localBestCost = branch == BranchSide.Left ? costs.Item1 : costs.Item2;
+                    if (order == TreeOrder.FurthestToClosest ? localBestCost > bestCost : localBestCost < bestCost)
+                    {
+                        path = GetPathTo(info.Connections, localClosest, branch);
+                        closestTerminal = terminal;
+                        bestCost = localBestCost;
+                    }
+                }
+
+                path.ForEach(p => magnetTerminals.Add(p));
+                AddPathToTree(closestTerminal, path, leafsToTrunkTree);
+                leafTerminals.Remove(closestTerminal);
+                appliedLeafs.Add(closestTerminal);
+            }
+
+            //Find closest connection from leafs once again.
+            //New trunk sections were added after all leafs were routed first time.
+            //Old connection point is first node from leaf that has more than 2 connections.
+            //Leafs are reconnected in reverse order of which they were added to the tree, skipping last one.
+            foreach (var leaf in appliedLeafs.Reverse<ulong>().Skip(1))
+            {
+                var leafNode = leafsToTrunkTree[leaf];
+                var leafPath = PathToFirstBranching(leafNode);
+                var localMagnets = magnetTerminals.Except(leafPath.Select(l => l.Id));
+                var info = terminalInfo[leaf];
+                var (localClosest, branchSide) = FindConnectionPoint(
+                    localMagnets, info.Costs, info.Connections, leafsToTrunkTree, weights);
+                var lastSnap = leafPath.Last().Trunk == null ? leafPath.Last().Id : leafPath.Last().Trunk.Id;
+                if (localClosest != lastSnap)
+                {
+                    //If better connection if found - remove old path from tree.
+                    foreach (var node  in leafPath)
+                    {
+                        magnetTerminals.Remove(node.Id);
+                        node.Disconnect();
+                        leafsToTrunkTree.Remove(node.Id);
+                    }
+
+                    var path = GetPathTo(info.Connections, localClosest, branchSide);
+                    path.ForEach(p => magnetTerminals.Add(p));
+                    AddPathToTree(leaf, path, leafsToTrunkTree);
+                }
+            }
         }
 
         /// <summary>
@@ -560,7 +542,7 @@ namespace Elements.Spatial.AdaptiveGrid
                     }
 
                     //Compute cost of each its neighbors as cost of vertex we came from plus cost of edge.
-                    var newWeight = travelCost[u] + edgeWeight.Length * edgeWeight.Factor;
+                    var newWeight = travelCost[u] + EdgeCost(edgeWeight);
 
                     //We need as little change of direction as possible. A penalty is added if
                     //a) We have a turn traveling to the next vertex.
@@ -571,7 +553,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         if (startDirection.HasValue &&
                             !Vector3.AreCollinearByAngle(_grid.GetVertex(startDirection.Value).Point, vertex.Point, v.Point))
                         {
-                            newWeight += CalculateTurnCost(edgeWeight, vertex, startDirection.Value, edgeWeights);
+                            newWeight += TurnCost(edgeWeight, vertex, startDirection.Value, edgeWeights);
                         }
                     }
                     else
@@ -579,13 +561,13 @@ namespace Elements.Spatial.AdaptiveGrid
                         var vertexBefore = _grid.GetVertex(beforeId);
                         if (!Vector3.AreCollinearByAngle(vertexBefore.Point, vertex.Point, v.Point))
                         {
-                            newWeight += CalculateTurnCost(edgeWeight, vertex, vertexBefore.Id, edgeWeights);
+                            newWeight += TurnCost(edgeWeight, vertex, vertexBefore.Id, edgeWeights);
                         }
                         if (pathDirections != null &&
                             pathDirections.TryGetValue(v.Id, out var vertexAfter) && vertexAfter.HasValue &&
                             !Vector3.AreCollinearByAngle(vertex.Point, v.Point, _grid.GetVertex(vertexAfter.Value).Point))
                         {
-                            newWeight += CalculateTurnCost(edgeWeight, v, vertexAfter.Value, edgeWeights);
+                            newWeight += TurnCost(edgeWeight, v, vertexAfter.Value, edgeWeights);
                         }
                     }
 
@@ -672,7 +654,7 @@ namespace Elements.Spatial.AdaptiveGrid
                     }
 
                     //Compute cost of each its neighbors as cost of vertex we came from plus cost of edge.
-                    var newWeight = edgeWeight.Length * edgeWeight.Factor;
+                    var newWeight = EdgeCost(edgeWeight);
                     BranchSide bestBranch = BranchSide.Left;
 
                     //We need as little change of direction as possible. A penalty is added if
@@ -684,7 +666,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         if (startDirection.HasValue &&
                             !Vector3.AreCollinearByAngle(_grid.GetVertex(startDirection.Value).Point, vertex.Point, v.Point))
                         {
-                            newWeight += CalculateTurnCost(edgeWeight, vertex, startDirection.Value, edgeWeights);
+                            newWeight += TurnCost(edgeWeight, vertex, startDirection.Value, edgeWeights);
                         }
                     }
                     else
@@ -696,7 +678,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         var leftCost = cost.Item1 + newWeight;
                         if (!leftCollinear)
                         {
-                            leftCost += CalculateTurnCost(edgeWeight, vertex, leftBefore.Id, edgeWeights);
+                            leftCost += TurnCost(edgeWeight, vertex, leftBefore.Id, edgeWeights);
                         }
 
                         var rigthCost = Double.MaxValue;
@@ -706,7 +688,7 @@ namespace Elements.Spatial.AdaptiveGrid
                             rigthCost = cost.Item2 + newWeight;
                             if (!Vector3.AreCollinearByAngle(rigthBefore.Point, vertex.Point, v.Point))
                             {
-                                rigthCost += CalculateTurnCost(edgeWeight, vertex, rigthBefore.Id, edgeWeights);
+                                rigthCost += TurnCost(edgeWeight, vertex, rigthBefore.Id, edgeWeights);
                             }
                         }
 
@@ -767,12 +749,11 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <param name="thirdVertexId">Third vertex Id</param>
         /// <param name="edgeWeights">Precalculated length and factor for each edge</param>
         /// <returns></returns>
-        private double CalculateTurnCost(
+        private double TurnCost(
             EdgeInfo edgeInfo, Vertex sharedVertex, ulong thirdVertexId,
             IDictionary<ulong, EdgeInfo> edgeWeights)
         {
-            var otherEdge = sharedVertex.Edges.Where(
-                edge => edge.StartId == thirdVertexId || edge.EndId == thirdVertexId).FirstOrDefault();
+            var otherEdge = sharedVertex.GetEdge(thirdVertexId);
             var otherWeight = edgeWeights[otherEdge.Id];
 
             //Do not modify turn cost if either of edges is not horizontal.
@@ -786,6 +767,11 @@ namespace Elements.Spatial.AdaptiveGrid
             //have several turns but don't give advantage for the tiny edges that are
             //fully inside hint line influence area.
             return _configuration.TurnCost * Math.Min(edgeInfo.Factor, otherWeight.Factor);
+        }
+
+        private double EdgeCost(EdgeInfo info)
+        {
+            return info.Length * info.Factor;
         }
 
         private PriorityQueue<ulong> PreparePriorityQueue(ulong start,
@@ -872,21 +858,39 @@ namespace Elements.Spatial.AdaptiveGrid
         }
 
         private void AddPathToTree(
-            ulong start, List<ulong> path, Dictionary<ulong, ulong?> tree)
+            ulong start,
+            List<ulong> path,
+            Dictionary<ulong, TreeNode> tree)
         {
             if (path.First() != start)
             {
                 path.Reverse();
             }
 
-            for (int i = 1; i < path.Count; i++)
+            for (int i = path.Count - 2; i >= 0; i--)
             {
                 //Path is composed from end to inlets. If tree already has next vertex
                 //from this one recorded, we don't want to override it. This way we join
                 //the flow that is already created, removing unnecessary loops.
-                if (!tree.ContainsKey(path[i - 1]) || tree[path[i - 1]] == null)
-                    tree[path[i - 1]] = path[i];
+                if (!tree.TryGetValue(path[i], out var oldNode) || oldNode.Trunk == null)
+                {
+                    var node = oldNode ?? new TreeNode(path[i]);
+                    var nextNode = tree[path[i + 1]];
+                    node.SetTrunk(nextNode);
+                    tree[path[i]] = node;
+                }
             }
+        }
+
+        private List<TreeNode> PathToFirstBranching(TreeNode node)
+        {
+            List<TreeNode> path = new List<TreeNode>();
+            while (node != null && node.Leafs.Count < 2)
+            {
+                path.Add(node);
+                node = node.Trunk;
+            }
+            return path;
         }
 
         private List<Vertex> NearbyVertices(
@@ -1013,69 +1017,84 @@ namespace Elements.Spatial.AdaptiveGrid
             IEnumerable<ulong> collection,
             IDictionary<ulong, (double, double)> travelCost,
             IDictionary<ulong, ((ulong, BranchSide), (ulong, BranchSide))> connections,
-            IDictionary<ulong, ulong?> tree,
+            IDictionary<ulong, TreeNode> tree,
             IDictionary<ulong, EdgeInfo> weights)
 
         {
             ulong bestIndex = 0;
             double bestCost = double.MaxValue;
             BranchSide bestBranch = BranchSide.Left;
+            double bestCostToTrunk = -1;
+
             foreach (var index in collection)
             {
                 if (travelCost.TryGetValue(index, out var costs))
                 {
-                    if (tree.TryGetValue(index, out var next) && next.HasValue)
+                    double candidateCost = costs.Item1;
+                    BranchSide candidateBranch = BranchSide.Left;
+                    if (costs.Item2 - costs.Item1 < Vector3.EPSILON)
                     {
-                        double cost1 = costs.Item1;
-                        double cost2 = costs.Item2;
-                        var activeV = _grid.GetVertex(index);
-                        var nextV = _grid.GetVertex(next.Value);
+                        candidateCost = costs.Item2;
+                        candidateBranch = BranchSide.Right;
+                    }
 
-                        //TO DO: better investigate why they 0 sometimes
+                    if (candidateCost > bestCost + Vector3.EPSILON)
+                    {
+                        continue;
+                    }
+
+                    if (costs.Item1.ApproximatelyEquals(costs.Item2) &&
+                        tree.TryGetValue(index, out var node) && node.Trunk != null)
+                    {
+                        var activeV = _grid.GetVertex(index);
+                        var nextV = _grid.GetVertex(node.Trunk.Id);
                         var before = connections[index];
-                        var before1 = before.Item1.Item1;
-                        var before2 = before.Item2.Item1;
-                        if (before1 != 0)
+                        bool needTurn1 = false;
+                        bool needTurn2 = false;
+
+                        if (before.Item1.Item1 != 0)
                         {
                             var beforeV1 = _grid.GetVertex(before.Item1.Item1);
-                            if (!Vector3.AreCollinearByAngle(beforeV1.Point, activeV.Point, nextV.Point))
-                            {
-                                var edge = activeV.Edges.Where(
-                                    e => e.StartId == beforeV1.Id || e.EndId == beforeV1.Id).First();
-                                var edgeWeight = weights[edge.Id];
-                                cost1 += CalculateTurnCost(edgeWeight, activeV, nextV.Id, weights);
-                            }
+                            needTurn1 = !Vector3.AreCollinearByAngle(beforeV1.Point, activeV.Point, nextV.Point);
                         }
 
-                        if (before2 != 0)
+                        if (before.Item2.Item1 != 0)
                         {
                             var beforeV2 = _grid.GetVertex(before.Item2.Item1);
-                            if (!Vector3.AreCollinearByAngle(beforeV2.Point, activeV.Point, nextV.Point))
-                            {
-                                var edge = activeV.Edges.Where(
-                                    e => e.StartId == beforeV2.Id || e.EndId == beforeV2.Id).First();
-                                var edgeWeight = weights[edge.Id];
-                                cost2 += CalculateTurnCost(edgeWeight, activeV, nextV.Id, weights);
-                            }
-
+                            needTurn2 = !Vector3.AreCollinearByAngle(beforeV2.Point, activeV.Point, nextV.Point);
                         }
 
-                        var bestCandidate = cost1 < cost2 ? (cost1, BranchSide.Left) : (cost2, BranchSide.Right);
-                        if (bestCandidate.Item1 < bestCost)
+                        if (needTurn1 && !needTurn2)
                         {
-                            bestCost = bestCandidate.Item1;
+                            (candidateCost, candidateBranch) = (costs.Item2, BranchSide.Right);
+                        }
+                        else
+                        {
+                            (candidateCost, candidateBranch) = (costs.Item1, BranchSide.Left);
+                        }
+                    }
+
+                    if (candidateCost.ApproximatelyEquals(bestCost))
+                    {
+                        if (bestCostToTrunk < 0)
+                        {
+                            bestCostToTrunk = CostToTrunk(tree[bestIndex], weights);
+                        }
+                        var candidateToTrunk = CostToTrunk(tree[index], weights);
+                        if (bestCostToTrunk - candidateToTrunk > Vector3.EPSILON)
+                        {
                             bestIndex = index;
-                            bestBranch = bestCandidate.Item2;
+                            bestCost = candidateCost;
+                            bestBranch = candidateBranch;
+                            bestCostToTrunk = candidateToTrunk;
                         }
                     }
                     else
                     {
-                        if (costs.Item1 < bestCost)
-                        {
-                            bestCost = costs.Item1;
-                            bestIndex = index;
-                            bestBranch = BranchSide.Left;
-                        }
+                        bestIndex = index;
+                        bestCost = candidateCost;
+                        bestBranch = candidateBranch;
+                        bestCostToTrunk = -1;
                     }
                 }
             }
@@ -1093,19 +1112,33 @@ namespace Elements.Spatial.AdaptiveGrid
             return bestIndex;
         }
 
-        private void CombinePath(List<ulong> mainPath, List<ulong> newPortion)
+        private double CostToTrunk(
+            TreeNode start,
+            IDictionary<ulong, EdgeInfo> weights)
         {
-            for (int i = 0; i < mainPath.Count; i++)
+            double cost = 0;
+            Vertex before = null;
+            Vertex vertex = _grid.GetVertex(start.Id);
+            TreeNode node = start;
+
+            while (node != null && node.Trunk != null)
             {
-                var index = newPortion.IndexOf(mainPath[i]);
-                if (index != -1)
+                var edge = vertex.GetEdge(node.Trunk.Id);
+                Vertex next = _grid.GetVertex(node.Trunk.Id);
+                var edgeWeight = weights[edge.Id];
+                cost += EdgeCost(edgeWeight);
+
+                if (before != null &&
+                    !Vector3.AreCollinearByAngle(before.Point, vertex.Point, next.Point))
                 {
-                    mainPath.RemoveRange(i, mainPath.Count - i);
-                    mainPath.AddRange(newPortion.Skip(index));
-                    return;
+                    cost += TurnCost(edgeWeight, vertex, before.Id, weights);
                 }
+
+                before = vertex;
+                vertex = next;
+                node = node.Trunk;
             }
-            mainPath.AddRange(newPortion);
+            return cost;
         }
 
         private HashSet<ulong> FilteredSet(HashSet<ulong> hashSet, IEnumerable<ulong> exceptions)

--- a/Elements/src/Spatial/AdaptiveGrid/TreeNode.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/TreeNode.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elements.Spatial.AdaptiveGrid
+{
+    /// <summary>
+    /// Node that represents a vertex in a routed tree.
+    /// </summary>
+    public class TreeNode
+    {
+        /// <summary>
+        /// List of incoming nodes.
+        /// </summary>
+        public List<TreeNode> Leafs = new List<TreeNode>();
+
+        /// <summary>
+        /// Outgoing node.
+        /// </summary>
+        public TreeNode Trunk = null;
+
+        /// <summary>
+        /// Id of corresponding vertex in the gird.
+        /// </summary>
+        public ulong Id;
+
+        /// <summary>
+        /// Create new node from vertex id without any connections.
+        /// </summary>
+        /// <param name="id">Id of vertex.</param>
+        public TreeNode(ulong id)
+        {
+            Id = id;
+        }
+
+        /// <summary>
+        /// Remove all incoming and outgoing connections from the grid.
+        /// Removed nodes will also be disconnected from this node.
+        /// </summary>
+        public void Disconnect()
+        {
+            foreach (var leaf in Leafs)
+            {
+                leaf.Trunk = null;
+            }
+            Leafs.Clear();
+
+            if (Trunk != null)
+            {
+                Trunk.RemoveLeaf(this);
+            }
+        }
+
+        /// <summary>
+        /// Remove leaf connection and set its trunk to null.
+        /// </summary>
+        /// <param name="leaf"></param>
+        public void RemoveLeaf(TreeNode leaf)
+        {
+            Leafs.Remove(leaf);
+            leaf.Trunk = null;
+        }
+
+        /// <summary>
+        /// Set trunk node and add this node as leaf to it.
+        /// </summary>
+        /// <param name="trunk"></param>
+        public void SetTrunk(TreeNode trunk)
+        {
+            if (Trunk != null)
+            {
+                Trunk.Leafs.Remove(this);
+            }
+
+            Trunk = trunk;
+            trunk.Leafs.Add(this);
+        }
+    }
+}

--- a/Elements/test/AdaptiveGraphRoutingTests.cs
+++ b/Elements/test/AdaptiveGraphRoutingTests.cs
@@ -421,20 +421,8 @@ namespace Elements.Tests
             alg.BuildSpanningTree(inputVertices, tailVertex, new List<RoutingHintLine>(), TreeOrder.ClosestToFurthest);
 
             //Results visualization
-            List<Line> lines = new List<Line>();
-            foreach (var input in inputVertices)
-            {
-                var node = tree[input.Id];
-                while (node.Trunk != null)
-                {
-                    lines.Add(new Line(grid.GetVertex(node.Id).Point,
-                                       grid.GetVertex(node.Trunk.Id).Point));
-                    node = node.Trunk;
-                }
-            }
-            ModelLines ml = new ModelLines(lines, new Material("", new Color("red")));
-            this.Model.AddElements(alg.RenderElements(hints, keyPoints));
-            this.Model.AddElement(ml);
+            VisualizeRoutingTree(grid, inputVertices, tree);
+            VisualizeGrid(alg, hints, keyPoints);
         }
 
         [Fact]
@@ -547,20 +535,8 @@ namespace Elements.Tests
                 inputVertices, tailVertex, new List<List<RoutingHintLine>>(), TreeOrder.ClosestToFurthest);
 
             //Result visualization
-            List<Line> lines = new List<Line>();
-            foreach (var input in inputVertices.SelectMany(iv => iv))
-            {
-                var node = tree[input.Id];
-                while (node.Trunk != null)
-                {
-                    lines.Add(new Line(grid.GetVertex(node.Id).Point,
-                                       grid.GetVertex(node.Trunk.Id).Point));
-                    node = node.Trunk;
-                }
-            }
-            ModelLines ml = new ModelLines(lines, new Material("", new Color("red")));
-            this.Model.AddElements(alg.RenderElements(hints.SelectMany(h => h).ToList(), keyPoints));
-            this.Model.AddElement(ml);
+            VisualizeRoutingTree(grid, inputVertices.SelectMany(iv => iv), tree);
+            VisualizeGrid(alg, hints.SelectMany(h => h).ToList(), keyPoints);
         }
 
         [Fact]
@@ -1063,6 +1039,34 @@ namespace Elements.Tests
                 new Vector3(0, 0, 0)
             };
             CheckTree(grid, inputId2, tree, expectedPath);
+        }
+
+        private void VisualizeRoutingTree(
+            AdaptiveGrid grid,
+            IEnumerable<RoutingVertex> routingVertices,
+            IDictionary<ulong, TreeNode> tree)
+        {
+            List<Line> lines = new List<Line>();
+            foreach (var input in routingVertices)
+            {
+                var node = tree[input.Id];
+                while (node.Trunk != null)
+                {
+                    lines.Add(new Line(grid.GetVertex(node.Id).Point,
+                                       grid.GetVertex(node.Trunk.Id).Point));
+                    node = node.Trunk;
+                }
+            }
+            ModelLines ml = new ModelLines(lines, new Material("", new Color("red")));
+            this.Model.AddElement(ml);
+        }
+
+        private void VisualizeGrid(
+            AdaptiveGraphRouting alg,
+            IList<RoutingHintLine> hints, 
+            IList<Vector3> keyPoints)
+        {
+            this.Model.AddElements(alg.RenderElements(hints, keyPoints));
         }
 
         private static void CheckTree(

--- a/Elements/test/AdaptiveGraphRoutingTests.cs
+++ b/Elements/test/AdaptiveGraphRoutingTests.cs
@@ -424,13 +424,12 @@ namespace Elements.Tests
             List<Line> lines = new List<Line>();
             foreach (var input in inputVertices)
             {
-                var v0 = input.Id;
-                var v1 = tree[v0];
-                while (v1.HasValue && v1 != 0)
+                var node = tree[input.Id];
+                while (node.Trunk != null)
                 {
-                    lines.Add(new Line(grid.GetVertex(v0).Point, grid.GetVertex(v1.Value).Point));
-                    v0 = v1.Value;
-                    v1 = tree[v0];
+                    lines.Add(new Line(grid.GetVertex(node.Id).Point,
+                                       grid.GetVertex(node.Trunk.Id).Point));
+                    node = node.Trunk;
                 }
             }
             ModelLines ml = new ModelLines(lines, new Material("", new Color("red")));
@@ -551,13 +550,12 @@ namespace Elements.Tests
             List<Line> lines = new List<Line>();
             foreach (var input in inputVertices.SelectMany(iv => iv))
             {
-                var v0 = input.Id;
-                var v1 = tree[v0];
-                while (v1.HasValue && v1 != 0)
+                var node = tree[input.Id];
+                while (node.Trunk != null)
                 {
-                    lines.Add(new Line(grid.GetVertex(v0).Point, grid.GetVertex(v1.Value).Point));
-                    v0 = v1.Value;
-                    v1 = tree[v0];
+                    lines.Add(new Line(grid.GetVertex(node.Id).Point,
+                                       grid.GetVertex(node.Trunk.Id).Point));
+                    node = node.Trunk;
                 }
             }
             ModelLines ml = new ModelLines(lines, new Material("", new Color("red")));
@@ -889,17 +887,195 @@ namespace Elements.Tests
             CheckTree(grid, inputId, route, expectedPath);
         }
 
-        private static void CheckTree(
-            AdaptiveGrid grid, ulong startId, IDictionary<ulong, ulong?> tree, List<Vector3> expectedPath)
+        [Fact]
+        public void AdaptiveGraphRoutingEqualLeafCheck()
         {
-            ulong? before = startId;
+            var grid = new AdaptiveGrid();
+            grid.AddVertices(new Vector3[] {
+                new Vector3(0, 0, 0),
+                new Vector3(10, 0, 0),
+            }, AdaptiveGrid.VerticesInsertionMethod.Connect);
+
+            grid.AddVertices(new Vector3[] {
+                new Vector3(2, 2, 0),
+                new Vector3(2, 0, 0)
+            }, AdaptiveGrid.VerticesInsertionMethod.ConnectAndCut);
+
+            grid.AddVertices(new Vector3[] {
+                new Vector3(5, 10, 0),
+                new Vector3(4, 10, 0),
+                new Vector3(4, 0, 0),
+            }, AdaptiveGrid.VerticesInsertionMethod.ConnectAndCut);
+
+            grid.AddVertices(new Vector3[] {
+                new Vector3(5, 10, 0),
+                new Vector3(6, 10, 0),
+                new Vector3(6, 0, 0),
+            }, AdaptiveGrid.VerticesInsertionMethod.ConnectAndCut);
+
+            grid.AddVertices(new Vector3[] {
+                new Vector3(8, 2, 0),
+                new Vector3(8, 0, 0)
+            }, AdaptiveGrid.VerticesInsertionMethod.ConnectAndCut);
+
+
+            var c = new RoutingConfiguration();
+            var routing = new AdaptiveGraphRouting(grid, c);
+            Assert.True(grid.TryGetVertexIndex(new Vector3(2, 2), out var inputId0, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 10), out var inputId1, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(8, 2), out var inputId2, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0), out var outputId, grid.Tolerance));
+            var inputs = new List<RoutingVertex> {
+                new RoutingVertex(inputId0, 0),
+                new RoutingVertex(inputId1, 0),
+                new RoutingVertex(inputId2, 0)
+            };
+            var tree = routing.BuildSpanningTree(inputs, outputId, new List<RoutingHintLine>(), TreeOrder.ClosestToFurthest);
+
+            var expectedPath = new List<Vector3>()
+            {
+                new Vector3(5, 10, 0),
+                new Vector3(4, 10, 0),
+                new Vector3(4, 0, 0),
+                new Vector3(2, 0, 0),
+                new Vector3(0, 0, 0)
+            };
+            CheckTree(grid, inputId1, tree, expectedPath);
+
+            Assert.True(grid.TryGetVertexIndex(new Vector3(10, 0), out outputId, grid.Tolerance));
+            tree = routing.BuildSpanningTree(inputs, outputId, new List<RoutingHintLine>(), TreeOrder.ClosestToFurthest);
+
+            expectedPath = new List<Vector3>()
+            {
+                new Vector3(5, 10, 0),
+                new Vector3(6, 10, 0),
+                new Vector3(6, 0, 0),
+                new Vector3(8, 0, 0),
+                new Vector3(10, 0, 0)
+            };
+            CheckTree(grid, inputId1, tree, expectedPath);
+        }
+
+        [Fact]
+        public void AdaptiveGraphRoutingClosestLeafCheck()
+        {
+            var grid = new AdaptiveGrid();
+            grid.AddVertices(new Vector3[] {
+                new Vector3(0, 20, 0),
+                new Vector3(0, 10, 0),
+                new Vector3(10, 10, 0),
+                new Vector3(10, 0, 0),
+                new Vector3(20, 0, 0),
+            }, AdaptiveGrid.VerticesInsertionMethod.Connect);
+
+            grid.AddVertices(new Vector3[] {
+                new Vector3(10, 20, 0),
+                new Vector3(8, 20, 0),
+                new Vector3(8, 10, 0),
+            }, AdaptiveGrid.VerticesInsertionMethod.ConnectAndCut);
+
+            grid.AddVertices(new Vector3[] {
+                new Vector3(10, 20, 0),
+                new Vector3(12, 20, 0),
+                new Vector3(12, 0, 0),
+            }, AdaptiveGrid.VerticesInsertionMethod.ConnectAndCut);
+
+            var c = new RoutingConfiguration();
+            var routing = new AdaptiveGraphRouting(grid, c);
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 20), out var inputId0, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(10, 20), out var inputId1, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(20, 0), out var outputId, grid.Tolerance));
+            var inputs = new List<RoutingVertex> {
+                new RoutingVertex(inputId0, 1),
+                new RoutingVertex(inputId1, 1),
+            };
+            var tree = routing.BuildSpanningTree(inputs, outputId, new List<RoutingHintLine>(), TreeOrder.ClosestToFurthest);
+
+            var expectedPath = new List<Vector3>()
+            {
+                new Vector3(10, 20, 0),
+                new Vector3(8, 20, 0),
+                new Vector3(8, 10, 0),
+                new Vector3(10, 10, 0),
+                new Vector3(10, 0, 0),
+                new Vector3(12, 0, 0),
+                new Vector3(20, 0, 0),
+            };
+            CheckTree(grid, inputId1, tree, expectedPath);
+        }
+
+        [Fact]
+        public void AdaptiveGraphRoutingCorrectTurn()
+        {
+            var grid = new AdaptiveGrid();
+            grid.AddVertices(new Vector3[] {
+                new Vector3(5, 15, 0),
+                new Vector3(0, 15, 0),
+                new Vector3(0, 0, 0)
+            }, AdaptiveGrid.VerticesInsertionMethod.Connect);
+
+            grid.AddVertices(new Vector3[] {
+                new Vector3(5, 15, 0),
+                new Vector3(5, 10, 0),
+                new Vector3(-5, 10, 0),
+                new Vector3(-5, 5, 0),
+                new Vector3(5, 5, 0),
+            }, AdaptiveGrid.VerticesInsertionMethod.ConnectAndCut);
+
+            var c = new RoutingConfiguration();
+            var routing = new AdaptiveGraphRouting(grid, c);
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 5), out var inputId0, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(-5, 10), out var inputId1, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 15), out var inputId2, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0), out var outputId, grid.Tolerance));
+            var inputs = new List<RoutingVertex> {
+                new RoutingVertex(inputId0, 1),
+                new RoutingVertex(inputId1, 1),
+                new RoutingVertex(inputId2, 1),
+            };
+            var tree = routing.BuildSpanningTree(inputs, outputId, new List<RoutingHintLine>(), TreeOrder.ClosestToFurthest);
+
+            var expectedPath = new List<Vector3>()
+            {
+                new Vector3(5, 5, 0),
+                new Vector3(0, 5, 0),
+                new Vector3(0, 0, 0)
+            };
+            CheckTree(grid, inputId0, tree, expectedPath);
+
+            //Second and third vertex can go to the side and then down or down and then to the side.
+            //It should choose the direction of next path segment.
+            expectedPath = new List<Vector3>()
+            {
+                new Vector3(-5, 10, 0),
+                new Vector3(0, 10, 0),
+                new Vector3(0, 5, 0),
+                new Vector3(0, 0, 0)
+            };
+            CheckTree(grid, inputId1, tree, expectedPath);
+
+            expectedPath = new List<Vector3>()
+            {
+                new Vector3(5, 15, 0),
+                new Vector3(0, 15, 0),
+                new Vector3(0, 10, 0),
+                new Vector3(0, 5, 0),
+                new Vector3(0, 0, 0)
+            };
+            CheckTree(grid, inputId2, tree, expectedPath);
+        }
+
+        private static void CheckTree(
+            AdaptiveGrid grid, ulong startId, IDictionary<ulong, TreeNode> tree, List<Vector3> expectedPath)
+        {
+            TreeNode node = tree[startId];
             for (int i = 0; i < expectedPath.Count; i++)
             {
-                Assert.Equal(grid.GetVertex(before.Value).Point, expectedPath[i]);
-                before = tree[before.Value];
+                Assert.Equal(expectedPath[i], grid.GetVertex(node.Id).Point);
+                node = node.Trunk;
             }
             //After reaching start point before is pointing to 0 (nothing)
-            Assert.False(before.HasValue);
+            Assert.Null(node);
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- Were reported next issues with AdaptiveGraphRouting.
A) When leaf can connect to the tree in several points with the same cost - random path is chosen.
B) Longer as expected leaf is user for leafs that are connected to the tree first.  

DESCRIPTION:
- Added TreeNode and use it instead of just dictionary. This allows to track leaf/trunk connections in the tree.
- If several connection points on the tree have the same cost, one is chosen that is closer to the end.
- Do additional step of leaf routing. When trunk is constructed leafs can find better connection point. 
- Make decision making for choosing where to connect to the trunk more predictable:
A) Lowest travel cost
B) If same - closest point to the exit
C) From two calculated paths choose the one that has no turn with trunk direction.
- Moved common logic to RouteBranch function.

TESTING:
- Added new tests: 
A) AdaptiveGraphRoutingEqualLeafCheck
B) AdaptiveGraphRoutingClosestLeafCheck
C) AdaptiveGraphRoutingCorrectTurn

FUTURE WORK:
- AdaptiveGraphRouting.ConnectionPoint went through changes to make it more predictable but it may require more polishing after additional testing and feedback.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/915)
<!-- Reviewable:end -->
