### PR TITLE
Switch to the metal roughness model for glTF.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ### Fixed
 
 - Fix `Obstacle.FromLine` if line is vertical and start point is positioned higher than end.
+- Materials exported to glTF now have their `RoughnessFactor` set correctly.
+- Materials exported to glTF no longer use the `KHR_materials_pbrSpecularGlossiness` extension, as this extension is being sunset in favor of `KHR_materials_specular` and `KHR_materials_ior`.
 
 ## 1.3.0
 

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -200,7 +200,8 @@ namespace Elements.Serialization.glTF
                 gltfMaterial.PbrMetallicRoughness = new MaterialPbrMetallicRoughness
                 {
                     BaseColorFactor = material.Color.ToArray(true),
-                    MetallicFactor = 1.0f
+                    MetallicFactor = 1.0f,
+                    RoughnessFactor = 1.0f - (float)material.GlossinessFactor
                 };
                 gltfMaterial.DoubleSided = material.DoubleSided;
 

--- a/Elements/test/MaterialTests.cs
+++ b/Elements/test/MaterialTests.cs
@@ -1,5 +1,6 @@
 using Elements.Geometry;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Color = Elements.Geometry.Color;
@@ -20,28 +21,43 @@ namespace Elements.Tests
             var specularFactor = 0.0;
             var glossinessFactor = 0.0;
 
-            var rectangle = Polygon.Rectangle(0.5, 0.5);
+            var textData = new List<(Vector3, Vector3, Vector3, string, Color?)>();
+
+            var sphere = Mesh.Sphere(0.5, 20);
 
             for (var r = 0.0; r <= 1.0; r += 0.2)
             {
                 for (var g = 0.0; g <= 1.0; g += 0.2)
                 {
+                    if (r == 0)
+                    {
+                        textData.Add((new Vector3(-1.5, y), Vector3.ZAxis, Vector3.XAxis, $"roughness: {1 - glossinessFactor:f2}", Colors.Black));
+                    }
+                    if (g == 0)
+                    {
+                        textData.Add((new Vector3(x, -1), Vector3.ZAxis, Vector3.XAxis, $"specular: {specularFactor:f2}", Colors.Black));
+                    }
                     for (var b = 0.0; b <= 1.0; b += 0.2)
                     {
-                        var color = new Color(r, g, b, 1.0);
+                        var color = new Color(r, g, b, 1 - b);
+                        if (r == 1.0 && g == 0.0)
+                        {
+                            textData.Add((new Vector3(x + 1.5, y, z), Vector3.YAxis.Negate(), Vector3.XAxis, $"alpha: {color.Alpha:f2}", Colors.Black));
+                        }
                         var material = new Material($"{r}_{g}_{b}", color, specularFactor, glossinessFactor);
-                        var mass = new Mass(rectangle, 0.5, material, new Transform(new Vector3(x, y, z)));
-                        this.Model.AddElement(mass);
+                        Model.AddElement(new MeshElement(sphere, new Transform(new Vector3(x, y, z)), material));
                         z += 2.0;
                     }
                     z = 0;
                     y += 2.0;
+                    glossinessFactor += 0.2;
                 }
+                glossinessFactor = 0.0;
                 y = 0;
                 x += 2.0;
                 specularFactor += 0.2;
-                glossinessFactor += 0.2;
             }
+            Model.AddElement(new ModelText(textData, FontSize.PT72));
             // </example>
         }
 


### PR DESCRIPTION
BACKGROUND:
When integrating the three gpu path tracer in Hypar, I noticed that materials were overly reflective. After opening https://github.com/gkjohnson/three-gpu-pathtracer/issues/310, I was informed that the extension we have used previously, `KHR_materials_pbrSpecularGlossiness` is being "archived" in favor of newer extensions.

DESCRIPTION:
This PR updates our glTF serialization to support `KHR_materials_specular` and `KHR_materials_ior`, with conversions as noted in https://github.com/donmccurdy/glTF-Transform/blob/d77ca6a12c5b56efa1b6594806450dd38df19b25/packages/functions/src/metal-rough.ts

TESTING:
Run a test and export a glTF file. The results should look very similar. I've exported several glTF's and run them through Don McCurdy's viewer and they pass all validation and look correct. I've updated the Materials example to indicated roughness and specularity.

Here it is in Don McCurdy's viewer (latest three):
![image](https://user-images.githubusercontent.com/1139788/204639085-7973d743-365e-405c-9a3e-d4aee7a1b25a.png)

Here it is in Hypar (note: different HDRI environments are used)
![image](https://user-images.githubusercontent.com/1139788/204640205-c441bb4f-5a30-4941-8fbb-a76af72229ce.png)

FUTURE WORK:
- The `Material` class should be updated with properties that align with the metallic roughness model.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/921)
<!-- Reviewable:end -->
