### PR TITLE
store ID and selectability in GLTF without relying on `name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Removed rule exception from `AdaptiveGraphRouting` that prevented vertical edges turn cost being discounter.
 - `Message.FromLine` is set obsolete.
 - In `AdaptiveGridRouting`, if there are several connection points with the same cost - choose one that is closer to the trunk.
+- GLTF writing now includes an ad-hoc `HYPAR_info` extension which aids in mapping between GLTF content and element ids in the model.
 
 ### Fixed
 

--- a/Elements/src/GeometricElement.cs
+++ b/Elements/src/GeometricElement.cs
@@ -25,6 +25,11 @@ namespace Elements
         internal BBox3 _bounds;
         internal Csg.Solid _csg;
 
+        // Used to attach a "selectable: false" flag to the element in the
+        // generated GLB. NOTE: currently only considered in the "ModelLines /
+        // ModelPoints" pathways — this is not yet supported for mesh elements.
+        internal bool _isSelectable = true;
+
         /// <summary>
         /// The element's bounds.
         /// The bounds are only available when the geometry has been

--- a/Elements/src/ModelCurve.cs
+++ b/Elements/src/ModelCurve.cs
@@ -18,8 +18,6 @@ namespace Elements
         /// </summary>
         public Curve Curve { get; set; }
 
-        private bool _isSelectable = true;
-
         /// <summary>
         /// Create a model curve.
         /// </summary>

--- a/Elements/src/ModelLines.cs
+++ b/Elements/src/ModelLines.cs
@@ -19,8 +19,6 @@ namespace Elements
         /// </summary>
         public IList<Line> Lines { get; set; }
 
-        private bool _isSelectable = false;
-
         /// <summary>
         /// Create a collection of lines. They share Material, Transformation and other parameters.
         /// </summary>

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -797,7 +797,7 @@ namespace Elements.Serialization.glTF
                                          gbuffers,
                                          meshes);
 
-            NodeUtilities.CreateNodeForMesh(meshId, nodes, Guid.Empty, null);
+            NodeUtilities.CreateNodeForMesh(meshId, nodes);
 
             var edgeCount = 0;
             var vertices = new List<Vector3>();

--- a/Elements/src/Serialization/glTF/NodeUtilities.cs
+++ b/Elements/src/Serialization/glTF/NodeUtilities.cs
@@ -44,7 +44,7 @@ namespace Elements.Serialization.glTF
             return NodeUtilities.AddNodes(nodes, new[] { newNode }, parentId).First();
         }
 
-        internal static int CreateAndAddTransformNode(List<Node> nodes, Transform transform, int parentId)
+        internal static int CreateAndAddTransformNode(List<Node> nodes, Transform transform, int parentId, Guid? elementId = null)
         {
             if (transform != null)
             {
@@ -53,6 +53,10 @@ namespace Elements.Serialization.glTF
                 var c = transform.ZAxis;
 
                 var transNode = new Node();
+                if (elementId.HasValue)
+                {
+                    transNode.SetElementInfo(elementId.Value);
+                }
 
                 transNode.Matrix = new[]{
                     (float)a.X, (float)a.Y, (float)a.Z, 0.0f,
@@ -83,9 +87,12 @@ namespace Elements.Serialization.glTF
             // transform, so that the transform can be modified in explore at
             // runtime (e.g. by a transform override) and have the expected effect.
             float[] elementTransform = TransformToMatrix(transform);
-            var newNode = new glTFLoader.Schema.Node();
-            newNode.Name = $"{instanceElementId}";
-            newNode.Matrix = elementTransform;
+            var newNode = new glTFLoader.Schema.Node
+            {
+                Name = $"{instanceElementId}",
+                Matrix = elementTransform
+            };
+            newNode.SetElementInfo(instanceElementId);
             nodes.Add(newNode);
             newNode.Children = new[] { nodes.Count };
 
@@ -165,15 +172,13 @@ namespace Elements.Serialization.glTF
         {
             var parentId = 0;
 
-            parentId = NodeUtilities.CreateAndAddTransformNode(nodes, transform, parentId);
+            parentId = NodeUtilities.CreateAndAddTransformNode(nodes, transform, parentId, elementId);
 
             // Add mesh node to gltf nodes
             var node = new Node
             {
                 Mesh = meshId
             };
-
-            node.SetElementInfo(elementId);
 
             var nodeId = AddNode(nodes, node, parentId);
             return nodeId;

--- a/Elements/src/Serialization/glTF/NodeUtilities.cs
+++ b/Elements/src/Serialization/glTF/NodeUtilities.cs
@@ -168,7 +168,7 @@ namespace Elements.Serialization.glTF
             return matrix;
         }
 
-        internal static int CreateNodeForMesh(int meshId, List<glTFLoader.Schema.Node> nodes, Guid elementId, Transform transform = null)
+        internal static int CreateNodeForMesh(int meshId, List<glTFLoader.Schema.Node> nodes, Guid? elementId = null, Transform transform = null)
         {
             var parentId = 0;
 
@@ -190,21 +190,17 @@ namespace Elements.Serialization.glTF
             {
                 node.Extensions = new Dictionary<string, object>();
             }
-            if (selectable.HasValue)
-            {
-                node.Extensions["HYPAR_info"] = new Dictionary<string, object>
+
+            var extensionDict = new Dictionary<string, object>
                 {
                     {"id", elementId},
-                    {"selectable", selectable.Value}
                 };
-            }
-            else
+
+            if (selectable.HasValue)
             {
-                node.Extensions["HYPAR_info"] = new Dictionary<string, object>
-            {
-                {"id", elementId}
-            };
+                extensionDict["selectable"] = selectable.Value;
             }
+            node.Extensions["HYPAR_info"] = extensionDict;
         }
     }
 }

--- a/Elements/test/GltfTests.cs
+++ b/Elements/test/GltfTests.cs
@@ -140,10 +140,35 @@ namespace Elements.Tests
                 IsElementDefinition = true
             };
             var instance = baseDef.CreateInstance(new Transform(0, 0, 10), null);
+            var contentElement = new ContentElement("https://hypar-content-catalogs.s3-us-west-2.amazonaws.com/a1cf1df6-0762-45e7-942b-7ba17d813ff4/HermanMiller_Collection_Eames_MoldedPlywood_DiningChair_MtlBase+-+Upholstered.glb",
+                                                              new BBox3((0, 0, 0), (1, 1, 1)),
+                                                              1,
+                                                              Vector3.XAxis,
+                                                              new Transform(),
+                                                              null,
+                                                              null,
+                                                              false,
+                                                              Guid.NewGuid(),
+                                                              "",
+                                                              "");
+            var singleElementBaseDef = new ContentElement("https://hypar-content-catalogs.s3-us-west-2.amazonaws.com/a1cf1df6-0762-45e7-942b-7ba17d813ff4/HermanMiller_Collection_Eames_MoldedPlywood_DiningChair_MtlBase+-+Upholstered.glb",
+                                                   new BBox3((0, 0, 0), (1, 1, 1)),
+                                                   1,
+                                                   Vector3.XAxis,
+                                                   new Transform(),
+                                                   null,
+                                                   null,
+                                                   true,
+                                                   Guid.NewGuid(),
+                                                   "",
+                                                   "");
+            var contentInstance = singleElementBaseDef.CreateInstance(new Transform(0, 0, 20), null);
             var model = new Model();
             model.AddElement(modelCurve);
             model.AddElement(mass);
             model.AddElement(instance);
+            model.AddElement(contentElement);
+            model.AddElement(contentInstance);
             var modelsDir = Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "models");
             var gltfPath = Path.Combine(modelsDir, "Embedded-Ids.glb");
 
@@ -171,6 +196,20 @@ namespace Elements.Tests
                     n.Extensions.TryGetValue("HYPAR_info", out var info) &&
                     info is JObject j &&
                     j["id"].Value<string>() == instance.Id.ToString();
+            });
+            Assert.Contains(gltf.Nodes, (n) =>
+            {
+                return n.Extensions != null &&
+                    n.Extensions.TryGetValue("HYPAR_info", out var info) &&
+                    info is JObject j &&
+                    j["id"].Value<string>() == contentElement.Id.ToString();
+            });
+            Assert.Contains(gltf.Nodes, (n) =>
+            {
+                return n.Extensions != null &&
+                    n.Extensions.TryGetValue("HYPAR_info", out var info) &&
+                    info is JObject j &&
+                    j["id"].Value<string>() == contentInstance.Id.ToString();
             });
         }
     }


### PR DESCRIPTION
BACKGROUND:
- In early days of Elements, the `name` of the object in the GLTF wasn't utilized for anything. Over time, the Hypar front end has evolved to rely on parsing out critical information from the name — specifically, the element Id, and whether or not it is meant to be selectable. 

DESCRIPTION:
- Establishes an ad-hoc gltf extension called `HYPAR_info` which contains information necessary for the hypar front end to connect element data to GLTF mesh objects. 

TESTING:
- I added a test which verifies that the data is written correctly to the GLTF. 
- I have an in-progress `explore` branch which can read this info if it's present. 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/937)
<!-- Reviewable:end -->
