### PR TITLE
remove bbox validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.0
+
+### Changed
+- Remove the BBox3 validator.
+
 ## 1.3.0
 
 ### Added

--- a/Elements/src/Validators/Validators.cs
+++ b/Elements/src/Validators/Validators.cs
@@ -88,28 +88,6 @@ namespace Elements.Validators
     }
 
     [Obsolete]
-    public class BBox3Validator : IValidator
-    {
-        public Type ValidatesType => typeof(BBox3);
-
-        public void PostConstruct(object obj)
-        { }
-
-        public void PreConstruct(object[] args)
-        {
-            var min = (Vector3)args[0];
-            var max = (Vector3)args[1];
-            if (min.X == max.X
-             || min.Y == max.Y
-             )
-            {
-                throw new System.ArgumentException("The bounding box will have zero volume, please ensure that the Min and Max don't have any identical vertex values.");
-            }
-        }
-
-    }
-
-    [Obsolete]
     public class LineValidator : IValidator
     {
         public Type ValidatesType => typeof(Line);


### PR DESCRIPTION
BACKGROUND:
- A developer had a really tricky bug in a function because of a model failing to deserialize.  They eventually traced it down to a failure  creating a BBox3.  The failure was only because our validator doesn't allow degenerate bounding boxes.  There's no real reason to disallow 0 volume bounding boxes.

DESCRIPTION:
- Remove the BBox3 validator

TESTING:
- Tests are fine.
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/917)
<!-- Reviewable:end -->
