### PR TITLE
fix GetCells caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 - `AdaptiveGraphRouting.RenderElements` is no longer paint hint lines in two different colors. Instead regular edges are paint into three groups. Weights are included to additional properties of produced elements.
 - Removed rule exception from `AdaptiveGraphRouting` that prevented vertical edges turn cost being discounter.
 
-
 ### Fixed
 
 - Fix `Obstacle.FromLine` if line is vertical and start point is positioned higher than end.
@@ -31,6 +30,7 @@
 - Materials exported to glTF no longer use the `KHR_materials_pbrSpecularGlossiness` extension, as this extension is being sunset in favor of `KHR_materials_specular` and `KHR_materials_ior`.
 - Gltfs that are merged that require additional extensions will also merge their extensions.
 - Don't try to save test models that have no name, they can interfere with each other because they want to save to the same file.
+- Fixed an issue where `Grid2d.GetCells()` multiple times could fail to return the correct results on subsequent calls, because changes to the axis grids were not invalidating the grid's computed cells.
 
 ## 1.3.0
 

--- a/Elements/src/Spatial/Grid1d.cs
+++ b/Elements/src/Spatial/Grid1d.cs
@@ -32,11 +32,8 @@ namespace Elements.Spatial
             get => cells;
             private set
             {
-                if (this.parent != null)
-                {
-                    //invalidate previously generated 2d grid
-                    parent.TryInvalidateGrid();
-                }
+                //invalidate the 2d grid this belongs to
+                parent?.TryInvalidateGrid();
                 cells = value;
             }
         }
@@ -203,6 +200,7 @@ namespace Elements.Spatial
             this.topLevelParentGrid = topLevelParent;
             this.curve = topLevelParent.curve;
             this.curveDomain = curveDomain;
+            this.parent = topLevelParent.parent;
             Domain = domain;
         }
 
@@ -302,8 +300,13 @@ namespace Elements.Spatial
                         }
                     }
                 }
-            }
 
+                // Direct `set` to the `Cells` property will trigger this
+                // automatically, but in this pathway we also use `Insert`,
+                // `RemoveAt`, `AddRange`, etc, which won't cause the parent to
+                // update, so we call it explicitly here.
+                parent?.TryInvalidateGrid();
+            }
         }
 
         /// <summary>
@@ -397,7 +400,6 @@ namespace Elements.Spatial
             if (Curve is Polyline pl && pl.Segments().Count() > 1)
             {
                 var minDist = Double.MaxValue;
-                Vector3 closestPoint = Vector3.Origin;
                 Line[] segments = pl.Segments();
                 int closestSegment = -1;
                 for (int i = 0; i < segments.Length; i++)
@@ -407,7 +409,6 @@ namespace Elements.Spatial
                     var dist = cp.DistanceTo(point);
                     if (dist < minDist)
                     {
-                        closestPoint = cp;
                         minDist = dist;
                         closestSegment = i;
                     }

--- a/Elements/test/Grid2dTests.cs
+++ b/Elements/test/Grid2dTests.cs
@@ -561,5 +561,26 @@ namespace Elements.Tests
                 Assert.False(c.IsTrimmed());
             }
         }
+
+        [Fact]
+        public void GetCellsDoesntChangeCells()
+        {
+            var grid1 = new Grid2d(Polygon.Rectangle(4, 20));
+            for (int i = 0; i < 10; i++)
+            {
+                grid1.V.SplitAtOffset(i);
+            }
+
+            var grid2 = new Grid2d(Polygon.Rectangle(4, 20));
+            for (int i = 0; i < 10; i++)
+            {
+                grid2.V.SplitAtOffset(i);
+                // it used to be that calling `GetCells` would cause the `Cells`
+                // to be cached, and then it would fail to update after that.
+                // This test ensures that doesn't happen.
+                var cells = grid2.GetCells();
+            }
+            Assert.True(grid1.GetCells().Count() == grid2.GetCells().Count());
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- in `Grid2d`, calling `GetCells` would cause `Cells` to be cached, and changes to child grids like `SplitAtOffset` would not correctly invalidate the cached result.

DESCRIPTION:
- Ensures that all child grid changes invalidate the parent grid2d's computed cells. 

TESTING:
- Added a minimal test, and also ran (but did not commit) the example from @serenayl's code.

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/931)
<!-- Reviewable:end -->
