### PR TITLE
Removed rule exception from `AdaptiveGraphRouting.TurnCost`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `RoutingConfiguration.MainLayer` and `RoutingConfiguration.LayerPenalty` are set obsolete.
 - `EdgeInfo.HasVerticalChange` is set obsolete.
 - `AdaptiveGraphRouting.RenderElements` is no longer paint hint lines in two different colors. Instead regular edges are paint into three groups. Weights are included to additional properties of produced elements.
+- Removed rule exception from `AdaptiveGraphRouting` that prevented vertical edges turn cost being discounter.
 
 
 ### Fixed

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -812,25 +812,8 @@ namespace Elements.Spatial.AdaptiveGrid
             var otherEdge = sharedVertex.GetEdge(thirdVertexId);
             var otherInfo = edgeInfos[otherEdge.Id];
 
-            //Do not modify turn cost if either of edges is not horizontal.
-            //This prevents "free to travel" loops under 2d hint lines.
-            //If either of two edges are affected by 3d hint line - turn cost can be 
-            //discounted but still can't be bigger than TurnCost.
-            if (edgeInfo.HasAnyFlag(EdgeFlags.HasVerticalChange) ||
-                otherInfo.HasAnyFlag(EdgeFlags.HasVerticalChange))
-            {
-                var factor = 1d;
-                if (edgeInfo.HasAnyFlag(EdgeFlags.UserDefinedHint3D))
-                {
-                    factor = Math.Min(edgeInfo.Factor, 1);
-                }
-                else if (otherInfo.HasAnyFlag(EdgeFlags.UserDefinedHint3D))
-                {
-                    factor = Math.Min(otherInfo.Factor, 1);
-                }
-
-                return factor * _configuration.TurnCost;
-            }
+            //TODO: This may lead to almost "free to travel" loops under 2d hint lines,
+            //if vertical edge between elevation is discounted as well.
 
             //Minimum factor makes algorithm prefer edges inside of hint lines even if they
             //have several turns but don't give advantage for the tiny edges that are


### PR DESCRIPTION
BACKGROUND:
- After adding weight modifier to vertical edges, highlighted for changing, it was not working as intended, since vertical edge turns weren't discounter. Routing chose to drop whole path to lower elevation instead of lowering at intended point. 

DESCRIPTION:
- Removed rule exception from `AdaptiveGraphRouting.TurnCost` that prevented vertical edges turn cost being discounter. It was not reliable and worked bad with new concept of weight modifiers.
  
FUTURE WORK:
- If problem of "free to travel" loops under 2d hint lines appears again, new solution should be found.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/929)
<!-- Reviewable:end -->
