### PR TITLE
Add `Message.FromCurve` that can take any Curve including Line, Polyline, etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `AdaptiveGraphRouting.AddPlaneModifier(string name, Plane plane, double factor)`
 - `SvgSection.SaveAsSvg`, `SvgSection.SaveAsPdf`
 - `Network.TraverseLeftWithoutLeaves()`
+- `Message.FromCurve`
 
 ### Changed
 
@@ -22,6 +23,7 @@
 - `EdgeInfo.HasVerticalChange` is set obsolete.
 - `AdaptiveGraphRouting.RenderElements` is no longer paint hint lines in two different colors. Instead regular edges are paint into three groups. Weights are included to additional properties of produced elements.
 - Removed rule exception from `AdaptiveGraphRouting` that prevented vertical edges turn cost being discounter.
+- `Message.FromLine` is set obsolete.
 
 ### Fixed
 

--- a/Elements/src/Annotations/Messages.cs
+++ b/Elements/src/Annotations/Messages.cs
@@ -97,6 +97,7 @@ namespace Elements.Annotations
         /// <param name="name">The name given to the message.</param>
         /// <param name="stackTrace">Any stack trace associated with the message.</param>
         /// <returns></returns>
+        [Obsolete("Use FromCurve instead.")]
         public static Message FromLine(string messageText,
                                        Line line,
                                        MessageSeverity severity = MessageSeverity.Warning,
@@ -129,6 +130,36 @@ namespace Elements.Annotations
                                       toPipeLineTransform.Moved(new Vector3(0, 0, -sideLength / 2)),
                                       MaterialForSeverity(severity),
                                       new Representation(new[] { extrude }),
+                                      id: Guid.NewGuid(),
+                                      name: name ?? DefaultName);
+            return message;
+        }
+
+        /// <summary>
+        /// Create a simple message along a curve.
+        /// </summary>
+        /// <param name="messageText">The message to the user.</param>
+        /// <param name="curve"></param>
+        /// <param name="severity">The severity of the message.</param>
+        /// <param name="sideLength"></param>
+        /// <param name="name">The name given to the message.</param>
+        /// <param name="stackTrace">Any stack trace associated with the message.</param>
+        /// <returns></returns>
+        public static Message FromCurve(string messageText,
+                                           Curve curve,
+                                           MessageSeverity severity = MessageSeverity.Warning,
+                                           double sideLength = DefaultSideLength,
+                                           string name = null,
+                                           string stackTrace = null)
+        {
+            var profile = Polygon.Rectangle(sideLength, sideLength);
+            var sweep = new Sweep(profile, curve, 0, 0, 0, false);
+            var message = new Message(messageText,
+                                      stackTrace,
+                                      severity,
+                                      null,
+                                      MaterialForSeverity(severity),
+                                      new Representation(new[] { sweep }),
                                       id: Guid.NewGuid(),
                                       name: name ?? DefaultName);
             return message;


### PR DESCRIPTION

BACKGROUND:
- I needed a way to visualize a warning related to a polyline but there was only a way to do it for a single line. After inspecting the code I realized that one function can handle both line and polyline 
 
DESCRIPTION:
- Added  `Message.FromCurve`: much simpler function that takes both line and polyline. 
- `Message.FromLine` is set obsolete.

TESTING:
- No test were added as Message class is about representation and not covered by unit tests.

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/932)
<!-- Reviewable:end -->
