### PR TITLE
Add IsAffectedBy and IsNearby to RoutingHintLine public interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - `AdaptiveGraphRouting.AddPlaneModifier(string name, Plane plane, double factor)`
 - `SvgSection.SaveAsSvg`, `SvgSection.SaveAsPdf`
 - `Network.TraverseLeftWithoutLeaves()`
+- `RoutingHintLine.IsNearby`
+- `RoutingHintLine.Affects`
 
 ### Changed
 

--- a/Elements/src/Spatial/AdaptiveGrid/RoutingHintLine.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/RoutingHintLine.cs
@@ -8,7 +8,7 @@ namespace Elements.Spatial.AdaptiveGrid
     /// <summary>
     /// Structure that holds information about polylines that are used to guide routing.
     /// </summary>
-    public struct RoutingHintLine
+    public class RoutingHintLine
     {
         /// <summary>
         /// Construct new RoutingHintLine structure.
@@ -61,5 +61,93 @@ namespace Elements.Spatial.AdaptiveGrid
         /// Should polyline be virtually extended by Z coordinate.
         /// </summary>
         public readonly bool Is2D;
+
+        /// <summary>
+        /// Check if point is within influence of the hint line.
+        /// If hint line is 2D than only 2D distance is calculated, ignoring Z coordinate.
+        /// </summary>
+        /// <param name="point">Point to check.</param>
+        /// <param name="tolerance">Minimum allowed distance to polyline, even if influence is 0.</param>
+        /// <returns>True if point is close enough to the polyline.</returns>
+        public bool IsNearby(Vector3 point, double tolerance = Vector3.EPSILON)
+        {
+            var influenceDistance = Math.Max(InfluenceDistance, tolerance);
+            var target = Is2D ? new Vector3(point.X, point.Y) : point;
+            return target.DistanceTo(Polyline) <= influenceDistance;
+        }
+
+        /// <summary>
+        /// Check if hint line affects the line represented by two points.
+        /// Both points must be withing influence radius of the polyline.
+        /// Only edges parallel to polyline segments are affected.
+        /// </summary>
+        /// <param name="start">Start of the line point.</param>
+        /// <param name="end">End of the line point.</param>
+        /// <param name="tolerance">Minimum allowed distance to polyline, even if influence is 0.</param>
+        /// <returns></returns>
+        public bool Affects(Vector3 start, Vector3 end, double tolerance = Vector3.EPSILON)
+        {
+            var influenceDistance = Math.Max(InfluenceDistance, tolerance);
+            Vector3 vs = Is2D ? new Vector3(start.X, start.Y) : start;
+            Vector3 ve = Is2D ? new Vector3(end.X, end.Y) : end;
+            //Vertical edges are not affected by 2D hint lines
+            if (!Is2D || !vs.IsAlmostEqualTo(ve, tolerance) && Math.Abs(start.Z - end.Z) < tolerance)
+            {
+                foreach (var segment in Polyline.Segments())
+                {
+                    double lowClosest = 1;
+                    double hiClosest = 0;
+
+                    var dot = segment.Direction().Dot((ve - vs).Unitized());
+                    if (!Math.Abs(dot).ApproximatelyEquals(1))
+                    {
+                        continue;
+                    }
+
+                    if (vs.DistanceTo(segment) <= influenceDistance)
+                    {
+                        lowClosest = 0;
+                    }
+
+                    if (ve.DistanceTo(segment) <= influenceDistance)
+                    {
+                        hiClosest = 1;
+                    }
+
+                    if (lowClosest < hiClosest)
+                    {
+                        return true;
+                    }
+
+                    var edgeLine = new Line(vs, ve);
+                    Action<Vector3> check = (Vector3 p) =>
+                    {
+                        if (p.DistanceTo(edgeLine, out var closest) <= influenceDistance)
+                        {
+                            var t = (closest - vs).Length() / edgeLine.Length();
+                            if (t < lowClosest)
+                            {
+                                lowClosest = t;
+                            }
+
+                            if (t > hiClosest)
+                            {
+                                hiClosest = t;
+                            }
+                        }
+                    };
+
+                    check(segment.Start);
+                    check(segment.End);
+
+                    if (hiClosest > lowClosest &&
+                        (hiClosest - lowClosest) * edgeLine.Length() > influenceDistance)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
     }
 }

--- a/Elements/test/RoutingHintLineTests.cs
+++ b/Elements/test/RoutingHintLineTests.cs
@@ -1,0 +1,143 @@
+﻿using Elements.Geometry;
+using Elements.Spatial.AdaptiveGrid;
+using Xunit;
+
+namespace Elements.Tests
+{
+    public class RoutingHintLineTests
+    {
+        [Fact]
+        public void IsNearby2D()
+        {
+            var polyline = new Polyline(new Vector3[] { (0, 0), (0, 5), (5, 5) });
+            var hint_1 = new RoutingHintLine(polyline, factor: 1, influence: 1, userDefined: true, is2D: true);
+            var hint_0 = new RoutingHintLine(polyline, factor: 1, influence: 0, userDefined: true, is2D: true);
+
+            //Point not near polyline
+            Assert.False(hint_0.IsNearby((5, 0)));
+            Assert.False(hint_1.IsNearby((5, 0)));
+
+            //Point on elevation
+            Assert.True(hint_0.IsNearby((0, 2, 10)));
+            Assert.True(hint_1.IsNearby((0, 2, -10)));
+
+            //Point close
+            Assert.False(hint_0.IsNearby((3, 5.1)));
+            Assert.True(hint_1.IsNearby((3, 5.1)));
+
+            //On influence edge
+            Assert.True(hint_1.IsNearby((1, 3)));
+
+            //Point very close
+            Assert.True(hint_0.IsNearby((3, 5.000000001)));
+            Assert.True(hint_1.IsNearby((3, 5.000000001)));
+        }
+
+        [Fact]
+        public void IsNearby3D()
+        {
+            var polyline = new Polyline(new Vector3[] { (0, 0), (0, 5), (0, 5, 5) });
+            var hint_1 = new RoutingHintLine(polyline, factor: 1, influence: 1, userDefined: true, is2D: false);
+            var hint_0 = new RoutingHintLine(polyline, factor: 1, influence: 0, userDefined: true, is2D: false);
+
+            //Point not near polyline
+            Assert.False(hint_0.IsNearby((5, 0)));
+            Assert.False(hint_1.IsNearby((5, 0)));
+
+            //Point on elevation
+            Assert.False(hint_0.IsNearby((0, 2, 10)));
+            Assert.False(hint_1.IsNearby((0, 2, -10)));
+            Assert.True(hint_1.IsNearby((0, 2, 0.5)));
+
+            //Point close
+            Assert.False(hint_0.IsNearby((0.1, 5.1, 3)));
+            Assert.True(hint_1.IsNearby((0.1, 5.1, 3)));
+
+            //On influence edge
+            Assert.True(hint_1.IsNearby((1, 5, 3)));
+
+            //Point very close
+            Assert.True(hint_0.IsNearby((0.000000001, 4)));
+            Assert.True(hint_1.IsNearby((0.000000001, 4)));
+        }
+
+        [Fact]
+        public void Affects2D()
+        {
+            var polyline = new Polyline(new Vector3[] { (5, 0), (0, 0), (0, 5), (5, 5) });
+            var hint_1 = new RoutingHintLine(polyline, factor: 1, influence: 1, userDefined: true, is2D: true);
+            var hint_0 = new RoutingHintLine(polyline, factor: 1, influence: 0, userDefined: true, is2D: true);
+
+            //Line not near polyline
+            Assert.False(hint_0.Affects((5, 0), (5, 3)));
+            Assert.False(hint_1.Affects((5, 0), (5, 3)));
+
+            //Line on elevation
+            Assert.True(hint_0.Affects((0, 2, 10), (0, 4, 10)));
+            Assert.True(hint_1.Affects((0, 2, -10), (0, 4, -10)));
+
+            //Line close
+            Assert.False(hint_0.Affects((3, 5.1), (4, 5.1)));
+            Assert.True(hint_1.Affects((3, 5.1), (4, 5.1)));
+
+            //Line influence edge
+            Assert.True(hint_1.Affects((1, 3), (1, 4)));
+
+            //Line very close
+            Assert.True(hint_0.Affects((3, 5.000000001), (4, 5.000000001)));
+            Assert.True(hint_1.Affects((3, 5.000000001), (4, 5.000000001)));
+
+            //Vertical Line
+            Assert.False(hint_0.Affects((3, 5), (3, 5, 1)));
+            Assert.False(hint_1.Affects((3, 5), (3, 5, 1)));
+
+            //Perpendicular line inside influence
+            Assert.False(hint_1.Affects((5, 0), (5, 0.5)));
+
+            //Lays on different segments
+            Assert.False(hint_0.Affects((5, 0), (5, 5)));
+            Assert.False(hint_1.Affects((5.1, 0), (5.1, 5)));
+        }
+
+        [Fact]
+        public void Affects3D()
+        {
+            var polyline = new Polyline(new Vector3[] { (0, 0, 5), (0, 0), (0, 5), (0, 5, 5) });
+            var hint_1 = new RoutingHintLine(polyline, factor: 1, influence: 1, userDefined: true, is2D: false);
+            var hint_0 = new RoutingHintLine(polyline, factor: 1, influence: 0, userDefined: true, is2D: false);
+
+            //Line not near polyline
+            Assert.False(hint_0.Affects((5, 0), (5, 3)));
+            Assert.False(hint_1.Affects((5, 0), (5, 3)));
+
+            //Line on elevation
+            Assert.False(hint_0.Affects((0, 2, 10), (0, 4, 10)));
+            Assert.False(hint_1.Affects((0, 2, -10), (0, 4, -10)));
+            Assert.True(hint_1.Affects((0, 2, 0.5), (0, 4, 0.5)));
+
+            //Line close
+            Assert.False(hint_0.Affects((0.1, 3), (0.1, 4)));
+            Assert.True(hint_1.Affects((0.1, 3), (0.1, 4)));
+
+            //Line influence edge
+            Assert.True(hint_1.Affects((1, 3), (1, 4)));
+
+            //Line very close
+            Assert.True(hint_0.Affects((0.000000001, 3), (0.000000001, 4)));
+            Assert.True(hint_1.Affects((0.000000001, 3), (0.000000001, 4)));
+
+            //Vertical Line
+            Assert.False(hint_0.Affects((3, 5), (3, 5, 1)));
+            Assert.False(hint_1.Affects((3, 5), (3, 5, 1)));
+            Assert.True(hint_0.Affects((0, 5), (0, 5, 1)));
+            Assert.True(hint_1.Affects((0.5, 5), (0.5, 5, 1)));
+
+            //Perpendicular line inside influence
+            Assert.False(hint_1.Affects((0, 0), (0.5, 0)));
+
+            //Lays on different segments
+            Assert.False(hint_0.Affects((0, 0, 5), (0, 5, 5)));
+            Assert.False(hint_1.Affects((0.1, 0, 5), (0.1, 5, 5)));
+        }
+    }
+}


### PR DESCRIPTION
BACKGROUND:
- There was a need in being able check if edges influenced by the hint line are part of the final tree.

DESCRIPTION:
- Moved IsAffectedBy and IsNearby from AdaptiveGraphRouting to RoutingHintLine. This was AdaptiveGraphRouting is simpler and RoutingHintLine has new public functions to use.

TESTING:
- Added RoutingHintLineTests with several tests.
  
REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/935)
<!-- Reviewable:end -->
