### PR TITLE
EdgeInfo.Flags hotfix

### DIFF
--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -992,12 +992,6 @@ namespace Elements.Spatial.AdaptiveGrid
             return false;
         }
 
-        private bool IsAffectedBy(
-            Vector3 start, Vector3 end, IEnumerable<RoutingHintLine> hints)
-        {
-            return hints != null && hints.Any(h => IsAffectedBy(start, end, h));
-        }
-
         private bool IsAffectedBy(Vector3 start, Vector3 end, RoutingHintLine hint)
         {
             var influenceDistance = Math.Max(hint.InfluenceDistance, _grid.Tolerance);

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -478,7 +478,7 @@ namespace Elements.Spatial.AdaptiveGrid
                     }
 
                     var info = new EdgeInfo(_grid, e, hintFactor * offsetFactor * modifierFactor);
-                    info.Flags = flags;
+                    info.AddFlags(flags);
                     weights[e.Id] = info;
                 }
             }

--- a/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
@@ -51,7 +51,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// Are edge end points on different elevations.
         /// </summary>
-        [Obsolete("Use HasFlag(EdgeFlags.HasVerticalChange) instead")]
+        [Obsolete("Use HasAnyFlag(EdgeFlags.HasVerticalChange) instead")]
         public readonly bool HasVerticalChange;
 
         /// <summary>

--- a/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
@@ -28,7 +28,7 @@ namespace Elements.Spatial.AdaptiveGrid
 
             if (Math.Abs(v0.Point.Z - v1.Point.Z) > grid.Tolerance)
             {
-                Flags &= EdgeFlags.HasVerticalChange;
+                Flags |= EdgeFlags.HasVerticalChange;
                 HasVerticalChange = true;
             }
         }

--- a/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
@@ -57,7 +57,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// Additional information about the edge.
         /// </summary>
-        internal EdgeFlags Flags;
+        private EdgeFlags Flags;
 
         /// <summary>
         /// Check if edge info has a certain flag or combination of flags set.

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -1083,12 +1083,24 @@ namespace Elements.Tests
             AdaptiveGrid grid = new AdaptiveGrid();
             var polygon = Polygon.Rectangle(Vector3.Origin, new Vector3(10, 10));
             grid.AddFromPolygon(polygon, new List<Vector3>() { new Vector3(5, 5) });
-            EdgeInfo info = new EdgeInfo(grid, grid.GetEdges().First());
-            info.AddFlags(EdgeFlags.UserDefinedHint2D | EdgeFlags.HasVerticalChange);
-            Assert.True(info.HasAnyFlag(EdgeFlags.HasVerticalChange));
-            Assert.True(info.HasAnyFlag(EdgeFlags.UserDefinedHint2D));
-            Assert.False(info.HasAnyFlag(EdgeFlags.UserDefinedHint3D));
-            Assert.True(info.HasAnyFlag(EdgeFlags.UserDefinedHint2D | EdgeFlags.UserDefinedHint3D));
+            grid.AddEdge(Vector3.Origin, new Vector3(0, 0, 5));
+
+            grid.TryGetVertexIndex(Vector3.Origin, out var id0);
+            grid.TryGetVertexIndex(new Vector3(0, 0, 5), out var id1);
+            grid.TryGetVertexIndex(new Vector3(0, 5), out var id2);
+
+            var verticalEdge = grid.GetVertex(id0).Edges.First(e => e.StartId == id1 || e.EndId == id1);
+            var horizontalEdge = grid.GetVertex(id0).Edges.First(e => e.StartId == id2 || e.EndId == id2);
+            EdgeInfo verticalEdgeInfo = new EdgeInfo(grid, verticalEdge);
+            EdgeInfo horizontalEdgeInfo = new EdgeInfo(grid, horizontalEdge);
+            Assert.True(verticalEdgeInfo.HasAnyFlag(EdgeFlags.HasVerticalChange));
+            Assert.False(horizontalEdgeInfo.HasAnyFlag(EdgeFlags.HasVerticalChange));
+
+            horizontalEdgeInfo.AddFlags(EdgeFlags.UserDefinedHint2D | EdgeFlags.HasVerticalChange);
+            Assert.True(horizontalEdgeInfo.HasAnyFlag(EdgeFlags.HasVerticalChange));
+            Assert.True(horizontalEdgeInfo.HasAnyFlag(EdgeFlags.UserDefinedHint2D));
+            Assert.False(horizontalEdgeInfo.HasAnyFlag(EdgeFlags.UserDefinedHint3D));
+            Assert.True(horizontalEdgeInfo.HasAnyFlag(EdgeFlags.UserDefinedHint2D | EdgeFlags.UserDefinedHint3D));
         }
 
         //          (4)


### PR DESCRIPTION
BACKGROUND:
- During testing of AdaptiveGraphRouting I have found that HasVerticalChanes flag is set incorrecly.

DESCRIPTION:
- Made EdgeInfo.Flags private.
- Fix wrong usage of bit flag in EdgeInfo constructor.

TESTING:
- Failed case is included into EdgeInfoFlagsTest.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`. (No changes required)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/926)
<!-- Reviewable:end -->
