### PR TITLE
AdaptiveGraphRouting: add WeightModifier and EdgeInfo.Flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,20 @@
 ### Added
 
 - `AdaptiveGraphRouting.ErrorMessages`
+- `EdgeInfo.Flags`
+- `Elements.Spatial.WeightModifier`
+- `AdaptiveGraphRouting.GetWeightModifier(string name)`
+- `AdaptiveGraphRouting.AddWeightModifier`,
+- `AdaptiveGraphRouting.RemoveWeightModifier`
+- `AdaptiveGraphRouting.ClearWeightModifiers`,
+- `AdaptiveGraphRouting.AddPlaneModifier(string name, Plane plane, double factor)`
 - `SvgSection.SaveAsSvg`, `SvgSection.SaveAsPdf`
 
 ### Changed
 
 - Remove the BBox3 validator.
+- `RoutingConfiguration.MainLayer` and `RoutingConfiguration.LayerPenalty` are set obsolete.
+- `EdgeInfo.HasVerticalChange` is set obsolete.
 
 ### Fixed
 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -12,7 +12,7 @@ namespace Elements.Spatial.AdaptiveGrid
     /// <summary>
     /// Class for routing through an AdaptiveGrid.
     /// </summary>
-    public class AdaptiveGraphRouting
+    public partial class AdaptiveGraphRouting
     {
         private AdaptiveGrid _grid;
         private RoutingConfiguration _configuration;
@@ -49,6 +49,19 @@ namespace Elements.Spatial.AdaptiveGrid
             //global information line boundaries, points, lines and obstacles.
             _grid = grid;
             _configuration = configuration;
+
+            if (!_configuration.LayerPenalty.ApproximatelyEquals(1))
+            { 
+                var plane = new Plane(new Vector3(0, 0, _configuration.MainLayer), Vector3.ZAxis);
+                var modifier = new WeightModifier(
+                    "Not Main Layer",
+                    new Func<Vertex, Vertex, bool>((a, b) =>
+                    {
+                        return Math.Abs(a.Point.Z - _configuration.MainLayer) > _grid.Tolerance ||
+                               Math.Abs(b.Point.Z - _configuration.MainLayer) > _grid.Tolerance;
+                    }),
+                    _configuration.LayerPenalty);
+            }
         }
 
         /// <summary>
@@ -72,12 +85,12 @@ namespace Elements.Spatial.AdaptiveGrid
         public IList<Element> RenderElements(IList<RoutingHintLine> hintLines,
                                              IList<Vector3> splitPoints)
         {
-            List<Line> normalEdgesMain = new List<Line>();
-            List<Line> hintEdgesMain = new List<Line>();
-            List<Line> offsetEdgesMain = new List<Line>();
-            List<Line> normalEdgesOther = new List<Line>();
-            List<Line> hintEdgesOther = new List<Line>();
-            List<Line> offsetEdgesOther = new List<Line>();
+            List<Line> normalEdgesCheap = new List<Line>();
+            List<Line> hintEdgesCheap = new List<Line>();
+            List<Line> offsetEdgesCheap = new List<Line>();
+            List<Line> normalEdgesExpensive = new List<Line>();
+            List<Line> hintEdgesExpensive = new List<Line>();
+            List<Line> offsetEdgesExpensive = new List<Line>();
 
             var hintGroups = hintLines.GroupBy(h => h.UserDefined);
             var userHints = hintGroups.SingleOrDefault(hg => hg.Key == true);
@@ -90,38 +103,38 @@ namespace Elements.Spatial.AdaptiveGrid
                 var v0 = _grid.GetVertex(edge.StartId);
                 var v1 = _grid.GetVertex(edge.EndId);
                 Line l = new Line(v0.Point, v1.Point);
-                var mainLayer = OnMainLayer(v0, v1);
+                var modifierFactor = ModifierFactor(v0, v1);
                 if (IsAffectedBy(v0.Point, v1.Point, userHints))
                 {
-                    if (mainLayer == true)
+                    if (modifierFactor < 1 + _grid.Tolerance)
                     {
-                        hintEdgesMain.Add(l);
+                        hintEdgesCheap.Add(l);
                     }
                     else
                     {
-                        hintEdgesOther.Add(l);
+                        hintEdgesExpensive.Add(l);
                     }
                 }
                 else if (IsAffectedBy(v0.Point, v1.Point, defaultHints))
                 {
-                    if (mainLayer == true)
+                    if (modifierFactor < 1 + _grid.Tolerance)
                     {
-                        offsetEdgesMain.Add(l);
+                        offsetEdgesCheap.Add(l);
                     }
                     else
                     {
-                        offsetEdgesOther.Add(l);
+                        offsetEdgesExpensive.Add(l);
                     }
                 }
                 else
                 {
-                    if (mainLayer == true)
+                    if (modifierFactor < 1 + _grid.Tolerance)
                     {
-                        normalEdgesMain.Add(l);
+                        normalEdgesCheap.Add(l);
                     }
                     else
                     {
-                        normalEdgesOther.Add(l);
+                        normalEdgesExpensive.Add(l);
                     }
                 }
             }
@@ -129,17 +142,17 @@ namespace Elements.Spatial.AdaptiveGrid
             List<Element> visualizations = new List<Element>();
             visualizations.Add(VisualizePoints(splitPoints));
 
-            visualizations.Add(new ModelLines(normalEdgesMain, new Material(
+            visualizations.Add(new ModelLines(normalEdgesCheap, new Material(
                 "Normal Edges Main", Colors.Blue)));
-            visualizations.Add(new ModelLines(normalEdgesOther, new Material(
+            visualizations.Add(new ModelLines(normalEdgesExpensive, new Material(
                 "Normal Edges Other", Colors.Cobalt)));
-            visualizations.Add(new ModelLines(offsetEdgesMain, new Material(
+            visualizations.Add(new ModelLines(offsetEdgesCheap, new Material(
                 "Offset Edges Main", Colors.Orange)));
-            visualizations.Add(new ModelLines(offsetEdgesOther, new Material(
+            visualizations.Add(new ModelLines(offsetEdgesExpensive, new Material(
                 "Offset Edges Other", Colors.Yellow)));
-            visualizations.Add(new ModelLines(hintEdgesMain, new Material(
+            visualizations.Add(new ModelLines(hintEdgesCheap, new Material(
                 "Hint Edges Main", Colors.Green)));
-            visualizations.Add(new ModelLines(hintEdgesOther, new Material(
+            visualizations.Add(new ModelLines(hintEdgesExpensive, new Material(
                 "Hint Edges Other", Colors.Emerald)));
 
             return visualizations;
@@ -425,6 +438,8 @@ namespace Elements.Spatial.AdaptiveGrid
                     angle = 180 - angle;
                 }
 
+                EdgeFlags flags = EdgeFlags.None;
+
                 if (_configuration.SupportedAngles != null &&
                     !_configuration.SupportedAngles.Any(a => a.ApproximatelyEquals(angle, 0.01)))
                 {
@@ -434,11 +449,7 @@ namespace Elements.Spatial.AdaptiveGrid
                 {
                     double hintFactor = 1;
                     double offsetFactor = 1;
-                    double layerFactor = 1;
-                    if (_configuration.LayerPenalty != 1 && !OnMainLayer(v0, v1))
-                    {
-                        layerFactor = _configuration.LayerPenalty;
-                    }
+                    double modifierFactor = ModifierFactor(v0, v1);
 
                     if (hintLines != null && hintLines.Any())
                     {
@@ -452,6 +463,7 @@ namespace Elements.Spatial.AdaptiveGrid
                                 if (l.UserDefined)
                                 {
                                     hintFactor = Math.Min(l.Factor, hintFactor);
+                                    flags &= l.Is2D ? EdgeFlags.Hint2D : EdgeFlags.Hint3D;
                                 }
                                 else
                                 {
@@ -461,7 +473,7 @@ namespace Elements.Spatial.AdaptiveGrid
                         }
                     }
 
-                    weights[e.Id] = new EdgeInfo(_grid, e, hintFactor * offsetFactor * layerFactor);
+                    weights[e.Id] = new EdgeInfo(_grid, e, hintFactor * offsetFactor * modifierFactor);
                 }
             }
 
@@ -792,19 +804,32 @@ namespace Elements.Spatial.AdaptiveGrid
             IDictionary<ulong, EdgeInfo> edgeInfos)
         {
             var otherEdge = sharedVertex.GetEdge(thirdVertexId);
-            var otherWeight = edgeInfos[otherEdge.Id];
+            var otherInfo = edgeInfos[otherEdge.Id];
 
             //Do not modify turn cost if either of edges is not horizontal.
             //This prevents "free to travel" loops under 2d hint lines.
-            if (edgeInfo.HasVerticalChange || otherWeight.HasVerticalChange)
+            //If either of two edges are affected by 3d hint line - turn cost can be 
+            //discounted but still can't be bigger than TurnCost.
+            if (edgeInfo.HasFlag(EdgeFlags.HasVerticalChange) ||
+                otherInfo.HasFlag(EdgeFlags.HasVerticalChange))
             {
-                return _configuration.TurnCost;
+                var factor = 1d;
+                if (edgeInfo.HasFlag(EdgeFlags.Hint3D))
+                {
+                    factor = Math.Min(edgeInfo.Factor, 1);
+                }
+                else if (otherInfo.HasFlag(EdgeFlags.Hint3D))
+                {
+                    factor = Math.Min(otherInfo.Factor, 1);
+                }
+
+                return factor * _configuration.TurnCost;
             }
 
             //Minimum factor makes algorithm prefer edges inside of hint lines even if they
             //have several turns but don't give advantage for the tiny edges that are
             //fully inside hint line influence area.
-            return _configuration.TurnCost * Math.Min(edgeInfo.Factor, otherWeight.Factor);
+            return _configuration.TurnCost * Math.Min(edgeInfo.Factor, otherInfo.Factor);
         }
 
         private double EdgeCost(EdgeInfo info)
@@ -950,8 +975,9 @@ namespace Elements.Spatial.AdaptiveGrid
             {
                 foreach(var hint in hints)
                 {
+                    var influenceDistance = Math.Max(hint.InfluenceDistance, _grid.Tolerance);
                     var target = hint.Is2D ? new Vector3(v.X, v.Y) : v;
-                    if (target.DistanceTo(hint.Polyline) < hint.InfluenceDistance)
+                    if (target.DistanceTo(hint.Polyline) <= influenceDistance)
                     {
                         return true;
                     }
@@ -968,6 +994,7 @@ namespace Elements.Spatial.AdaptiveGrid
 
         private bool IsAffectedBy(Vector3 start, Vector3 end, RoutingHintLine hint)
         {
+            var influenceDistance = Math.Max(hint.InfluenceDistance, _grid.Tolerance);
             Vector3 vs = hint.Is2D ? new Vector3(start.X, start.Y) : start;
             Vector3 ve = hint.Is2D ? new Vector3(end.X, end.Y) : end;
             //Vertical edges are not affected by 2D hint lines
@@ -985,12 +1012,12 @@ namespace Elements.Spatial.AdaptiveGrid
                         continue;
                     }
 
-                    if (vs.DistanceTo(segment) < hint.InfluenceDistance)
+                    if (vs.DistanceTo(segment) <= influenceDistance)
                     {
                         lowClosest = 0;
                     }
 
-                    if (ve.DistanceTo(segment) < hint.InfluenceDistance)
+                    if (ve.DistanceTo(segment) <= influenceDistance)
                     {
                         hiClosest = 1;
                     }
@@ -1003,7 +1030,7 @@ namespace Elements.Spatial.AdaptiveGrid
                     var edgeLine = new Line(vs, ve);
                     Action<Vector3> check = (Vector3 p) =>
                     {
-                        if (p.DistanceTo(edgeLine, out var closest) < hint.InfluenceDistance)
+                        if (p.DistanceTo(edgeLine, out var closest) <= influenceDistance)
                         {
                             var t = (closest - vs).Length() / edgeLine.Length();
                             if (t < lowClosest)
@@ -1021,21 +1048,14 @@ namespace Elements.Spatial.AdaptiveGrid
                     check(segment.Start);
                     check(segment.End);
 
-                    var minResulution = Math.Max(_grid.Tolerance, hint.InfluenceDistance);
                     if (hiClosest > lowClosest &&
-                        (hiClosest - lowClosest) * edgeLine.Length() > minResulution)
+                        (hiClosest - lowClosest) * edgeLine.Length() > influenceDistance)
                     {
                         return true;
                     }
                 }
             }
             return false;
-        }
-
-        private bool OnMainLayer(Vertex v0, Vertex v1)
-        {
-            return Math.Abs(v0.Point.Z - _configuration.MainLayer) < _grid.Tolerance &&
-                   Math.Abs(v1.Point.Z - _configuration.MainLayer) < _grid.Tolerance;
         }
 
         private void Compare(ulong index, IDictionary<ulong, double> travelCost,

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -462,9 +462,9 @@ namespace Elements.Spatial.AdaptiveGrid
                     double modifierFactor = ModifierFactor(v0, v1);
 
                     //TODO: consider unifying hint line, offset line and modifiers as single concept.
-                    //There still be functions for adding hint/offset lines but everything will be processes inside
-                    //as WeightModifier. Would need to solve function that takes list of groups and define how
-                    //multiply factors are combined together: by choosing one, combining, etc.
+                    //There will still be functions for adding hint/offset lines but everything will be processed inside
+                    //as WeightModifier. We would need to decide on the function that takes a list of these weight modifier
+                    //groups and defines how multiple factors are combined together: by choosing one, combining, etc.
                     if (hintLines != null && hintLines.Any())
                     {
                         foreach (var l in hintLines)

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -451,6 +451,10 @@ namespace Elements.Spatial.AdaptiveGrid
                     double offsetFactor = 1;
                     double modifierFactor = ModifierFactor(v0, v1);
 
+                    //TODO: consider unifying hint line, offset line and modifiers as single concept.
+                    //There still be functions for adding hint/offset lines but everything will be processes inside
+                    //as WeightModifier. Would need to solve function that takes list of groups and define how
+                    //multiply factors are combined together: by choosing one, combining, etc.
                     if (hintLines != null && hintLines.Any())
                     {
                         foreach (var l in hintLines)
@@ -463,6 +467,7 @@ namespace Elements.Spatial.AdaptiveGrid
                                 if (l.UserDefined)
                                 {
                                     hintFactor = Math.Min(l.Factor, hintFactor);
+                                    //Store the information if the edge was affected by 2D and (or) 3D hint line. 
                                     flags &= l.Is2D ? EdgeFlags.Hint2D : EdgeFlags.Hint3D;
                                 }
                                 else
@@ -810,15 +815,15 @@ namespace Elements.Spatial.AdaptiveGrid
             //This prevents "free to travel" loops under 2d hint lines.
             //If either of two edges are affected by 3d hint line - turn cost can be 
             //discounted but still can't be bigger than TurnCost.
-            if (edgeInfo.HasFlag(EdgeFlags.HasVerticalChange) ||
-                otherInfo.HasFlag(EdgeFlags.HasVerticalChange))
+            if (edgeInfo.HasAnyFlag(EdgeFlags.HasVerticalChange) ||
+                otherInfo.HasAnyFlag(EdgeFlags.HasVerticalChange))
             {
                 var factor = 1d;
-                if (edgeInfo.HasFlag(EdgeFlags.Hint3D))
+                if (edgeInfo.HasAnyFlag(EdgeFlags.Hint3D))
                 {
                     factor = Math.Min(edgeInfo.Factor, 1);
                 }
-                else if (otherInfo.HasFlag(EdgeFlags.Hint3D))
+                else if (otherInfo.HasAnyFlag(EdgeFlags.Hint3D))
                 {
                     factor = Math.Min(otherInfo.Factor, 1);
                 }

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRoutingWeightModifier.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRoutingWeightModifier.cs
@@ -52,45 +52,44 @@ namespace Elements.Spatial.AdaptiveGrid
         }
 
         /// <summary>
-        /// Create WeightModifier that sets factor to all edges lying on given plane.
+        /// Create WeightModifier that sets factor on all edges lying on a given plane.
         /// </summary>
         /// <param name="name">Name of new WeightModifier.</param>
         /// <param name="plane">Plane to check if edge lays on.</param>
         /// <param name="factor">Factor of new WeightModifier.</param>
         /// <returns>Created WeightModifier.</returns>
-        public WeightModifier AddPlaneModifier(string name, Plane plane, double factor)
+        public WeightModifier AddPlanarWeightModifier(string name, Plane plane, double factor)
         {
             var modifier = new WeightModifier(
                 name,
                 new Func<Vertex, Vertex, bool>((a, b) =>
                 {
-                    return plane.SignedDistanceTo(a.Point) > _grid.Tolerance ||
-                           plane.SignedDistanceTo(b.Point) > _grid.Tolerance;
+                    return Math.Abs(plane.SignedDistanceTo(a.Point)) < _grid.Tolerance &&
+                           Math.Abs(plane.SignedDistanceTo(b.Point)) < _grid.Tolerance;
                 }),
                 factor);
             AddWeightModifier(modifier);
             return modifier;
         }
 
+        /// <summary>
+        /// Check if edge passes any modifier check and return the lowest value among them.
+        /// Returns 1 if no modifiers applied.
+        /// </summary>
+        /// <param name="a">Start Vertex</param>
+        /// <param name="b">End Vertex</param>
         private double ModifierFactor(Vertex a, Vertex b)
         {
-            double modifierFactor = -1;
+            double modifierFactor = double.MaxValue;
             foreach (var modifier in _weightModifiers)
             {
                 if (modifier.Value.Condition(a, b))
                 {
-                    if (modifierFactor == -1)
-                    {
-                        modifierFactor = modifier.Value.Factor;
-                    }
-                    else
-                    {
-                        modifierFactor = Math.Min(modifierFactor, modifier.Value.Factor);
-                    }
+                    modifierFactor = Math.Min(modifierFactor, modifier.Value.Factor);
                 }
             }
 
-            return modifierFactor != -1 ? modifierFactor : 1;
+            return modifierFactor != double.MaxValue ? modifierFactor : 1;
         }
     }
 }

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRoutingWeightModifier.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRoutingWeightModifier.cs
@@ -1,0 +1,96 @@
+﻿using Elements.Geometry;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elements.Spatial.AdaptiveGrid
+{
+    public partial class AdaptiveGraphRouting
+    {
+        private Dictionary<string, WeightModifier> _weightModifiers =
+            new Dictionary<string, WeightModifier>();
+
+        /// <summary>
+        /// Get WeightModifier with given name.
+        /// </summary>
+        /// <param name="name">Name of WeightModifier.</param>
+        /// <returns>WeightModifier object.</returns>
+        public WeightModifier GetWeightModifier(string name)
+        {
+            if (_weightModifiers.TryGetValue(name, out var modifier))
+            {
+                return modifier;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Add WeightModifier to the dictionary of modifiers.
+        /// </summary>
+        /// <param name="modifier">WeightModifier to add.</param>
+        public void AddWeightModifier(WeightModifier modifier)
+        {
+            _weightModifiers[modifier.Name] = modifier;
+        }
+
+        /// <summary>
+        /// Remove WeightModifier from the dictionary of modifiers.
+        /// </summary>
+        /// <param name="modifier">WeightModifier to remove.</param>
+        /// <returns>False if WeightModifier is not present in the dictionary of modifiers.</returns>
+        public bool RemoveWeightModifier(WeightModifier modifier)
+        {
+            return _weightModifiers.Remove(modifier.Name);
+        }
+
+        /// <summary>
+        /// Remove all WeightModifier from the dictionary of modifiers.
+        /// </summary>
+        public void ClearWeightModifiers()
+        {
+            _weightModifiers.Clear();
+        }
+
+        /// <summary>
+        /// Create WeightModifier that sets factor to all edges lying on given plane.
+        /// </summary>
+        /// <param name="name">Name of new WeightModifier.</param>
+        /// <param name="plane">Plane to check if edge lays on.</param>
+        /// <param name="factor">Factor of new WeightModifier.</param>
+        /// <returns>Created WeightModifier.</returns>
+        public WeightModifier AddPlaneModifier(string name, Plane plane, double factor)
+        {
+            var modifier = new WeightModifier(
+                name,
+                new Func<Vertex, Vertex, bool>((a, b) =>
+                {
+                    return plane.SignedDistanceTo(a.Point) > _grid.Tolerance ||
+                           plane.SignedDistanceTo(b.Point) > _grid.Tolerance;
+                }),
+                factor);
+            AddWeightModifier(modifier);
+            return modifier;
+        }
+
+        private double ModifierFactor(Vertex a, Vertex b)
+        {
+            double modifierFactor = -1;
+            foreach (var modifier in _weightModifiers)
+            {
+                if (modifier.Value.Condition(a, b))
+                {
+                    if (modifierFactor == -1)
+                    {
+                        modifierFactor = modifier.Value.Factor;
+                    }
+                    else
+                    {
+                        modifierFactor = Math.Min(modifierFactor, modifier.Value.Factor);
+                    }
+                }
+            }
+
+            return modifierFactor != -1 ? modifierFactor : 1;
+        }
+    }
+}

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRoutingWeightModifier.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRoutingWeightModifier.cs
@@ -52,7 +52,7 @@ namespace Elements.Spatial.AdaptiveGrid
         }
 
         /// <summary>
-        /// Create WeightModifier that sets factor on all edges lying on a given plane.
+        /// Create WeightModifier that sets the factor on all edges lying on a given plane.
         /// </summary>
         /// <param name="name">Name of new WeightModifier.</param>
         /// <param name="plane">Plane to check if edge lays on.</param>

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRoutingWeightModifier.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRoutingWeightModifier.cs
@@ -73,7 +73,7 @@ namespace Elements.Spatial.AdaptiveGrid
         }
 
         /// <summary>
-        /// Check if edge passes any modifier check and return the lowest value among them.
+        /// Check if edge passes any modifier check and returns the lowest value among them.
         /// Returns 1 if no modifiers applied.
         /// </summary>
         /// <param name="a">Start Vertex</param>

--- a/Elements/src/Spatial/AdaptiveGrid/EdgeFlags.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/EdgeFlags.cs
@@ -20,18 +20,38 @@ namespace Elements.Spatial.AdaptiveGrid
         None = 0,
 
         /// <summary>
-        /// Is edge affected by any 2D hint line.
+        /// Is edge affected by user defined 2D hint line.
         /// </summary>
-        Hint2D = 1,
+        UserDefinedHint2D = 1,
 
         /// <summary>
-        /// Is edge affected by any 3D hint line.
+        /// Is edge affected by user defined 3D hint line.
         /// </summary>
-        Hint3D = 2,
+        UserDefinedHint3D = 2,
+
+        /// <summary>
+        /// Is edge affected by hidden 2D hint line.
+        /// </summary>
+        HiddenHint2D = 4,
+
+        /// <summary>
+        /// Is edge affected by hidden 2D hint line.
+        /// </summary>
+        HiddenHint3D = 8,
+
+        /// <summary>
+        /// Is edge affected by hidden hint line.
+        /// </summary>
+        UserDefinedHint = UserDefinedHint2D | UserDefinedHint3D,
+
+        /// <summary>
+        /// Is edge affected by hidden hint line.
+        /// </summary>
+        HiddenHint = HiddenHint2D | HiddenHint3D,
 
         /// <summary>
         /// Are edge end points on different elevations.
         /// </summary>
-        HasVerticalChange = 4
+        HasVerticalChange = 16
     }
 }

--- a/Elements/src/Spatial/AdaptiveGrid/EdgeFlags.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/EdgeFlags.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elements.Spatial.AdaptiveGrid
+{
+    /// <summary>
+    /// Bit set of flags storing describing information about edge.
+    /// Each flag is set to it's own number - power of 2, so they can be safely combined.
+    /// Use | or |= to combine flags: flag = Hint2D | HasVerticalChange = 1 + 4 = 001 + 100 = 101 = 5.
+    /// Use & or &= to check of one or more flags: flags & Hint3D == 101 & 010 == 0 == None, but 
+    /// but flags & Hint2D == 101 & 001 == 001 == Hint2D.
+    /// </summary>
+    [Flags]
+    public enum EdgeFlags
+    {
+        /// <summary>
+        /// No flags set.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Is edge affected by any 2D hint line.
+        /// </summary>
+        Hint2D = 1,
+
+        /// <summary>
+        /// Is edge affected by any 3D hint line.
+        /// </summary>
+        Hint3D = 2,
+
+        /// <summary>
+        /// Are edge end points on different elevations.
+        /// </summary>
+        HasVerticalChange = 4
+    }
+}

--- a/Elements/src/Spatial/AdaptiveGrid/EdgeFlags.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/EdgeFlags.cs
@@ -5,10 +5,10 @@ using System.Text;
 namespace Elements.Spatial.AdaptiveGrid
 {
     /// <summary>
-    /// Bit set of flags storing describing information about edge.
+    /// Bit set of flags storing information about edge.
     /// Each flag is set to it's own number - power of 2, so they can be safely combined.
     /// Use | or |= to combine flags: flag = Hint2D | HasVerticalChange = 1 + 4 = 001 + 100 = 101 = 5.
-    /// Use & or &= to check of one or more flags: flags & Hint3D == 101 & 010 == 0 == None, but 
+    /// Use & or &= to check of one or more flags: flags & Hint3D == 101 & 010 == 0 == None,
     /// but flags & Hint2D == 101 & 001 == 001 == Hint2D.
     /// </summary>
     [Flags]

--- a/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
@@ -57,43 +57,29 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// Additional information about the edge.
         /// </summary>
-        public EdgeFlags Flags;
+        internal EdgeFlags Flags;
 
         /// <summary>
-        /// Check if edge info has certain flag or combination of flags set.
+        /// Check if edge info has a certain flag or combination of flags set.
         /// </summary>
-        /// <param name="flag">Flag or combination of flags to check.</param>
+        /// <param name="flag">Flag or combination of flags to check.
+        /// For example: HasFlag(Hint2D) or HasFlag(Hint2D | Hint3D).</param>
         /// <returns>True if edge have the flag included.</returns>
-        public bool HasFlag(EdgeFlags flag)
+        public bool HasAnyFlag(EdgeFlags flag)
         {
             return (Flags & flag) != EdgeFlags.None;
         }
-    }
-
-    /// <summary>
-    /// Bit set of flags storing describing information about edge.
-    /// </summary>
-    [Flags]
-    public enum EdgeFlags
-    {
-        /// <summary>
-        /// No flags set.
-        /// </summary>
-        None = 0,
-        
-        /// <summary>
-        /// Is edge affected by any 2D hint line.
-        /// </summary>
-        Hint2D = 1,
 
         /// <summary>
-        /// Is edge affected by any 3D hint line.
+        /// Add a flag or combinations of flags. 
+        /// Adding a flag more than once has no effect.
         /// </summary>
-        Hint3D = 2,
-
-        /// <summary>
-        /// Are edge end points on different elevations.
-        /// </summary>
-        HasVerticalChange = 4 
+        /// <param name="flags">Flag or combination of flags to add.</param>
+        /// For example: AddFlags(Hint2D) or AddFlags(Hint2D | Hint3D).</param>
+        /// <returns></returns>
+        public void AddFlags(EdgeFlags flags)
+        {
+            Flags |= flags;
+        }
     }
 }

--- a/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
@@ -63,7 +63,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// Check if edge info has a certain flag or combination of flags set.
         /// </summary>
         /// <param name="flag">Flag or combination of flags to check.
-        /// For example: HasFlag(Hint2D) or HasFlag(Hint2D | Hint3D).</param>
+        /// For example: HasAnyFlag(Hint2D) or HasAnyFlag(Hint2D | Hint3D).</param>
         /// <returns>True if edge have the flag included.</returns>
         public bool HasAnyFlag(EdgeFlags flag)
         {

--- a/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
@@ -23,7 +23,14 @@ namespace Elements.Spatial.AdaptiveGrid
             var vector = (v1.Point - v0.Point);
             Length = vector.Length();
             Factor = factor;
-            HasVerticalChange = Math.Abs(v0.Point.Z - v1.Point.Z) > grid.Tolerance;
+            HasVerticalChange = false;
+            Flags = EdgeFlags.None;
+
+            if (Math.Abs(v0.Point.Z - v1.Point.Z) > grid.Tolerance)
+            {
+                Flags &= EdgeFlags.HasVerticalChange;
+                HasVerticalChange = true;
+            }
         }
 
         /// <summary>
@@ -44,6 +51,49 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// Are edge end points on different elevations.
         /// </summary>
+        [Obsolete("Use HasFlag(EdgeFlags.HasVerticalChange) instead")]
         public readonly bool HasVerticalChange;
+
+        /// <summary>
+        /// Additional information about the edge.
+        /// </summary>
+        public EdgeFlags Flags;
+
+        /// <summary>
+        /// Check if edge info has certain flag or combination of flags set.
+        /// </summary>
+        /// <param name="flag">Flag or combination of flags to check.</param>
+        /// <returns>True if edge have the flag included.</returns>
+        public bool HasFlag(EdgeFlags flag)
+        {
+            return (Flags & flag) != EdgeFlags.None;
+        }
+    }
+
+    /// <summary>
+    /// Bit set of flags storing describing information about edge.
+    /// </summary>
+    [Flags]
+    public enum EdgeFlags
+    {
+        /// <summary>
+        /// No flags set.
+        /// </summary>
+        None = 0,
+        
+        /// <summary>
+        /// Is edge affected by any 2D hint line.
+        /// </summary>
+        Hint2D = 1,
+
+        /// <summary>
+        /// Is edge affected by any 3D hint line.
+        /// </summary>
+        Hint3D = 2,
+
+        /// <summary>
+        /// Are edge end points on different elevations.
+        /// </summary>
+        HasVerticalChange = 4 
     }
 }

--- a/Elements/src/Spatial/AdaptiveGrid/RoutingConfiguration.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/RoutingConfiguration.cs
@@ -13,8 +13,8 @@ namespace Elements.Spatial.AdaptiveGrid
         /// Construct new RoutingConfiguration structure.
         /// </summary>
         /// <param name="turnCost">Travel cost penalty if route changes it's direction.</param>
-        /// <param name="mainLayer">Elevation at which route prefers to travel.</param>
-        /// <param name="layerPenalty">Penalty if route travels through an elevation different from MainLayer.</param>
+        /// <param name="mainLayer">OBSOLETE. Elevation at which route prefers to travel.</param>
+        /// <param name="layerPenalty">OBSOLETE. Penalty if route travels through an elevation different from MainLayer.</param>
         /// <param name="supportedAngles">List of angles route can turn.</param>
         public RoutingConfiguration(double turnCost = 0,
                                     double mainLayer = 0,
@@ -39,11 +39,13 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// Elevation at which route prefers to travel.
         /// </summary>
+        [Obsolete("Use WeightModified instead")]
         public readonly double MainLayer;
 
         /// <summary>
         /// Travel cost penalty if route travels through an elevation different from MainLayer.
         /// </summary>
+        [Obsolete("Use WeightModified instead")]
         public readonly double LayerPenalty;
 
         /// <summary>

--- a/Elements/src/Spatial/AdaptiveGrid/WeightModifier.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/WeightModifier.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elements.Spatial.AdaptiveGrid
+{
+    /// <summary>
+    /// Object that hold function that allows to apply factor multiplier to edge travel cost.
+    /// If edge passes check of several WeightModifier objects - lowest factor is chosen.
+    /// </summary>
+    public class WeightModifier
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="condition"></param>
+        /// <param name="factor"></param>
+        public WeightModifier(string name, Func<Vertex, Vertex, bool> condition, double factor)
+        {
+            Name = name;
+            Condition = condition;
+            Factor = factor;
+        }
+
+        /// <summary>
+        ///  WeightModifier description.
+        /// </summary>
+        public readonly string Name;
+
+        /// <summary>
+        /// Function, edge need to pass, can include additional data, captured by lambda.
+        /// </summary>
+        public Func<Vertex, Vertex, bool> Condition;
+
+        /// <summary>
+        /// Multiplier number that is applied to edge traveling cost.
+        /// </summary>
+        public double Factor;
+    }
+}

--- a/Elements/src/Spatial/AdaptiveGrid/WeightModifier.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/WeightModifier.cs
@@ -5,17 +5,17 @@ using System.Text;
 namespace Elements.Spatial.AdaptiveGrid
 {
     /// <summary>
-    /// Object that hold function that allows to apply factor multiplier to edge travel cost.
-    /// If edge passes check of several WeightModifier objects - lowest factor is chosen.
+    /// Object that lets you apply an edge weight factor to edges that meet a Condition filter function.
+    /// If an edge meets the nameof(Condition) of several WeightModifier objects the lowest factor is chosen.
     /// </summary>
     public class WeightModifier
     {
         /// <summary>
-        /// 
+        /// Basic constructor for a WeightModifier
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="condition"></param>
-        /// <param name="factor"></param>
+        /// <param name="name">Name of the modifier.</param>
+        /// <param name="condition">Filter function.</param>
+        /// <param name="factor">Weight to be applied.</param>
         public WeightModifier(string name, Func<Vertex, Vertex, bool> condition, double factor)
         {
             Name = name;
@@ -24,17 +24,17 @@ namespace Elements.Spatial.AdaptiveGrid
         }
 
         /// <summary>
-        ///  WeightModifier description.
+        ///  WeightModifier name.
         /// </summary>
         public readonly string Name;
 
         /// <summary>
-        /// Function, edge need to pass, can include additional data, captured by lambda.
+        /// Filter function that the determines if this WeightModifier applies to an edge.
         /// </summary>
         public Func<Vertex, Vertex, bool> Condition;
 
         /// <summary>
-        /// Multiplier number that is applied to edge traveling cost.
+        /// Weight to be applied according to this WeightModifier.
         /// </summary>
         public double Factor;
     }

--- a/Elements/src/Spatial/AdaptiveGrid/WeightModifier.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/WeightModifier.cs
@@ -6,7 +6,7 @@ namespace Elements.Spatial.AdaptiveGrid
 {
     /// <summary>
     /// Object that lets you apply an edge weight factor to edges that meet a Condition filter function.
-    /// If an edge meets the nameof(Condition) of several WeightModifier objects the lowest factor is chosen.
+    /// If an edge meets the condition of several WeightModifier objects the lowest factor is chosen.
     /// </summary>
     public class WeightModifier
     {
@@ -29,7 +29,7 @@ namespace Elements.Spatial.AdaptiveGrid
         public readonly string Name;
 
         /// <summary>
-        /// Filter function that the determines if this WeightModifier applies to an edge.
+        /// Filter function that determines if this WeightModifier applies to an edge.
         /// </summary>
         public Func<Vertex, Vertex, bool> Condition;
 

--- a/Elements/test/AdaptiveGraphRoutingTests.cs
+++ b/Elements/test/AdaptiveGraphRoutingTests.cs
@@ -187,6 +187,7 @@ namespace Elements.Tests
         [Fact]
         public void AdaptiveGraphRoutingGeneralTest()
         {
+            double mainLayer = 2;
             Polygon mainRegionBoundary = new Polygon(new List<Vector3>()
             {
                 new Vector3(0, 0, 1),
@@ -202,9 +203,6 @@ namespace Elements.Tests
                 new Vector3(10, 10, 3),
                 new Vector3(0, 10, 3)
             });
-
-            var configuration = new RoutingConfiguration(
-                turnCost: 1, mainLayer: 2, layerPenalty: 2);
 
             var inputPoints = new List<Vector3>()
             {
@@ -228,7 +226,7 @@ namespace Elements.Tests
 
             });
             keyPoints.AddRange(hintPolyline.Vertices.Select(
-                v => new Vector3(v.X, v.Y, configuration.MainLayer)));
+                v => new Vector3(v.X, v.Y, mainLayer)));
 
             var offsetPolyline = new Polyline(new List<Vector3>()
             {
@@ -237,7 +235,7 @@ namespace Elements.Tests
                 new Vector3(5, 10)
             });
             keyPoints.AddRange(offsetPolyline.Vertices.Select(
-                v => new Vector3(v.X, v.Y, configuration.MainLayer)));
+                v => new Vector3(v.X, v.Y, mainLayer)));
 
             var hints = new List<RoutingHintLine>();
             hints.Add(new RoutingHintLine(hintPolyline, 
@@ -254,7 +252,7 @@ namespace Elements.Tests
             grid.AddFromPolygon(auxilaryRegionBoundary, keyPoints);
             foreach (var input in inputPoints)
             {
-                var p = new Vector3(input.X, input.Y, configuration.MainLayer);
+                var p = new Vector3(input.X, input.Y, mainLayer);
                 Assert.True(grid.TryGetVertexIndex(p, out ulong down, grid.Tolerance));
                 grid.AddVertex(input, new ConnectVertexStrategy(grid.GetVertex(down)));
             }
@@ -271,7 +269,14 @@ namespace Elements.Tests
 
             Assert.True(grid.TryGetVertexIndex(tailPoint, out ulong tailVertex, grid.Tolerance));
 
+            var configuration = new RoutingConfiguration(turnCost: 1);
             AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, configuration);
+            var func = new Func<Vertex, Vertex, bool>((a, b) =>
+            {
+                return Math.Abs(a.Point.Z - mainLayer) > grid.Tolerance ||
+                       Math.Abs(b.Point.Z - mainLayer) > grid.Tolerance;
+            });
+            alg.AddWeightModifier(new WeightModifier("Not Main Layer", func, 2));
             var tree = alg.BuildSpanningTree(inputVertices, tailVertex, hints, TreeOrder.ClosestToFurthest);
 
             List<Vector3> expectedPath = new List<Vector3>()
@@ -1076,8 +1081,14 @@ namespace Elements.Tests
             grid.InsertSnapshot(snapshot, new Transform(0, 0, -1), true);
 
 
-            var c = new RoutingConfiguration(turnCost: 1, layerPenalty: 2);
+            var c = new RoutingConfiguration(turnCost: 1);
             var routing = new AdaptiveGraphRouting(grid, c);
+            var func = new Func<Vertex, Vertex, bool>((a, b) =>
+            {
+                return Math.Abs(a.Point.Z) > grid.Tolerance ||
+                       Math.Abs(b.Point.Z) > grid.Tolerance;
+            });
+            routing.AddWeightModifier(new WeightModifier("Not Main Layer", func, 2));
             routing.AddRoutingFilter((Vertex start, Vertex end) => start.Point.Z > end.Point.Z - Vector3.EPSILON);
             Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0, 5), out var inputId0, grid.Tolerance));
             Assert.True(grid.TryGetVertexIndex(new Vector3(5, 0, 5), out var inputId1, grid.Tolerance));
@@ -1219,6 +1230,60 @@ namespace Elements.Tests
             Assert.Single(alg.ErrorMessages);
             var filtered = alg.ErrorMessages.Where(e => e.MessageText.Contains(id4.ToString())).First();
             Assert.Contains("filter", filtered.MessageText);
+        }
+
+        [Fact]
+        public void AdaptiveGraphRoutingWeightModifier()
+        {
+            var grid = new AdaptiveGrid();
+            var keyPoints = Enumerable.Range(1, 9).Select(i => new Vector3(i, i));
+            grid.AddFromPolygon(Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10)),
+                                keyPoints);
+
+            Assert.True(grid.TryGetVertexIndex(new Vector3(2, 5), out var start, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(8, 5), out var end, grid.Tolerance));
+            
+            //Remove alternative route with the same best cost.
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 7), out var v, grid.Tolerance));
+            foreach (var e in grid.GetVertex(v).Edges.ToList())
+            {
+                grid.RemoveEdge(e);
+            }
+
+            var alg = new AdaptiveGraphRouting(grid, new RoutingConfiguration(turnCost: 1));
+            var center = new Vector3(5, 5);
+
+            //Add WeightModifier that wants you to travel through edges not to close and not to far.
+            alg.AddWeightModifier(new WeightModifier(
+                "Test",
+                new Func<Vertex, Vertex, bool>((a, b) =>
+                {
+                    return a.Point.DistanceTo(center) <= 1 || b.Point.DistanceTo(center) <= 1 ||
+                           a.Point.DistanceTo(center) >= 3.5 || b.Point.DistanceTo(center) >= 3.5;
+                }), 
+                10));
+
+            var tree = alg.BuildSpanningTree(
+                new List<RoutingVertex>() { new RoutingVertex(start, 0) },
+                end,
+                new List<RoutingHintLine>(),
+                TreeOrder.ClosestToFurthest);
+
+            var expectedPath = new List<Vector3>()
+            {
+                new Vector3(2, 5),
+                new Vector3(3, 5),
+                new Vector3(3, 4),
+                new Vector3(3, 3),
+                new Vector3(4, 3),
+                new Vector3(5, 3),
+                new Vector3(6, 3),
+                new Vector3(7, 3),
+                new Vector3(7, 4),
+                new Vector3(7, 5),
+                new Vector3(8, 5)
+            };
+            CheckTree(grid, start, tree, expectedPath);
         }
 
         private void VisualizeRoutingTree(

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -1084,11 +1084,11 @@ namespace Elements.Tests
             var polygon = Polygon.Rectangle(Vector3.Origin, new Vector3(10, 10));
             grid.AddFromPolygon(polygon, new List<Vector3>() { new Vector3(5, 5) });
             EdgeInfo info = new EdgeInfo(grid, grid.GetEdges().First());
-            info.AddFlags(EdgeFlags.Hint2D | EdgeFlags.HasVerticalChange);
+            info.AddFlags(EdgeFlags.UserDefinedHint2D | EdgeFlags.HasVerticalChange);
             Assert.True(info.HasAnyFlag(EdgeFlags.HasVerticalChange));
-            Assert.True(info.HasAnyFlag(EdgeFlags.Hint2D));
-            Assert.False(info.HasAnyFlag(EdgeFlags.Hint3D));
-            Assert.True(info.HasAnyFlag(EdgeFlags.Hint2D | EdgeFlags.Hint3D));
+            Assert.True(info.HasAnyFlag(EdgeFlags.UserDefinedHint2D));
+            Assert.False(info.HasAnyFlag(EdgeFlags.UserDefinedHint3D));
+            Assert.True(info.HasAnyFlag(EdgeFlags.UserDefinedHint2D | EdgeFlags.UserDefinedHint3D));
         }
 
         //          (4)

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -1077,6 +1077,20 @@ namespace Elements.Tests
             Assert.Contains(new Vector3(10, 5, 4), neighbourPoints);
         }
 
+        [Fact]
+        public void EdgeInfoFlagsTest()
+        {
+            AdaptiveGrid grid = new AdaptiveGrid();
+            var polygon = Polygon.Rectangle(Vector3.Origin, new Vector3(10, 10));
+            grid.AddFromPolygon(polygon, new List<Vector3>() { new Vector3(5, 5) });
+            EdgeInfo info = new EdgeInfo(grid, grid.GetEdges().First());
+            info.AddFlags(EdgeFlags.Hint2D | EdgeFlags.HasVerticalChange);
+            Assert.True(info.HasAnyFlag(EdgeFlags.HasVerticalChange));
+            Assert.True(info.HasAnyFlag(EdgeFlags.Hint2D));
+            Assert.False(info.HasAnyFlag(EdgeFlags.Hint3D));
+            Assert.True(info.HasAnyFlag(EdgeFlags.Hint2D | EdgeFlags.Hint3D));
+        }
+
         //          (4)
         //         /   \
         //        /     \


### PR DESCRIPTION
BACKGROUND:
- Support of 3D routing required more flexible way to set weight modifiers to regions of the grid instead of just main layer and penalty.

DESCRIPTION:
- Added WeightModifier object that hold function that allows to apply factor multiplier to edge travel cost.
If edge passes check of several WeightModifier objects - lowest factor is chosen.
- Added Flags field to EdgeInfo to hold additional information, like is edge used by and hint line, without inflating object size too much.

TESTING:
- Added AdaptiveGraphRoutingWeightModifier test.
  
FUTURE WORK:
- 3D routing is complex topic so code can still undergo changes.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Not sure if we need marking code "Obsolete". Let me know if I just need to remove it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/920)
<!-- Reviewable:end -->
