### PR TITLE
In `AdaptiveGridRouting`, if there are several connection points with…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `EdgeInfo.HasVerticalChange` is set obsolete.
 - `AdaptiveGraphRouting.RenderElements` is no longer paint hint lines in two different colors. Instead regular edges are paint into three groups. Weights are included to additional properties of produced elements.
 - Removed rule exception from `AdaptiveGraphRouting` that prevented vertical edges turn cost being discounter.
+- In `AdaptiveGridRouting`, if there are several connection points with the same cost - choose one that is closer to the trunk.
 
 ### Fixed
 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -400,6 +400,9 @@ namespace Elements.Spatial.AdaptiveGrid
             foreach (var leaf in appliedLeafs.Reverse<ulong>().Skip(1))
             {
                 var leafNode = leafsToTrunkTree[leaf];
+                //If other route goes though this leaf - in case if isolation radius is 0,
+                //do not try to optimize it, since it can lead to the whole subtree.
+                //TODO: make it possible to optimize subtrees and only leaf branches.
                 if(leafNode.Leafs.Any())
                 {
                     continue;

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -355,6 +355,7 @@ namespace Elements.Spatial.AdaptiveGrid
                 ulong closestTerminal = 0;
                 List<ulong> path = null;
                 double bestCost = order == TreeOrder.FurthestToClosest ? double.NegativeInfinity : double.PositiveInfinity;
+                double bestCostToTrunk = double.PositiveInfinity;
                 foreach (var terminal in validLeafTerminals)
                 {
                     var info = terminalInfo[terminal];
@@ -363,11 +364,23 @@ namespace Elements.Spatial.AdaptiveGrid
                     var costs = info.Costs[localClosest];
                     var localBestCost = branch == BranchSide.Left ? costs.Item1 : costs.Item2;
 
-                    if (order == TreeOrder.FurthestToClosest ? localBestCost > bestCost : localBestCost < bestCost)
+                    bool sameCost = localBestCost.ApproximatelyEquals(bestCost);
+                    bool betterCost = order == TreeOrder.FurthestToClosest ?
+                        localBestCost > bestCost : localBestCost < bestCost;
+                    if (sameCost || betterCost)
                     {
+                        //If there are several connection points with the same cost - 
+                        //choose one that is closer to the trunk.
+                        var localCostToTrunk = CostToTrunk(leafsToTrunkTree[localClosest], weights);
+                        if (sameCost && localCostToTrunk >= bestCostToTrunk)
+                        {
+                            continue;
+                        }
+
                         path = GetPathTo(info.Connections, localClosest, branch);
                         closestTerminal = terminal;
                         bestCost = localBestCost;
+                        bestCostToTrunk = localCostToTrunk;
                     }
                 }
 
@@ -387,6 +400,11 @@ namespace Elements.Spatial.AdaptiveGrid
             foreach (var leaf in appliedLeafs.Reverse<ulong>().Skip(1))
             {
                 var leafNode = leafsToTrunkTree[leaf];
+                if(leafNode.Leafs.Any())
+                {
+                    continue;
+                }
+
                 var leafPath = PathToFirstBranching(leafNode);
                 var localMagnets = magnetTerminals.Except(leafPath.Select(l => l.Id));
                 var info = terminalInfo[leaf];


### PR DESCRIPTION
… the same cost - choose one that is closer to the trunk.

BACKGROUND:
- While testing routing pattern that consist of several parallel lines with many inputs each, it was discovered that routing can choose any paths between lines since they produce the same tree sum. This was not consistent since numeric noise decided which one is shortest.

DESCRIPTION:
- If there are several connection points with the same cost - choose one that is closer to the trunk.

TESTING:
- Added new AdaptiveGraphRoutingEqualTransitions test that covers this case.

FUTURE WORK:

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- AdaptiveGraphRoutingEqualTransitions  uses more compact way where `Vector3` name is often skipped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/933)
<!-- Reviewable:end -->
