### PR TITLE
add support for flipped extrude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.5.0
+
+### Added
+
+- `Extrude` Solid Operation supports an optional `Flipped` parameter to purposely turn its normals inside out.
+
 ## 1.4.0
 
 ### Added

--- a/Elements/src/Geometry/Kernel.cs
+++ b/Elements/src/Geometry/Kernel.cs
@@ -38,9 +38,9 @@ namespace Elements.Geometry
         /// Create an extrude.
         /// </summary>
         /// <returns>A solid.</returns>
-        public Solid CreateExtrude(Profile profile, double depth, Vector3 direction)
+        public Solid CreateExtrude(Profile profile, double depth, Vector3 direction, bool flipped = false)
         {
-            if (profile.Perimeter.Normal().Dot(direction) < 0)
+            if (profile.Perimeter.Normal().Dot(direction) < 0 != flipped)
             {
                 profile = profile.Reversed();
             }

--- a/Elements/src/Geometry/Solids/Extrude.cs
+++ b/Elements/src/Geometry/Solids/Extrude.cs
@@ -12,6 +12,7 @@ namespace Elements.Geometry.Solids
         private Profile _profile;
         private double _height;
         private Vector3 _direction;
+        private bool _flipped;
 
         /// <summary>The id of the profile to extrude.</summary>
         [JsonProperty("Profile", Required = Required.AllowNull)]
@@ -59,6 +60,21 @@ namespace Elements.Geometry.Solids
             }
         }
 
+        /// <summary>Is the extrusion flipped inside out?</summary>
+        [JsonProperty("Flipped")]
+        public bool Flipped
+        {
+            get { return _flipped; }
+            set
+            {
+                if (_flipped != value)
+                {
+                    _flipped = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
         /// <summary>
         /// Construct an extrusion.
         /// </summary>
@@ -67,7 +83,7 @@ namespace Elements.Geometry.Solids
         /// <param name="direction"></param>
         /// <param name="isVoid"></param>
         [JsonConstructor]
-        public Extrude(Profile @profile, double @height, Vector3 @direction, bool @isVoid)
+        public Extrude(Profile @profile, double @height, Vector3 @direction, bool @isVoid = false, bool flipped = false)
             : base(isVoid)
         {
             if (!Validator.DisableValidationOnConstruction)
@@ -81,6 +97,7 @@ namespace Elements.Geometry.Solids
             this._profile = @profile;
             this._height = @height;
             this._direction = @direction;
+            this._flipped = flipped;
 
             this.PropertyChanged += (sender, args) => { UpdateGeometry(); };
             UpdateGeometry();
@@ -88,7 +105,7 @@ namespace Elements.Geometry.Solids
 
         private void UpdateGeometry()
         {
-            this._solid = Kernel.Instance.CreateExtrude(this._profile, this._height, this._direction);
+            this._solid = Kernel.Instance.CreateExtrude(this._profile, this._height, this._direction, this._flipped);
         }
     }
 }

--- a/Elements/src/Geometry/Solids/Extrude.cs
+++ b/Elements/src/Geometry/Solids/Extrude.cs
@@ -78,12 +78,17 @@ namespace Elements.Geometry.Solids
         /// <summary>
         /// Construct an extrusion.
         /// </summary>
-        /// <param name="profile"></param>
-        /// <param name="height"></param>
-        /// <param name="direction"></param>
-        /// <param name="isVoid"></param>
+        /// <param name="profile">The profile to extrude.</param>
+        /// <param name="height">The height/length of the extrusion.</param>
+        /// <param name="direction">The direction of the extrusion.</param>
+        /// <param name="isVoid">If true, the extrusion is a "void" in a group
+        /// of solid operations, subtracted from other solids.</param>
+        /// <param name="flipped">True if the extrusion should be flipped inside
+        /// out, with normals facing in instead of out. Use with caution if
+        /// using with other solid operations in a representation — boolean
+        /// results may be unexpected.</param>
         [JsonConstructor]
-        public Extrude(Profile @profile, double @height, Vector3 @direction, bool @isVoid = false, bool flipped = false)
+        public Extrude(Profile profile, double height, Vector3 direction, bool isVoid = false, bool flipped = false)
             : base(isVoid)
         {
             if (!Validator.DisableValidationOnConstruction)
@@ -94,9 +99,9 @@ namespace Elements.Geometry.Solids
                 }
             }
 
-            this._profile = @profile;
-            this._height = @height;
-            this._direction = @direction;
+            this._profile = profile;
+            this._height = height;
+            this._direction = direction;
             this._flipped = flipped;
 
             this.PropertyChanged += (sender, args) => { UpdateGeometry(); };

--- a/Elements/test/SolidTests.cs
+++ b/Elements/test/SolidTests.cs
@@ -740,6 +740,36 @@ namespace Elements.Tests
             Assert.Equal(8, buffer.FacetCount); // Two faces of 4 facets each.
         }
 
+        [Fact]
+        public void FlippedExtrude()
+        {
+            Name = nameof(FlippedExtrude);
+            var normalExtrude = new Extrude(Polygon.Rectangle(1, 1), 1, Vector3.ZAxis);
+            var flippedExtrude = new Extrude(Polygon.Rectangle(1, 1).TransformedPolygon(new Transform(2, 0, 0)), 1, Vector3.ZAxis, false, true);
+            var geo = new GeometricElement
+            {
+                Representation = new Representation(normalExtrude, flippedExtrude)
+            };
+            Model.AddElement(geo);
+            var centroid1 = new Vector3(0, 0, 0.5);
+            var centroid2 = new Vector3(2, 0, 0.5);
+            Assert.All(normalExtrude._solid.Faces, (face) =>
+            {
+                var faceCenter = face.Value.Outer.ToPolygon().Centroid();
+                var centroidToFaceCenter = faceCenter - centroid1;
+                var faceNormal = face.Value.Plane().Normal;
+                Assert.True(centroidToFaceCenter.Unitized().Dot(faceNormal.Unitized()) == 1.0);
+            });
+            Assert.All(flippedExtrude._solid.Faces, (face) =>
+            {
+                var faceCenter = face.Value.Outer.ToPolygon().Centroid();
+                var centroidToFaceCenter = faceCenter - centroid2;
+                var faceNormal = face.Value.Plane().Normal;
+                Assert.True(centroidToFaceCenter.Unitized().Dot(faceNormal.Unitized()) == -1.0);
+            });
+            // Visually verify that flipped geometry is flipped.
+        }
+
         private class DebugInfo
         {
             public List<Solid> Solid { get; set; }


### PR DESCRIPTION
BACKGROUND:
- For Hypar Space, we rely on a visual trick for our spaces — we turn them inside out, with their normals inwards, so that you only see the faces on the opposite side of the room, and can look through the top to see the furniture, and easily select it. 
- This is presently achieved by manually building a `ConstructedSolid` direct from faces, since `Extrude` has a built-in check to ensure that normals point out. This works fine, but means that we serialize much more data than is needed in the model: we have to store every vertex, edge, and face, which makes the model json heavy. 

DESCRIPTION:
- Adds an optional `Flipped` property, which inverts the normal check when building the extrude. if `Flipped` is true, the profile is flipped w/r/t the extrusion direction, resulting in an inside-out shape. 

TESTING:
- I added a new test which verifies technically and visually that the `Flipped` parameter has the desired effect.
![image](https://user-images.githubusercontent.com/31935763/217262425-235e8f13-65d4-415c-b119-c12adbbd31e4.png)

FUTURE WORK:
- It is conceivable, if a bit unlikely, that other primitives might want similar behavior. 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/940)
<!-- Reviewable:end -->
