### PR TITLE
Clean profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `AdaptiveGraphRouting.AddPlaneModifier(string name, Plane plane, double factor)`
 - `SvgSection.SaveAsSvg`, `SvgSection.SaveAsPdf`
 - `Network.TraverseLeftWithoutLeaves()`
+- `Profile.Cleaned()`
 
 ### Changed
 

--- a/Elements/src/Geometry/Profile.cs
+++ b/Elements/src/Geometry/Profile.cs
@@ -769,7 +769,7 @@ namespace Elements.Geometry
         /// <param name="tolerance">Below this distance, similar points will be
         /// merged.</param>
         /// <returns>A cleaned list of profiles.</returns>        
-        public static List<Profile> Clean(this IEnumerable<Profile> profiles, double tolerance = 0.01)
+        public static List<Profile> Cleaned(this IEnumerable<Profile> profiles, double tolerance = 0.01)
         {
             var cleaned = new List<Profile>();
             var points = new List<Vector3>();

--- a/Elements/src/Geometry/Profile.cs
+++ b/Elements/src/Geometry/Profile.cs
@@ -831,7 +831,7 @@ namespace Elements.Geometry
                 {
                     // leave it alone
                 }
-                foreach (var vertex in profile.Perimeter.Vertices)
+                foreach (var vertex in profile.Perimeter.Vertices.Union(profile.Voids.SelectMany(v => v.Vertices)))
                 {
                     var indexOfFirstPointWithinDistance = points.FindIndex(p => p.DistanceTo(vertex) < tolerance);
                     if (indexOfFirstPointWithinDistance == -1)

--- a/Elements/src/Geometry/Profile.cs
+++ b/Elements/src/Geometry/Profile.cs
@@ -822,9 +822,10 @@ namespace Elements.Geometry
                 // Try removing collinear points
                 try
                 {
-                    // squaring the tolerance seems to work well, but this was
-                    // determined experimentally. we may want to make this value configurable.
-                    profile.Perimeter = profile.Perimeter.CollinearPointsRemoved(tolerance * tolerance);
+                    // Reducing the tolerance this way seems to work well, but
+                    // this was determined experimentally. We may want to make
+                    // this value configurable.
+                    profile.Perimeter = profile.Perimeter.CollinearPointsRemoved(tolerance / 100);
                 }
                 catch
                 {

--- a/Elements/test/ProfileTests.cs
+++ b/Elements/test/ProfileTests.cs
@@ -630,5 +630,17 @@ namespace Elements.Tests
             var uniquePoints = cleaned.SelectMany(c => c.Perimeter.Vertices).Distinct().ToList();
             Assert.True(uniquePoints.Count == 8);
         }
+
+        [Fact]
+        public void CleanProfilesPreservesValidProfiles()
+        {
+            var profiles = new Profile[] {
+                new Profile(new Polygon((20.83686, 24.77025), (-6.27588, 24.77025), (-6.27588, -1.78971), (20.83686, -1.78971)), new List<Polygon> {
+                    new Polygon((2.28049, 6.49027), (2.28049, 16.49027), (12.28049, 16.49027), (12.28049, 6.49027))
+                }),
+            };
+            var cleaned = profiles.Cleaned();
+            Assert.Single(cleaned);
+        }
     }
 }

--- a/Elements/test/ProfileTests.cs
+++ b/Elements/test/ProfileTests.cs
@@ -587,7 +587,7 @@ namespace Elements.Tests
                 new Profile(new Polygon(h,c,d,e)),
                 new Profile(new Polygon(b,f,g,d)) // does not include c
             };
-            var cleaned = profiles.Clean();
+            var cleaned = profiles.Cleaned();
             // the "c" point should be present in all profiles
             Assert.True(cleaned.Count((p) => p.Perimeter.Vertices.Count == 4) == 2);
             Assert.True(cleaned.Count((p) => p.Perimeter.Vertices.Count == 5) == 1);
@@ -622,7 +622,7 @@ namespace Elements.Tests
                 new Profile(new Polygon(h2,c,d,e)),
                 new Profile(new Polygon(b2,f,g,d2))
             };
-            var cleaned = profiles.Clean();
+            var cleaned = profiles.Cleaned();
             // for the purposes of this test we are doing something "illegal" —
             // using `Distinct` on a set of points. Since for this test we only
             // care about exact equality, not "equality within tolerance," this


### PR DESCRIPTION
BACKGROUND:
- When editing profiles via overrides in the Hypar web UI, certain configurations result in "illegal" topologies, like infinitely thin triangles, which break the editor. Some examples of these configurations are:
   - adjacent profiles that are nearly-but-not-quite aligned
   - profiles where one adjacent edge has an intermediate vertex but the other does not
- This is avoided by providing a "clean" set of profiles.

DESCRIPTION:
- Adds a static `Profile.Cleaned` extension method which cleans up a set of profiles into a clean graph which can be edited.

TESTING:
- I added several tests for the method which passed
- I have also been utilizing this method in production in a real hypar function, with good success. I am moving it to elements because I have another function that needs it. 
  
FUTURE WORK:
- the Hypar web UI should become more resilient to bad geometry input. 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/934)
<!-- Reviewable:end -->
