### PR TITLE
AdaptiveGrid. Fix tolerances and vertices loopkup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `Message.FromLine` is set obsolete.
 - In `AdaptiveGridRouting`, if there are several connection points with the same cost - choose one that is closer to the trunk.
 - GLTF writing now includes an ad-hoc `HYPAR_info` extension which aids in mapping between GLTF content and element ids in the model.
+- `AdaptiveGrid.Tolerance` is not distance tolerance. Half the tolerance is used for individual coordinates snapping inside the grid.
 
 ### Fixed
 
@@ -42,6 +43,7 @@
 - Fixed an issue where `Grid2d.GetCells()` multiple times could fail to return the correct results on subsequent calls, because changes to the axis grids were not invalidating the grid's computed cells.
 - Adding the first vertex to a mesh with `merge: true` would throw an exception, this is fixed.
 - Handle quotes in string literals for content catalog code generation by doubling them up.
+- Fix `AdaptiveGrid.TryGetVertexIndex` returning `false` for existing vertex if other vertex has similar X or Y coordinate.
 
 ## 1.3.0
 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -61,9 +61,8 @@ namespace Elements.Spatial.AdaptiveGrid
         #region Properties
 
         /// <summary>
-        /// Tolerance for points being considered the same.
-        /// Applies individually to X, Y, and Z coordinates, not the cumulative difference!
-        /// Tolerance is twice the epsilon to make sure graph has no cracks when new sections are added.
+        /// Distance tolerance for points being considered the same.
+        /// Tolerance is twice the epsilon because gird uses single tolerance for individual coordinates snapping.
         /// </summary>
         public double Tolerance { get; } = Vector3.EPSILON * 2;
 
@@ -357,13 +356,13 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <returns>True if any Vertex is close enough.</returns>
         public bool TryGetVertexIndex(Vector3 point, out ulong id)
         {
-            var zDict = GetAddressParent(_verticesLookup, point, tolerance: Tolerance);
+            var zDict = GetAddressParent(_verticesLookup, point, tolerance: Tolerance / 2);
             if (zDict == null)
             {
                 id = 0;
                 return false;
             }
-            return TryGetValue(zDict, point.Z, out id, Tolerance);
+            return TryGetValue(zDict, point.Z, out id, Tolerance / 2);
         }
 
         /// <summary>
@@ -395,7 +394,7 @@ namespace Elements.Spatial.AdaptiveGrid
         {
             if (!TryGetVertexIndex(point, out var id))
             {
-                var zDict = GetAddressParent(_verticesLookup, point, true, Tolerance);
+                var zDict = GetAddressParent(_verticesLookup, point, true, Tolerance / 2);
                 id = this._vertexId;
                 var vertex = new Vertex(id, point);
                 zDict[point.Z] = id;
@@ -1295,14 +1294,14 @@ namespace Elements.Spatial.AdaptiveGrid
         {
             var vertex = _vertices[id];
             _vertices.Remove(id);
-            var zDict = GetAddressParent(_verticesLookup, vertex.Point, tolerance: Tolerance);
+            var zDict = GetAddressParent(_verticesLookup, vertex.Point, tolerance: Tolerance / 2);
             if (zDict == null)
             {
                 return;
             }
             zDict.Remove(vertex.Point.Z);
 
-            TryGetValue(_verticesLookup, vertex.Point.X, out var yzDict, Tolerance);
+            TryGetValue(_verticesLookup, vertex.Point.X, out var yzDict, Tolerance / 2);
             if (zDict.Count == 0)
             {
                 yzDict.Remove(vertex.Point.Y);

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -908,10 +908,10 @@ namespace Elements.Spatial.AdaptiveGrid
                 }
                 else if (oldEdgeLine.Direction().IsParallelTo(newEdgeLine.Direction()))
                 {
-                    var isNewEdgeStartOnOldEdge = oldEdgeLine.PointOnLine(newEdgeLine.Start);
-                    var isNewEdgeEndOnOldEdge = oldEdgeLine.PointOnLine(newEdgeLine.End);
-                    var isOldEdgeStartOnNewEdge = newEdgeLine.PointOnLine(oldEdgeLine.Start, true);
-                    var isOldEdgeEndOnNewEdge = newEdgeLine.PointOnLine(oldEdgeLine.End, true);
+                    var isNewEdgeStartOnOldEdge = oldEdgeLine.PointOnLine(newEdgeLine.Start, false, Tolerance);
+                    var isNewEdgeEndOnOldEdge = oldEdgeLine.PointOnLine(newEdgeLine.End, false, Tolerance);
+                    var isOldEdgeStartOnNewEdge = newEdgeLine.PointOnLine(oldEdgeLine.Start, true, Tolerance);
+                    var isOldEdgeEndOnNewEdge = newEdgeLine.PointOnLine(oldEdgeLine.End, true, Tolerance);
                     // new edge is inside old edge
                     if (isNewEdgeStartOnOldEdge && isNewEdgeEndOnOldEdge &&
                         AddEdgeInsideExisting(edgeV0, edgeV1, startVertex, endVertex))

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -356,7 +356,7 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <returns>True if any Vertex is close enough.</returns>
         public bool TryGetVertexIndex(Vector3 point, out ulong id)
         {
-            id = GetVertexFromDictionary(point, out _, out _, tolerance: Tolerance / 2);
+            id = GetFromXYZLookup(point, out _, out _, tolerance: Tolerance / 2);
             return id != 0;
         }
 
@@ -370,7 +370,7 @@ namespace Elements.Spatial.AdaptiveGrid
         [Obsolete("Tolerance parameter is obsolete. Grid automatically uses it's internal tolerance.")]
         public bool TryGetVertexIndex(Vector3 point, out ulong id, double? tolerance)
         {
-            id = GetVertexFromDictionary(point, out _, out _, tolerance: tolerance);
+            id = GetFromXYZLookup(point, out _, out _, tolerance: tolerance);
             return id != 0; 
         }
 
@@ -382,12 +382,12 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <returns>New or existing Vertex.</returns>
         public Vertex AddVertex(Vector3 point)
         {
-            var id = GetVertexFromDictionary(point, out var yzLookup, out var zLookup, Tolerance / 2);
+            var id = GetFromXYZLookup(point, out var yzLookup, out var zLookup, Tolerance / 2);
             if (id == 0)
             {
                 id = this._vertexId;
                 var vertex = new Vertex(id, point);
-                AddVertexToDictionary(vertex, yzLookup, zLookup);
+                AddToXYZLookup(vertex, yzLookup, zLookup);
                 _vertices[id] = vertex;
                 this._vertexId++;
                 return vertex;
@@ -1285,7 +1285,7 @@ namespace Elements.Spatial.AdaptiveGrid
         {
             var vertex = _vertices[id];
             _vertices.Remove(id);
-            DeleteVertexFromDictionary(vertex);
+            DeleteFromXYZLookup(vertex);
         }
 
         private Grid2d CreateGridFromPolygon(Polygon boundingPolygon)
@@ -1460,10 +1460,10 @@ namespace Elements.Spatial.AdaptiveGrid
             }
         }
 
-        private ulong GetVertexFromDictionary(Vector3 point,
-                                              out Dictionary<double, Dictionary<double, ulong>> yzLookup,
-                                              out Dictionary<double, ulong> zLookup,
-                                              double? tolerance = null)
+        private ulong GetFromXYZLookup(Vector3 point,
+                                       out Dictionary<double, Dictionary<double, ulong>> yzLookup,
+                                       out Dictionary<double, ulong> zLookup,
+                                       double? tolerance = null)
         {
             yzLookup = null;
             zLookup = null;
@@ -1484,9 +1484,9 @@ namespace Elements.Spatial.AdaptiveGrid
             return 0;
         }
 
-        private void AddVertexToDictionary(Vertex vertex,
-                                           Dictionary<double, Dictionary<double, ulong>> yzLookup,
-                                           Dictionary<double, ulong> zLookup)
+        private void AddToXYZLookup(Vertex vertex,
+                                    Dictionary<double, Dictionary<double, ulong>> yzLookup,
+                                    Dictionary<double, ulong> zLookup)
         {
             if (yzLookup == null)
             {
@@ -1503,9 +1503,9 @@ namespace Elements.Spatial.AdaptiveGrid
             zLookup[vertex.Point.Z] = vertex.Id;
         }
 
-        private void DeleteVertexFromDictionary(Vertex vertex)
+        private void DeleteFromXYZLookup(Vertex vertex)
         {
-            var id = GetVertexFromDictionary(vertex.Point, out var yzLookup, out var zLookup, Tolerance / 2);
+            var id = GetFromXYZLookup(vertex.Point, out var yzLookup, out var zLookup, Tolerance / 2);
             if (id == 0 || id != vertex.Id || zLookup == null || yzLookup == null)
             {
                 throw new Exception("Vertex can't be removed. Coordinate dictionary is broken.");

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -1441,15 +1441,6 @@ namespace Elements.Spatial.AdaptiveGrid
             return true;
         }
 
-        /// <summary>
-        /// A version of TryGetValue on a dictionary that optionally takes in a tolerance when running the comparison.
-        /// </summary>
-        /// <param name="dict"></param>
-        /// <param name="key">Number to search for.</param>
-        /// <param name="value">Value if match was found.</param>
-        /// <param name="tolerance">Amount of tolerance in the search for the key.</param>
-        /// <typeparam name="T">The type of the dictionary values.</typeparam>
-        /// <returns>Whether a match was found.</returns>
         private static IEnumerable<T> GetValue<T>(Dictionary<double, T> dict, double key, double? tolerance = null)
 
         {
@@ -1469,14 +1460,6 @@ namespace Elements.Spatial.AdaptiveGrid
             }
         }
 
-        /// <summary>
-        /// In a dictionary of x, y, and z coordinates, gets last level dictionary of z values.
-        /// </summary>
-        /// <param name="dict"></param>
-        /// <param name="point"></param>
-        /// <param name="addAddressIfNonExistent">Whether to create the dictionary address if it didn't previously exist.</param>
-        /// <param name="tolerance">Amount of tolerance in the search against each component of the coordinate.</param>
-        /// <returns>The created or existing last level of values. This can be null if the dictionary address didn't exist previously, and we chose not to add it.</returns>
         private ulong GetVertexFromDictionary(Vector3 point,
                                               out Dictionary<double, Dictionary<double, ulong>> yzDict,
                                               out Dictionary<double, ulong> zDict,
@@ -1501,14 +1484,6 @@ namespace Elements.Spatial.AdaptiveGrid
             return 0;
         }
 
-        /// <summary>
-        /// In a dictionary of x, y, and z coordinates, gets last level dictionary of z values.
-        /// </summary>
-        /// <param name="dict"></param>
-        /// <param name="point"></param>
-        /// <param name="addAddressIfNonExistent">Whether to create the dictionary address if it didn't previously exist.</param>
-        /// <param name="tolerance">Amount of tolerance in the search against each component of the coordinate.</param>
-        /// <returns>The created or existing last level of values. This can be null if the dictionary address didn't exist previously, and we chose not to add it.</returns>
         private void AddVertexToDictionary(Vertex vertex,
                                            Dictionary<double, Dictionary<double, ulong>> yzDict,
                                            Dictionary<double, ulong> zDict)

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -1078,6 +1078,22 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void AdaptiveGridFindsCorrectVertex()
+        {
+            AdaptiveGrid grid = new AdaptiveGrid();
+            var v0 = grid.AddVertex(new Vector3(0.999992, 1.000005, 9));
+            var v1 = grid.AddVertex(new Vector3(1.000008, 1.000005, 1));
+            var v2 = grid.AddVertex(new Vector3(1, 0.999995, 4));
+
+            Assert.True(grid.TryGetVertexIndex((1, 1, 9), out var id0));
+            Assert.True(grid.TryGetVertexIndex((1, 1, 1), out var id1));
+            Assert.True(grid.TryGetVertexIndex((1, 1, 4), out var id2));
+            Assert.Equal(v0.Id, id0);
+            Assert.Equal(v1.Id, id1);
+            Assert.Equal(v2.Id, id2);
+        }
+
+        [Fact]
         public void EdgeInfoFlagsTest()
         {
             AdaptiveGrid grid = new AdaptiveGrid();

--- a/Elements/test/ClipperTest.cs
+++ b/Elements/test/ClipperTest.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+using Elements.Geometry;
+using Xunit;
+
+namespace Elements
+{
+    public class ClipperTest
+    {
+        [Fact]
+        public void CliperChangesInputNumbers()
+        {
+            var range = Enumerable.Range(1, 100);
+            var vertices = new List<Vector3>();
+            var random = new Random();
+            var z = 1.23456789;
+            random.NextDouble();
+            vertices.AddRange(range.Select(r => new Vector3(
+                r + (random.NextDouble() - 0.5) * Vector3.EPSILON, 0, z)));
+            vertices.AddRange(range.Select(r => new Vector3(
+                100, r + (random.NextDouble() - 0.5) * Vector3.EPSILON, z)));
+            vertices.AddRange(range.Reverse().Select(r => new Vector3(
+                r + (random.NextDouble() - 0.5) * Vector3.EPSILON, 100, z)));
+            vertices.AddRange(range.Reverse().Select(r => new Vector3(
+                0, r + (random.NextDouble() - 0.5) * Vector3.EPSILON, z)));
+
+            Polygon polygon = new Polygon(vertices);
+            polygon = polygon.TransformedPolygon(new Transform().Rotated(Vector3.ZAxis, 25));
+
+            var tolerance = Vector3.EPSILON * 2;
+            var clipperPath = polygon.ToClipperPath(tolerance);
+            var changedPolygon = clipperPath.ToPolygon(tolerance);
+            Assert.Equal(polygon.Vertices.Count, changedPolygon.Vertices.Count);
+
+            for (int i = 0; i < polygon.Vertices.Count; i++)
+            {
+                var dx = polygon.Vertices[i].X - changedPolygon.Vertices[i].X;
+                var dy = polygon.Vertices[i].Y - changedPolygon.Vertices[i].Y;
+                Assert.True(polygon.Vertices[i].X != changedPolygon.Vertices[i].X);
+                Assert.True(polygon.Vertices[i].Y != changedPolygon.Vertices[i].Y);
+                Assert.True(Math.Abs(dx) <= tolerance / 2);
+                Assert.True(Math.Abs(dy) <= tolerance / 2);
+                Assert.True(changedPolygon.Vertices[i].Z == 0d);
+
+                var v2d = new Vector3(polygon.Vertices[i].X, polygon.Vertices[i].Y);
+                var dp = v2d.DistanceTo(changedPolygon.Vertices[i]);
+                Assert.True(dp < tolerance);
+            }
+        }
+    }
+}


### PR DESCRIPTION
BACKGROUND:
- During my work with AdaptiveGrid I encountered weird errors time to time: two vertices were inserted into the same spot, or I was not able to retrieve the vertex that is there by it approximate coordinates within the tolerance.  

DESCRIPTION:
- AdaptiveGrid.AddCutEdge: provided missing tolerance parameter PointOnLine. It's necessary since non default tolerance is used in AdaptiveGrid. 
- Define AdaptiveGrid.Tolerance as distance tolerance. Set coordinate tolerance as half of tolerance, so sum of deviations is still less than twice the tolerance.
- Rework vertices lookup of AdaptiveGrid. Don't just check the first suitable X/Y coordinate. Go over each suitable coordinate branch until good vertex is found. The complexity stays the same but function is no longer error prone.

TESTING:
- Added ClipperTest file that shows data modification tolerances.
- Added AdaptiveGridFindsCorrectVertex test that shows weak spot of previous lookup implementation.
- All existing tests are passing.
  
FUTURE WORK:
- I'm considering not using Grid2D for splitting Polygon by a set points. The problem is simple enough and not really require boolean operation. This way I'll eliminate input data modifications made by Clipper.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/941)
<!-- Reviewable:end -->
