### PR TITLE
Obsolete Tolerance parameter in AdaptiveGrid.TryGetVertexIndex

### DIFF
--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -350,12 +350,31 @@ namespace Elements.Spatial.AdaptiveGrid
 
         /// <summary>
         /// Whether a vertex location already exists in the AdaptiveGrid.
+        /// A vertex with each coordinate less than AdaptiveGrid.Tolerance away is considered suitable.
+        /// </summary>
+        /// <param name="point"></param>
+        /// <param name="id">The ID of the Vertex, if a match is found.</param>
+        /// <returns>True if any Vertex is close enough.</returns>
+        public bool TryGetVertexIndex(Vector3 point, out ulong id)
+        {
+            var zDict = GetAddressParent(_verticesLookup, point, tolerance: Tolerance);
+            if (zDict == null)
+            {
+                id = 0;
+                return false;
+            }
+            return TryGetValue(zDict, point.Z, out id, Tolerance);
+        }
+
+        /// <summary>
+        /// Whether a vertex location already exists in the AdaptiveGrid.
         /// </summary>
         /// <param name="point"></param>
         /// <param name="id">The ID of the Vertex, if a match is found.</param>
         /// <param name="tolerance">Amount of tolerance in the search against each component of the coordinate.</param>
-        /// <returns></returns>
-        public bool TryGetVertexIndex(Vector3 point, out ulong id, double? tolerance = null)
+        /// <returns>True if any Vertex is close enough.</returns>
+        [Obsolete("Tolerance parameter is obsolete. Grid automatically uses it's internal tolerance.")]
+        public bool TryGetVertexIndex(Vector3 point, out ulong id, double? tolerance)
         {
             var zDict = GetAddressParent(_verticesLookup, point, tolerance: tolerance);
             if (zDict == null)
@@ -374,7 +393,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <returns>New or existing Vertex.</returns>
         public Vertex AddVertex(Vector3 point)
         {
-            if (!TryGetVertexIndex(point, out var id, Tolerance))
+            if (!TryGetVertexIndex(point, out var id))
             {
                 var zDict = GetAddressParent(_verticesLookup, point, true, Tolerance);
                 id = this._vertexId;
@@ -755,14 +774,14 @@ namespace Elements.Spatial.AdaptiveGrid
                     // The same vertex can be part of multiple edges.
                     // Cache to avoid expensive cut operations.
                     if (!alreadyConnected.Contains(newSV.Id) && 
-                        TryGetVertexIndex(Start, out var id, Tolerance))
+                        TryGetVertexIndex(Start, out var id))
                     {
                         AddEdge(newSV.Id, id);
                         alreadyConnected.Add(newSV.Id);
                     }
 
                     if (!alreadyConnected.Contains(newEV.Id) &&
-                        TryGetVertexIndex(End, out id, Tolerance))
+                        TryGetVertexIndex(End, out id))
                     {
                         AddEdge(newEV.Id, id);
                         alreadyConnected.Add(newEV.Id);

--- a/Elements/test/AdaptiveGraphRoutingTests.cs
+++ b/Elements/test/AdaptiveGraphRoutingTests.cs
@@ -41,7 +41,7 @@ namespace Elements.Tests
             //Each turn cost 1 additional "meter"
             var configuration = new RoutingConfiguration(turnCost: 1);
             AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, configuration);
-            grid.TryGetVertexIndex(new Vector3(0, 4, 0), out var inV, grid.Tolerance);
+            grid.TryGetVertexIndex(new Vector3(0, 4, 0), out var inV);
 
             //Set travel cost for each edge equal to it's length
             var edgeCosts = new Dictionary<ulong, EdgeInfo>();
@@ -54,7 +54,7 @@ namespace Elements.Tests
             var paths = alg.ShortestPathDijkstra(inV, edgeCosts, out var travelCosts);
 
             //Find most efficient path from (0, 4) to (10, 4)
-            grid.TryGetVertexIndex(new Vector3(10, 4, 0), out var outV, grid.Tolerance);
+            grid.TryGetVertexIndex(new Vector3(10, 4, 0), out var outV);
             List<Vector3> expectedPath = new List<Vector3>()
             {
                 new Vector3(0, 4, 0),
@@ -77,7 +77,7 @@ namespace Elements.Tests
             Assert.Equal(20, travelCosts[outV]);
 
             //Find most efficient path from (0, 4) to (5, 10)
-            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 10, 0), out outV, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 10, 0), out outV));
             expectedPath = new List<Vector3>()
             {
                 new Vector3(0, 4, 0),
@@ -120,9 +120,9 @@ namespace Elements.Tests
             var configuration = new RoutingConfiguration(turnCost: 1);
             AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, configuration);
 
-            Assert.True(grid.TryGetVertexIndex(new Vector3(2, 2, 0), out var inV, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 2, 0), out var ev0, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(8, 2, 0), out var ev1, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(2, 2, 0), out var inV));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 2, 0), out var ev0));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(8, 2, 0), out var ev1));
 
             var edgeCosts = new Dictionary<ulong, EdgeInfo>();
 
@@ -136,11 +136,11 @@ namespace Elements.Tests
                 edgeCosts[e.Id] = new EdgeInfo(grid, e, factor);
             }
 
-            Assert.True(grid.TryGetVertexIndex(new Vector3(2, 3, 0), out var preV, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(2, 3, 0), out var preV));
             var paths = alg.ShortestBranchesDijkstra(inV, edgeCosts, out var travelCosts, preV);
 
             //Two paths calculated for (2, 3)->(8, 1) to approach end point from different edges.
-            Assert.True(grid.TryGetVertexIndex(new Vector3(8, 1, 0), out var outV, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(8, 1, 0), out var outV));
             List<Vector3> expectedLeft = new List<Vector3>()
             {
                 new Vector3(2, 2, 0),
@@ -253,7 +253,7 @@ namespace Elements.Tests
             foreach (var input in inputPoints)
             {
                 var p = new Vector3(input.X, input.Y, mainLayer);
-                Assert.True(grid.TryGetVertexIndex(p, out ulong down, grid.Tolerance));
+                Assert.True(grid.TryGetVertexIndex(p, out ulong down));
                 grid.AddVertex(input, new ConnectVertexStrategy(grid.GetVertex(down)));
             }
             grid.SubtractObstacle(obstacle);
@@ -261,13 +261,13 @@ namespace Elements.Tests
             var inputVertices = new List<RoutingVertex>();
             foreach (var input in inputPoints)
             {
-                Assert.True(grid.TryGetVertexIndex(input, out ulong id, grid.Tolerance));
+                Assert.True(grid.TryGetVertexIndex(input, out ulong id));
                 {
                     inputVertices.Add(new RoutingVertex(id, 0.5));
                 }
             }
 
-            Assert.True(grid.TryGetVertexIndex(tailPoint, out ulong tailVertex, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(tailPoint, out ulong tailVertex));
 
             var configuration = new RoutingConfiguration(turnCost: 1);
             AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, configuration);
@@ -402,13 +402,13 @@ namespace Elements.Tests
             var inputVertices = new List<RoutingVertex>();
             foreach (var input in inputPoints)
             {
-                Assert.True(grid.TryGetVertexIndex(input, out ulong id, grid.Tolerance));
+                Assert.True(grid.TryGetVertexIndex(input, out ulong id));
                 {
                     inputVertices.Add(new RoutingVertex(id, 0.5));
                 }
             }
 
-            Assert.True(grid.TryGetVertexIndex(tailPoint, out ulong tailVertex, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(tailPoint, out ulong tailVertex));
 
             //9. Set configurations for hint and offset lines.
             var hint = new RoutingHintLine(hintPolyline, 
@@ -502,7 +502,7 @@ namespace Elements.Tests
             inputVertices.Add(new List<RoutingVertex>());
             foreach (var input in inputPoints.Take(3))
             {
-                Assert.True(grid.TryGetVertexIndex(input, out ulong id, grid.Tolerance));
+                Assert.True(grid.TryGetVertexIndex(input, out ulong id));
                 {
                     inputVertices[0].Add(new RoutingVertex(id, 0.5));
                 }
@@ -510,13 +510,13 @@ namespace Elements.Tests
             inputVertices.Add(new List<RoutingVertex>());
             foreach (var input in inputPoints.Skip(3))
             {
-                Assert.True(grid.TryGetVertexIndex(input, out ulong id, grid.Tolerance));
+                Assert.True(grid.TryGetVertexIndex(input, out ulong id));
                 {
                     inputVertices[1].Add(new RoutingVertex(id, 0.5));
                 }
             }
 
-            Assert.True(grid.TryGetVertexIndex(tailPoint, out ulong tailVertex, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(tailPoint, out ulong tailVertex));
 
             //9. Set configurations for hint and offset lines. Split them into groups.
             var hint = new RoutingHintLine(hintPolyline,
@@ -594,7 +594,7 @@ namespace Elements.Tests
             var inputVertices = new List<RoutingVertex>();
             foreach (var input in inputPoints)
             {
-                Assert.True(grid.TryGetVertexIndex(input, out ulong id, grid.Tolerance));
+                Assert.True(grid.TryGetVertexIndex(input, out ulong id));
                 {
                     inputVertices.Add(new RoutingVertex(id, 0));
                 }
@@ -850,8 +850,8 @@ namespace Elements.Tests
 
             var c = new RoutingConfiguration();
             var routing = new AdaptiveGraphRouting(grid, c);
-            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 5), out var inputId, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(10, 5), out var outputId, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 5), out var inputId));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(10, 5), out var outputId));
             var input = new RoutingVertex(inputId, 0);
             var route = routing.BuildSpanningTree(
                 new List<RoutingVertex> { input }, outputId, new List<RoutingHintLine> { hint }, TreeOrder.ClosestToFurthest);
@@ -904,10 +904,10 @@ namespace Elements.Tests
 
             var c = new RoutingConfiguration();
             var routing = new AdaptiveGraphRouting(grid, c);
-            Assert.True(grid.TryGetVertexIndex(new Vector3(2, 2), out var inputId0, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 10), out var inputId1, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(8, 2), out var inputId2, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0), out var outputId, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(2, 2), out var inputId0));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 10), out var inputId1));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(8, 2), out var inputId2));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0), out var outputId));
             var inputs = new List<RoutingVertex> {
                 new RoutingVertex(inputId0, 0),
                 new RoutingVertex(inputId1, 0),
@@ -925,7 +925,7 @@ namespace Elements.Tests
             };
             CheckTree(grid, inputId1, tree, expectedPath);
 
-            Assert.True(grid.TryGetVertexIndex(new Vector3(10, 0), out outputId, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(10, 0), out outputId));
             tree = routing.BuildSpanningTree(inputs, outputId, new List<RoutingHintLine>(), TreeOrder.ClosestToFurthest);
 
             expectedPath = new List<Vector3>()
@@ -965,9 +965,9 @@ namespace Elements.Tests
 
             var c = new RoutingConfiguration();
             var routing = new AdaptiveGraphRouting(grid, c);
-            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 20), out var inputId0, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(10, 20), out var inputId1, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(20, 0), out var outputId, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 20), out var inputId0));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(10, 20), out var inputId1));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(20, 0), out var outputId));
             var inputs = new List<RoutingVertex> {
                 new RoutingVertex(inputId0, 1),
                 new RoutingVertex(inputId1, 1),
@@ -1007,10 +1007,10 @@ namespace Elements.Tests
 
             var c = new RoutingConfiguration();
             var routing = new AdaptiveGraphRouting(grid, c);
-            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 5), out var inputId0, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(-5, 10), out var inputId1, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 15), out var inputId2, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0), out var outputId, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 5), out var inputId0));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(-5, 10), out var inputId1));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 15), out var inputId2));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0), out var outputId));
             var inputs = new List<RoutingVertex> {
                 new RoutingVertex(inputId0, 1),
                 new RoutingVertex(inputId1, 1),
@@ -1090,11 +1090,11 @@ namespace Elements.Tests
                 new Plane(new Vector3(0, 0, -1), Vector3.ZAxis),
                 2);
             routing.AddRoutingFilter((Vertex start, Vertex end) => start.Point.Z > end.Point.Z - Vector3.EPSILON);
-            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0, 5), out var inputId0, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 0, 5), out var inputId1, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(10, 0, 5), out var inputId2, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(15, 0, 5), out var inputId3, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(20, 0, -5), out var outputId, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0, 5), out var inputId0));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 0, 5), out var inputId1));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(10, 0, 5), out var inputId2));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(15, 0, 5), out var inputId3));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(20, 0, -5), out var outputId));
             var inputs = new List<RoutingVertex> {
                 new RoutingVertex(inputId0, 0),
                 new RoutingVertex(inputId1, 0),
@@ -1174,11 +1174,11 @@ namespace Elements.Tests
                 new Vector3(15, 0, 0) },
                 AdaptiveGrid.VerticesInsertionMethod.ConnectAndCut); //goes underground.
 
-            grid.TryGetVertexIndex(new Vector3(0, 5, 0), out var id0, grid.Tolerance);
-            grid.TryGetVertexIndex(new Vector3(0.1, 3, 0), out var id1, grid.Tolerance);
-            grid.TryGetVertexIndex(new Vector3(5, -5, 0), out var id2, grid.Tolerance);
-            grid.TryGetVertexIndex(new Vector3(5, 5, 0), out var id3, grid.Tolerance);
-            grid.TryGetVertexIndex(new Vector3(15, -5, 0), out var id4, grid.Tolerance);
+            grid.TryGetVertexIndex(new Vector3(0, 5, 0), out var id0);
+            grid.TryGetVertexIndex(new Vector3(0.1, 3, 0), out var id1);
+            grid.TryGetVertexIndex(new Vector3(5, -5, 0), out var id2);
+            grid.TryGetVertexIndex(new Vector3(5, 5, 0), out var id3);
+            grid.TryGetVertexIndex(new Vector3(15, -5, 0), out var id4);
             List<RoutingVertex> leafs = new List<RoutingVertex>(){
                 new RoutingVertex(id0, 0.5),
                 new RoutingVertex(id1, 0.5),
@@ -1186,7 +1186,7 @@ namespace Elements.Tests
                 new RoutingVertex(id3, 0.5),
                 new RoutingVertex(id4, 0.5),
             };
-            grid.TryGetVertexIndex(new Vector3(20, 0, 0), out var trunk, grid.Tolerance);
+            grid.TryGetVertexIndex(new Vector3(20, 0, 0), out var trunk);
 
             RoutingConfiguration config = new RoutingConfiguration();  
             AdaptiveGraphRouting alg = new AdaptiveGraphRouting(grid, config);
@@ -1240,11 +1240,11 @@ namespace Elements.Tests
             grid.AddFromPolygon(Polygon.Rectangle(new Vector3(0, 0), new Vector3(10, 10)),
                                 keyPoints);
 
-            Assert.True(grid.TryGetVertexIndex(new Vector3(2, 5), out var start, grid.Tolerance));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(8, 5), out var end, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(2, 5), out var start));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(8, 5), out var end));
             
             //Remove alternative route with the same best cost.
-            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 7), out var v, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 7), out var v));
             foreach (var e in grid.GetVertex(v).Edges.ToList())
             {
                 grid.RemoveEdge(e);
@@ -1293,7 +1293,7 @@ namespace Elements.Tests
             var keyPoints = new[] { 1, 3, 5, 7, 9 }.Select(i => new Vector3(i, i));
             grid.AddFromPolygon(Polygon.Rectangle((0, 0), (10, 10)), keyPoints);
 
-            Assert.True(grid.TryGetVertexIndex((0, 5), out var end, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex((0, 5), out var end));
 
             var inputs = new List<Vector3>()
             {
@@ -1304,7 +1304,7 @@ namespace Elements.Tests
 
             var inputVertices = inputs.Select(i =>
             {
-                Assert.True(grid.TryGetVertexIndex(i, out var id, grid.Tolerance));
+                Assert.True(grid.TryGetVertexIndex(i, out var id));
                 return new RoutingVertex(id, 0);
             }).ToList();
 

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -271,13 +271,13 @@ namespace Elements.Tests
             var withoutTransfrom = Obstacle.FromBBox(bbox, addPerimeterEdges: true);
             adaptiveGrid.SubtractObstacle(withoutTransfrom);
 
-            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(3, 3), out _, adaptiveGrid.Tolerance));
-            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(3, 2), out _, adaptiveGrid.Tolerance));
-            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(3, 4), out _, adaptiveGrid.Tolerance));
-            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(2, 3), out _, adaptiveGrid.Tolerance));
-            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(4, 3), out _, adaptiveGrid.Tolerance));
+            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(3, 3), out _));
+            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(3, 2), out _));
+            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(3, 4), out _));
+            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(2, 3), out _));
+            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(4, 3), out _));
 
-            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(2, 2), out var id, adaptiveGrid.Tolerance));
+            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(2, 2), out var id));
             var v = adaptiveGrid.GetVertex(id);
             Assert.Equal(3, v.Edges.Count);
             Assert.Contains(v.Edges, e => adaptiveGrid.GetVertex(
@@ -285,7 +285,7 @@ namespace Elements.Tests
             Assert.Contains(v.Edges, e => adaptiveGrid.GetVertex(
                 e.OtherVertexId(v.Id)).Point.IsAlmostEqualTo(new Vector3(2.5, 1.5), adaptiveGrid.Tolerance));
 
-            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(4, 2), out id, adaptiveGrid.Tolerance));
+            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(4, 2), out id));
             v = adaptiveGrid.GetVertex(id);
             Assert.Equal(3, v.Edges.Count);
             Assert.Contains(v.Edges, e => adaptiveGrid.GetVertex(
@@ -293,7 +293,7 @@ namespace Elements.Tests
             Assert.Contains(v.Edges, e => adaptiveGrid.GetVertex(
                 e.OtherVertexId(v.Id)).Point.IsAlmostEqualTo(new Vector3(4.5, 2.5), adaptiveGrid.Tolerance));
 
-            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(4, 4), out id, adaptiveGrid.Tolerance));
+            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(4, 4), out id));
             v = adaptiveGrid.GetVertex(id);
             Assert.Equal(3, v.Edges.Count);
             Assert.Contains(v.Edges, e => adaptiveGrid.GetVertex(
@@ -301,7 +301,7 @@ namespace Elements.Tests
             Assert.Contains(v.Edges, e => adaptiveGrid.GetVertex(
                 e.OtherVertexId(v.Id)).Point.IsAlmostEqualTo(new Vector3(4.5, 3.5), adaptiveGrid.Tolerance));
 
-            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(2, 4), out id, adaptiveGrid.Tolerance));
+            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(2, 4), out id));
             v = adaptiveGrid.GetVertex(id);
             Assert.Equal(3, v.Edges.Count);
             Assert.Contains(v.Edges, e => adaptiveGrid.GetVertex(
@@ -316,9 +316,9 @@ namespace Elements.Tests
             withTransform.Orientation = new Transform();
             adaptiveGrid.SubtractObstacle(withTransform);
 
-            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(7, 7), out _, adaptiveGrid.Tolerance));
+            Assert.False(adaptiveGrid.TryGetVertexIndex(new Vector3(7, 7), out _));
 
-            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(6, 6), out id, adaptiveGrid.Tolerance));
+            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(6, 6), out id));
             v = adaptiveGrid.GetVertex(id);
             Assert.Equal(5, v.Edges.Count);
             Assert.Contains(v.Edges, e => adaptiveGrid.GetVertex(
@@ -330,7 +330,7 @@ namespace Elements.Tests
             Assert.Contains(v.Edges, e => adaptiveGrid.GetVertex(
                 e.OtherVertexId(v.Id)).Point.IsAlmostEqualTo(new Vector3(6.5, 5.5), adaptiveGrid.Tolerance));
 
-            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(8, 6), out id, adaptiveGrid.Tolerance));
+            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(8, 6), out id));
             v = adaptiveGrid.GetVertex(id);
             Assert.Equal(5, v.Edges.Count);
             Assert.Contains(v.Edges, e => adaptiveGrid.GetVertex(
@@ -342,7 +342,7 @@ namespace Elements.Tests
             Assert.Contains(v.Edges, e => adaptiveGrid.GetVertex(
                 e.OtherVertexId(v.Id)).Point.IsAlmostEqualTo(new Vector3(8.5, 6.5), adaptiveGrid.Tolerance));
 
-            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(8, 8), out id, adaptiveGrid.Tolerance));
+            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(8, 8), out id));
             v = adaptiveGrid.GetVertex(id);
             Assert.Equal(5, v.Edges.Count);
             Assert.Contains(v.Edges, e => adaptiveGrid.GetVertex(
@@ -354,7 +354,7 @@ namespace Elements.Tests
             Assert.Contains(v.Edges, e => adaptiveGrid.GetVertex(
                 e.OtherVertexId(v.Id)).Point.IsAlmostEqualTo(new Vector3(7.5, 8.5), adaptiveGrid.Tolerance));
 
-            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(6, 8), out id, adaptiveGrid.Tolerance));
+            Assert.True(adaptiveGrid.TryGetVertexIndex(new Vector3(6, 8), out id));
             v = adaptiveGrid.GetVertex(id);
             Assert.Equal(5, v.Edges.Count);
             Assert.Contains(v.Edges, e => adaptiveGrid.GetVertex(
@@ -500,7 +500,7 @@ namespace Elements.Tests
                 new ConnectVertexStrategy(adaptiveGrid.GetVertex(otherId)));
             Assert.Equal(id, newVertex.Id);
             modified = vertex.Point + new Vector3(-halfTol, -halfTol, -halfTol);
-            adaptiveGrid.TryGetVertexIndex(modified, out otherId, adaptiveGrid.Tolerance);
+            adaptiveGrid.TryGetVertexIndex(modified, out otherId);
             Assert.Equal(id, otherId);
         }
 
@@ -697,26 +697,26 @@ namespace Elements.Tests
             //Start point already exist and the last one is snapped.
             Assert.Equal(verticesBefore + 4, grid.GetVertices().Count);
 
-            Assert.True(grid.TryGetVertexIndex(new Vector3(3, 5, 0), out var id, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(3, 5, 0), out var id));
             var vertex = grid.GetVertex(id);
             Assert.Equal(3, vertex.Edges.Count);
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(4, 5, 1)));
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(2, 5, 0)));
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(5, 5, 0)));
 
-            Assert.True(grid.TryGetVertexIndex(new Vector3(4, 5, 1), out id, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(4, 5, 1), out id));
             vertex = grid.GetVertex(id);
             Assert.Equal(2, vertex.Edges.Count);
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(3, 5, 0)));
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(5, 5, 1)));
 
-            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 5, 1), out id, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 5, 1), out id));
             vertex = grid.GetVertex(id);
             Assert.Equal(2, vertex.Edges.Count);
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(4, 5, 1)));
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(6, 5, 0)));
 
-            Assert.True(grid.TryGetVertexIndex(new Vector3(6, 5, 0), out id, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(6, 5, 0), out id));
             vertex = grid.GetVertex(id);
             Assert.Equal(3, vertex.Edges.Count);
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(5, 5, 1)));
@@ -1039,7 +1039,7 @@ namespace Elements.Tests
             var snapshot = grid.SnapshotEdgesOnPlane(plane);
             Assert.Equal(12, snapshot.Count);
 
-            grid.TryGetVertexIndex(new Vector3(5, 0, 1), out var id, grid.Tolerance);
+            grid.TryGetVertexIndex(new Vector3(5, 0, 1), out var id);
             grid.RemoveVertex(grid.GetVertex(id));
             var edgesBefore = grid.GetEdges().Count;
 
@@ -1047,7 +1047,7 @@ namespace Elements.Tests
             grid.InsertSnapshot(snapshot, transform);
             Assert.Equal(edgesBefore + 20, grid.GetEdges().Count);
 
-            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 5, 3), out id, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 5, 3), out id));
             var v = grid.GetVertex(id);
             Assert.Equal(4, v.Edges.Count);
             var neighbourPoints = v.Edges.Select(e => grid.GetVertex(e.OtherVertexId(v.Id)).Point);
@@ -1057,7 +1057,7 @@ namespace Elements.Tests
             Assert.Contains(new Vector3(0, 5, 2), neighbourPoints);
             Assert.DoesNotContain(new Vector3(0, 5, 1), neighbourPoints);
 
-            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 0, 3), out id, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(5, 0, 3), out id));
             v = grid.GetVertex(id);
             Assert.Equal(3, v.Edges.Count);
             neighbourPoints = v.Edges.Select(e => grid.GetVertex(e.OtherVertexId(v.Id)).Point);
@@ -1066,7 +1066,7 @@ namespace Elements.Tests
             Assert.Contains(new Vector3(5, 5, 3), neighbourPoints);
             Assert.DoesNotContain(new Vector3(5, 0, 1), neighbourPoints);
 
-            Assert.True(grid.TryGetVertexIndex(new Vector3(10, 5, 3), out id, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(10, 5, 3), out id));
             v = grid.GetVertex(id);
             Assert.Equal(5, v.Edges.Count);
             neighbourPoints = v.Edges.Select(e => grid.GetVertex(e.OtherVertexId(v.Id)).Point);

--- a/Elements/test/ObstacleTests.cs
+++ b/Elements/test/ObstacleTests.cs
@@ -209,11 +209,11 @@ namespace Elements
             Assert.Equal(diagonalObstacle.Points.Count, expectedPoints.Count);
             Assert.True(diagonalObstacle.Points.All(p => expectedPoints.Any(e => e.IsAlmostEqualTo(p))));
             grid.SubtractObstacle(diagonalObstacle);
-            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0.70711, 0), out id, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0.70711, 0), out id));
             vertex = grid.GetVertex(id);
             Assert.Equal(4, vertex.Edges.Count());
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(9.292891, 10, 0)));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(0.70711, 0, 0), out id, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0.70711, 0, 0), out id));
             vertex = grid.GetVertex(id);
             Assert.Equal(4, vertex.Edges.Count());
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(10, 9.292891, 0)));
@@ -337,10 +337,10 @@ namespace Elements
             Assert.Equal(diagonalObstacle.Points.Count, expectedPoints.Count);
             Assert.True(diagonalObstacle.Points.All(p => expectedPoints.Any(e => e.IsAlmostEqualTo(p))));
             grid.SubtractObstacle(diagonalObstacle);
-            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0.70711, 0), out id, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0, 0.70711, 0), out id));
             vertex = grid.GetVertex(id);
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(9.292891, 10, 0)));
-            Assert.True(grid.TryGetVertexIndex(new Vector3(0.70711, 0, 0), out id, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0.70711, 0, 0), out id));
             vertex = grid.GetVertex(id);
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(10, 9.292891, 0)));
 
@@ -363,7 +363,7 @@ namespace Elements
             Assert.Equal(verticalObstacle.Points.Count, expectedPoints.Count);
             Assert.True(verticalObstacle.Points.All(p => expectedPoints.Any(e => e.IsAlmostEqualTo(p))));
             grid.SubtractObstacle(verticalObstacle);
-            Assert.True(grid.TryGetVertexIndex(new Vector3(0.5, 0.5, 0), out id, grid.Tolerance));
+            Assert.True(grid.TryGetVertexIndex(new Vector3(0.5, 0.5, 0), out id));
             vertex = grid.GetVertex(id);
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(1, 0, 0)));
             Assert.Contains(vertex.Edges, e => grid.GetVertex(e.OtherVertexId(id)).Point.IsAlmostEqualTo(new Vector3(0, 1, 0)));


### PR DESCRIPTION
BACKGROUND:
- In most of the cases AdaptiveGrid.TryGetVertexIndex was used with AdaptiveGrid.Tolerance as tolerance parameter. And even if you would want to use larger parameter - function applies tolerance for each coordinate and return first point that has all coordinates less than tolerance away, so it's not suitable for bigger tolerances anyway.

DESCRIPTION:
- What does this PR specifically accomplish?

FUTURE WORK:
- To either do so nested dictionary return actual closest point within tolerance or change the internal structure in favor of something like octree.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
I moved changelog from 1.5.0 alpha 0 from 1.4.0 section to 1.5.0 section

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/939)
<!-- Reviewable:end -->
