### PR TITLE
use double double quotes for string literals during code gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Don't try to save test models that have no name, they can interfere with each other because they want to save to the same file.
 - Fixed an issue where `Grid2d.GetCells()` multiple times could fail to return the correct results on subsequent calls, because changes to the axis grids were not invalidating the grid's computed cells.
 - Adding the first vertex to a mesh with `merge: true` would throw an exception, this is fixed.
+- Handle quotes in string literals for content catalog code generation by doubling them up.
 
 ## 1.3.0
 

--- a/Elements.CodeGeneration/src/CatalogGenerator.cs
+++ b/Elements.CodeGeneration/src/CatalogGenerator.cs
@@ -112,7 +112,7 @@ namespace Elements.Generate
                     switch (value)
                     {
                         case string str:
-                            codeToAdd = $"@\"{str}\"";
+                            codeToAdd = $"@\"{str.LiteralQuotes()}\"";
                             break;
                         case Guid guid:
                             codeToAdd = $"new Guid(\"{guid}\")";

--- a/Elements.CodeGeneration/src/HyparFilters.cs
+++ b/Elements.CodeGeneration/src/HyparFilters.cs
@@ -13,7 +13,7 @@ namespace Elements.Generate
     // Copied from https://github.com/RicoSuter/NJsonSchema/blob/687efeabdc30ddacd235e85213f3594458ed48b4/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs#L183
     /// <summary>
     /// This class contains text filtering methods.  They are used during rendering in liquid templates.
-    /// We shouldn't actually need to implement these ourselves. See the TODO in the source code for more information.  
+    /// We shouldn't actually need to implement these ourselves. See the TODO in the source code for more information.
     /// </summary>
     public static class HyparFilters
     {
@@ -48,6 +48,17 @@ namespace Elements.Generate
         public static string Safeidentifierupper(Context context, string input, bool firstCharacterMustBeAlpha = true)
         {
             return input.ToSafeIdentifier();
+        }
+
+        /// <summary>
+        /// Return a string that is literalized with double double quotes.
+        /// </summary>
+        /// <param name="context">The DotLiquid.Context this filter is running in.</param>
+        /// <param name="input">The string to be formatted.</param>
+        /// <param name="firstCharacterMustBeAlpha">Should the @ character be prepended to the string.</param>
+        public static string Literalquotes(Context context, string input, bool firstCharacterMustBeAlpha = true)
+        {
+            return input.LiteralQuotes();
         }
 
         /// <summary>

--- a/Elements.CodeGeneration/src/HyparFilters.cs
+++ b/Elements.CodeGeneration/src/HyparFilters.cs
@@ -53,10 +53,8 @@ namespace Elements.Generate
         /// <summary>
         /// Return a string that is literalized with double double quotes.
         /// </summary>
-        /// <param name="context">The DotLiquid.Context this filter is running in.</param>
         /// <param name="input">The string to be formatted.</param>
-        /// <param name="firstCharacterMustBeAlpha">Should the @ character be prepended to the string.</param>
-        public static string Literalquotes(Context context, string input, bool firstCharacterMustBeAlpha = true)
+        public static string Literalquotes(string input)
         {
             return input.LiteralQuotes();
         }

--- a/Elements.CodeGeneration/src/HyparFilters.cs
+++ b/Elements.CodeGeneration/src/HyparFilters.cs
@@ -31,10 +31,8 @@ namespace Elements.Generate
         /// <summary>
         /// Return the string turned into a save C# identifier lowercased.
         /// </summary>
-        /// <param name="context">The DotLiquid.Context this filter is running in.</param>
         /// <param name="input">The string to be formatted.</param>
-        /// <param name="firstCharacterMustBeAlpha">Should the @ character be prepended to the string.</param>
-        public static string Safeidentifierlower(Context context, string input, bool firstCharacterMustBeAlpha = true)
+        public static string Safeidentifierlower(string input)
         {
             return input.ToSafeIdentifier(true);
         }
@@ -42,10 +40,8 @@ namespace Elements.Generate
         /// <summary>
         /// Return the string turned into a save C# identifier uppercased.
         /// </summary>
-        /// <param name="context">The DotLiquid.Context this filter is running in.</param>
         /// <param name="input">The string to be formatted.</param>
-        /// <param name="firstCharacterMustBeAlpha">Should the @ character be prepended to the string.</param>
-        public static string Safeidentifierupper(Context context, string input, bool firstCharacterMustBeAlpha = true)
+        public static string Safeidentifierupper(string input)
         {
             return input.ToSafeIdentifier();
         }

--- a/Elements.CodeGeneration/src/StringUtilities.cs
+++ b/Elements.CodeGeneration/src/StringUtilities.cs
@@ -65,6 +65,15 @@ namespace Elements.Generate.StringUtils
             return cleanName;
         }
 
-    }
 
+        /// <summary>
+        /// returns a string with double quotes doubled, suitable for string literals.
+        /// </summary>
+        /// <param name="str"></param>
+        /// <returns></returns>
+        public static string LiteralQuotes(this string str)
+        {
+            return str.Replace("\"", "\"\"");
+        }
+    }
 }

--- a/Elements.CodeGeneration/src/Templates/Catalog.liquid
+++ b/Elements.CodeGeneration/src/Templates/Catalog.liquid
@@ -14,7 +14,7 @@ public static class {{ catalog.name | safeidentifierupper }} {
     public static List<ElementInstance> Reference = new List<ElementInstance> { {% for inst in catalog.reference_configuration %}
                                                             {{catalog.name | safeidentifierupper}}.{{inst.baseName | safeidentifierupper}}.CreateInstance(
                                                                                   {{inst.transform}},
-                                                                                  "{{inst.name}}"),
+                                                                                  @"{{inst.name | literalquotes}}"),
                                                         {%endfor%}
 
     };


### PR DESCRIPTION
BACKGROUND:
- A catalog created from Revit has quotes in the names of the content elements.  We want these to exist after code generation.

DESCRIPTION:
- Add double double quoting logic for strings and liquid templates.

TESTING:
- This catalog has the offending names. https://hypar.io/user-static/9a6a516e-4777-4ef0-be6b-2ca7c710b70b.json 
  
FUTURE WORK:
- This quoting is different than quotes for non-literal strings, which could cause us headaches in the future, but I think we mostly use string literals in code gen.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/elements/938)
<!-- Reviewable:end -->
