### PR TITLE
Fix regression in AdaptiveGraphRouting.RenderElements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - Remove the BBox3 validator.
 - `RoutingConfiguration.MainLayer` and `RoutingConfiguration.LayerPenalty` are set obsolete.
 - `EdgeInfo.HasVerticalChange` is set obsolete.
+- `AdaptiveGraphRouting.RenderElements` is no longer paint hint lines in two different colors. Instead regular edges are paint into three groups. Weights are included to additional properties of produced elements. 
+
 
 ### Fixed
 


### PR DESCRIPTION
BACKGROUND:
- After recent changes to AdaptiveGraphRouting RenderElements function stopped assigning colors to ModelLine objects.

DESCRIPTION:
- Fix wrong assignment of EdgeFlag flags.
- Removed coloring main/non main layer since main layer is obsolete.
- Instead color user/offset hint lines and and divide regular edges into groups with weights < 1, near 1 and > 1.

TESTING:
- All test are passing.
  
REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/924)
<!-- Reviewable:end -->
