### PR TITLE
fix mesh merge exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Gltfs that are merged that require additional extensions will also merge their extensions.
 - Don't try to save test models that have no name, they can interfere with each other because they want to save to the same file.
 - Fixed an issue where `Grid2d.GetCells()` multiple times could fail to return the correct results on subsequent calls, because changes to the axis grids were not invalidating the grid's computed cells.
+- Adding the first vertex to a mesh with `merge: true` would throw an exception, this is fixed.
 
 ## 1.3.0
 

--- a/Elements/src/Geometry/Mesh.cs
+++ b/Elements/src/Geometry/Mesh.cs
@@ -347,7 +347,9 @@ Triangles:{Triangles.Count}";
         {
             if (_octree == null)
             {
-                _octree = new PointOctree<Vertex>(Math.Max(_bbox.Max.DistanceTo(_bbox.Min), 100), _bbox.PointAt(0.5, 0.5, 0.5), Vector3.EPSILON);
+                // if we've never added any vertices, we may not have a valid bbox, so we have to guess at a default size.
+                var bbox = _bbox.IsValid() ? _bbox : new BBox3((-10, -10, -10), (10, 10, 10));
+                _octree = new PointOctree<Vertex>(Math.Max(bbox.Max.DistanceTo(bbox.Min), 100), bbox.PointAt(0.5, 0.5, 0.5), Vector3.EPSILON);
                 // make sure existing vertices are added to the octree — we're initializing it for the first time
                 foreach (var v in Vertices)
                 {

--- a/Elements/test/MeshTests.cs
+++ b/Elements/test/MeshTests.cs
@@ -101,6 +101,14 @@ namespace Elements.Tests
             Assert.Equal(_rays.Count, pts.Count);
         }
 
+        [Fact]
+        public void MergeOnFirstVertexAdd()
+        {
+            var mesh = new Mesh();
+            mesh.AddVertex(new Vector3(0, 0, 0), merge: true);
+            // no execptions
+        }
+
         public class InputsWithMesh
         {
             [JsonConstructor]


### PR DESCRIPTION
BACKGROUND:
- Adding the first vertex to a mesh with "merge" on would throw an exception.

DESCRIPTION:
- Fixes the exception.

TESTING:
-Added a new test which failed and now passes.

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/936)
<!-- Reviewable:end -->
