### PR TITLE
Add Line.DistanceTo(Line)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `RoutingHintLine.Affects`
 - `SvgFaceElevation`
 - `Units.FeetToFeetAndFractionalInches`, `Units.InchesToFractionalInches`
+- `Line.DistanceTo(Line other)`
 
 ### Changed
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -851,61 +851,64 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Measures the distance between two lines.
+        /// Measure the distance between two lines.
         /// </summary>
-        /// <param name="other">The line to measure the distance to</param>
-        /// <returns></returns>
+        /// <param name="other">The line to measure the distance to.</param>
         public double DistanceTo(Line other)
         {
             Vector3 dStartStart = this.Start - other.Start;
-            Vector3 vThis = this.End - this.Start,
-                    vOther = other.End - other.Start;
+            Vector3 vThis = this.End - this.Start;
+            Vector3 vOther = other.End - other.Start;
             Vector3 cross = vThis.Cross(vOther);
-            // directional vectors are collinear
+            // line vectors are collinear - two segments share the same infinite line on the infinite line.
             if (cross.IsZero())
             {
-                // the projection of this.Start is outside of the other, closer to other.Start
+                // if start of this line is "before" start of the other line.
                 if (vOther.Dot(dStartStart) < 0)
                 {
                     Vector3 dEndStart = this.End - other.Start;
-                    // the projection of this.End is outside of the other, closer to the other.Start
+                    // and end of this line is "before" start of the other line - line are not overlapping,
+                    // otherwise the projection of this contains other.Start
                     if (vOther.Dot(dEndStart) < 0)
                     {
+                        // the projection of this line is outside of the other, closer to other.Start
                         return Math.Sqrt(Math.Min(dStartStart.LengthSquared(), dEndStart.LengthSquared()));
                     }
-                    // otherwise the projection of this contains other.Start
                 }
-                // the projection og this.Start is either inside the other or outside, but closer to other.End
                 else
                 {
                     Vector3 dStartEnd = this.Start - other.End;
-                    // the projection of this.Start is outside of the other, closer to other.End
+                    // if end of this line is "after" end of the other line,
+                    // otherwise the projection of this.Start is inside other.
                     if (vOther.Dot(dStartEnd) > 0)
                     {
                         Vector3 dEndEnd = this.End - other.End;
-                        // the projection of this.End is outside of the other, closer to other.End
+                        // and start of this line is "after" end of the other line.
                         if (vOther.Dot(dEndEnd) > 0)
                         {
+                            // the projection of this line is outside of the other, closer to other.End
                             return Math.Sqrt(Math.Min(dStartEnd.LengthSquared(), dEndEnd.LengthSquared()));
                         }
-                        // otherwise the projection of this contains other.End
                     }
-                    // otherwise the projection of this.Start is inside other
                 }
                 dStartStart -= dStartStart.ProjectOnto(vThis);
             }
-            // directional vectors are not collinear, they span a 2-dimensional space, so the shortest segment connection two lines is collinear to their cross product
+            // line vectors are not collinear, their directions share the common plane.
             else
             {
-                dStartStart = dStartStart.ProjectOnto(cross); // the shortest segment
-                Vector3 vStartStart = other.Start + dStartStart - this.Start,
-                        vStartEnd = other.Start + dStartStart - this.End,
-                        vEndStart = other.End + dStartStart - this.Start,
-                        vEndEnd = other.End + dStartStart - this.End;
+                // dStartStart length is distance to the common plane. 
+                dStartStart = dStartStart.ProjectOnto(cross);
+                Vector3 vStartStart = other.Start + dStartStart - this.Start;
+                Vector3 vStartEnd = other.Start + dStartStart - this.End;
+                Vector3 vEndStart = other.End + dStartStart - this.Start;
+                Vector3 vEndEnd = other.End + dStartStart - this.End;
                 // other + dStartStart and this are now in the same plane
-                // we check whether other is fully on one side of this or vice versa, id est whether this and other + dStartStart intersect
-                if (vStartStart.Cross(vStartEnd).Dot(vEndStart.Cross(vEndEnd)) > 0 || vStartStart.Cross(vEndStart).Dot(vStartEnd.Cross(vEndEnd)) > 0)
+                // check if other is fully on one side of this or vice versa,
+                // in other words, if  this and `other + dStartStart` intersect on a shred plane
+                if (vStartStart.Cross(vStartEnd).Dot(vEndStart.Cross(vEndEnd)) > 0 ||
+                    vStartStart.Cross(vEndStart).Dot(vStartEnd.Cross(vEndEnd)) > 0)
                 {
+                    // if not intersect - shortest distance is minimum distance from a point to other line.
                     return Math.Min(Math.Min(this.Start.DistanceTo(other), this.End.DistanceTo(other)),
                                     Math.Min(other.Start.DistanceTo(this), other.End.DistanceTo(this)));
                 }

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -851,6 +851,70 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Measures the distance between two lines.
+        /// </summary>
+        /// <param name="other">The line to measure the distance to</param>
+        /// <returns></returns>
+        public double DistanceTo(Line other)
+        {
+            Vector3 dStartStart = this.Start - other.Start;
+            Vector3 vThis = this.End - this.Start,
+                    vOther = other.End - other.Start;
+            Vector3 cross = vThis.Cross(vOther);
+            // directional vectors are collinear
+            if (cross.IsZero())
+            {
+                // the projection of this.Start is outside of the other, closer to other.Start
+                if (vOther.Dot(dStartStart) < 0)
+                {
+                    Vector3 dEndStart = this.End - other.Start;
+                    // the projection of this.End is outside of the other, closer to the other.Start
+                    if (vOther.Dot(dEndStart) < 0)
+                    {
+                        return Math.Sqrt(Math.Min(dStartStart.LengthSquared(), dEndStart.LengthSquared()));
+                    }
+                    // otherwise the projection of this contains other.Start
+                }
+                // the projection og this.Start is either inside the other or outside, but closer to other.End
+                else
+                {
+                    Vector3 dStartEnd = this.Start - other.End;
+                    // the projection of this.Start is outside of the other, closer to other.End
+                    if (vOther.Dot(dStartEnd) > 0)
+                    {
+                        Vector3 dEndEnd = this.End - other.End;
+                        // the projection of this.End is outside of the other, closer to other.End
+                        if (vOther.Dot(dEndEnd) > 0)
+                        {
+                            return Math.Sqrt(Math.Min(dStartEnd.LengthSquared(), dEndEnd.LengthSquared()));
+                        }
+                        // otherwise the projection of this contains other.End
+                    }
+                    // otherwise the projection of this.Start is inside other
+                }
+                dStartStart -= dStartStart.ProjectOnto(vThis);
+            }
+            // directional vectors are not collinear, they span a 2-dimensional space, so the shortest segment connection two lines is collinear to their cross product
+            else
+            {
+                dStartStart = dStartStart.ProjectOnto(cross); // the shortest segment
+                Vector3 vStartStart = other.Start + dStartStart - this.Start,
+                        vStartEnd = other.Start + dStartStart - this.End,
+                        vEndStart = other.End + dStartStart - this.Start,
+                        vEndEnd = other.End + dStartStart - this.End;
+                // other + dStartStart and this are now in the same plane
+                // we check whether other is fully on one side of this or vice versa, id est whether this and other + dStartStart intersect
+                if (vStartStart.Cross(vStartEnd).Dot(vEndStart.Cross(vEndEnd)) > 0 || vStartStart.Cross(vEndStart).Dot(vStartEnd.Cross(vEndEnd)) > 0)
+                {
+                    return Math.Min(Math.Min(this.Start.DistanceTo(other), this.End.DistanceTo(other)),
+                                    Math.Min(other.Start.DistanceTo(this), other.End.DistanceTo(this)));
+                }
+            }
+
+            return dStartStart.Length();
+        }
+
+        /// <summary>
         /// Trim a line with a polygon.
         /// </summary>
         /// <param name="polygon">The polygon to trim with.</param>

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -541,7 +541,7 @@ namespace Elements.Geometry
         public Vector3 ProjectOnto(Vector3 a)
         {
             var b = this;
-            return (a.Dot(b) / Math.Pow(a.Length(), 2)) * a;
+            return (a.Dot(b) / a.LengthSquared()) * a;
         }
 
         /// <summary>

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -946,13 +946,21 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
-        public void LineDistanceParametric()
+        public void LineDistancePointsOnOneLine()
         {
             //Points on one line.
             Vector3 pt = new Vector3(-2.685818406894334, -2.476879934864206, -0.5565494179776103);
-            Vector3 v = new Vector3(-2.3537985903693657, 2.407193267710168, -2.771078003386066);
-            double q1 = -1.7567568535640823, q2 = -0.21721224020356145, q3 = 1.006813808941921, q4 = 2.112519713576212;
-            Vector3 pt1 = pt + q1 * v, pt2 = pt + q2 * v, pt3 = pt + q3 * v, pt4 = pt + q4 * v;
+            Vector3 direction = new Vector3(-2.3537985903693657, 2.407193267710168, -2.771078003386066);
+            //Sorted distance quantities from point by the vector.
+            double q1 = -1.7567568535640823;
+            double q2 = -0.21721224020356145;
+            double q3 = 1.006813808941921;
+            double q4 = 2.112519713576212;
+            //p1, p2, p3, p4 are on the same line defined by pt + direction * t equation.
+            Vector3 pt1 = pt + q1 * direction;
+            Vector3 pt2 = pt + q2 * direction;
+            Vector3 pt3 = pt + q3 * direction;
+            Vector3 pt4 = pt + q4 * direction;
             //Segments don't intersect.
             var expected = (pt3 - pt2).Length();
             Assert.Equal(expected, (new Line(pt1, pt2)).DistanceTo(new Line(pt3, pt4)), 12);
@@ -981,16 +989,30 @@ namespace Elements.Geometry.Tests
             Assert.Equal(0, (new Line(pt2, pt4)).DistanceTo(new Line(pt3, pt1)), 12);
             Assert.Equal(0, (new Line(pt4, pt2)).DistanceTo(new Line(pt1, pt3)), 12);
             Assert.Equal(0, (new Line(pt4, pt2)).DistanceTo(new Line(pt3, pt1)), 12);
+        }
 
+        [Fact]
+        public void LineDistancePointsOnTwoIndependentLines()
+        {
             //Two groups of points on two lines.
-            pt = new Vector3(2.798721214152833, -0.3556044049478837, -2.9550511796484766);
+            Vector3 pt = new Vector3(2.798721214152833, -0.3556044049478837, -2.9550511796484766);
             Vector3 v1 = new Vector3(2.465855774694745, 2.6356139841825836, 0.4933654383536945);
             Vector3 v2 = new Vector3(1.0293808889279106, -2.4963706389774964, 1.5988855967507778);
-            double q11 = -1.5791413478212935, q12 = 0.81511586964034, q13 = 1.732636303417701;
-            double q21 = -0.9234662064172614, q22 = 0.64387549346853, q23 = 2.083473245643838;
-            Vector3 pt11 = pt + q11 * v1, pt12 = pt + q12 * v1, pt13 = pt + q13 * v1;
-            Vector3 pt21 = pt + q21 * v2, pt22 = pt + q22 * v2;
-            //The segments intersect.
+            //Sorted distance quantities from point by the first vector.
+            double q11 = -1.5791413478212935;
+            double q12 = 0.81511586964034;
+            double q13 = 1.732636303417701;
+            //Sorted distance quantities from point by the first vector.
+            double q21 = -0.9234662064172614;
+            double q22 = 0.64387549346853;
+            //p11, p12, p13 are one the same line defined by pt + v1 * t equation.
+            Vector3 pt11 = pt + q11 * v1;
+            Vector3 pt12 = pt + q12 * v1;
+            Vector3 pt13 = pt + q13 * v1;
+            //p21, p22 are one the same line defined by pt + v2 * t equation.
+            Vector3 pt21 = pt + q21 * v2;
+            Vector3 pt22 = pt + q22 * v2;
+            //The segments (pt11, pt12) and (pt21, pt22) intersect.
             Assert.Equal(0, (new Line(pt11, pt12)).DistanceTo(new Line(pt21, pt22)), 12);
             Assert.Equal(0, (new Line(pt11, pt12)).DistanceTo(new Line(pt22, pt21)), 12);
             Assert.Equal(0, (new Line(pt12, pt11)).DistanceTo(new Line(pt21, pt22)), 12);
@@ -999,6 +1021,7 @@ namespace Elements.Geometry.Tests
             Assert.Equal(0, (new Line(pt21, pt22)).DistanceTo(new Line(pt12, pt11)), 12);
             Assert.Equal(0, (new Line(pt22, pt21)).DistanceTo(new Line(pt11, pt12)), 12);
             Assert.Equal(0, (new Line(pt22, pt21)).DistanceTo(new Line(pt12, pt11)), 12);
+            //The segments (pt12, pt13) and (pt21, pt22) does not intersect.
             //The shortest distance is between an endpoint and another segment.
             Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt12, pt13)).DistanceTo(new Line(pt21, pt22)), 12);
             Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt12, pt13)).DistanceTo(new Line(pt22, pt21)), 12);
@@ -1008,59 +1031,91 @@ namespace Elements.Geometry.Tests
             Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt21, pt22)).DistanceTo(new Line(pt13, pt12)), 12);
             Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt22, pt21)).DistanceTo(new Line(pt12, pt13)), 12);
             Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt22, pt21)).DistanceTo(new Line(pt13, pt12)), 12);
+        }
 
-            //Parallel lines - v2 is orthogonal to v1.
-            pt = new Vector3(2.798721214152833, -0.3556044049478837, -2.9550511796484766);
-            v1 = new Vector3(2.465855774694745, 2.6356139841825836, 0.4933654383536945);
-            v2 = new Vector3(1.633720404719513, -1.8504262591965435, 1.7198011154858075); 
-            q1 = -1.5791413478212935; q2 = -0.81511586964034; q3 = 0.732636303417701; q4 = 1.9234662064172614;
-            //The segments do not overlap.
-            expected = (v2 + (q3 - q2) * v1).Length();
-            Assert.Equal(expected, (new Line(pt + q1 * v1, pt + q2 * v1)).DistanceTo(new Line(pt + v2 + q3 * v1, pt + v2 + q4 * v1)), 12);
-            Assert.Equal(expected, (new Line(pt + q1 * v1, pt + q2 * v1)).DistanceTo(new Line(pt + v2 + q4 * v1, pt + v2 + q3 * v1)), 12);
-            Assert.Equal(expected, (new Line(pt + q2 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q3 * v1, pt + v2 + q4 * v1)), 12);
-            Assert.Equal(expected, (new Line(pt + q2 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q4 * v1, pt + v2 + q3 * v1)), 12);
-            Assert.Equal(expected, (new Line(pt + v2 + q1 * v1, pt + v2 + q2 * v1)).DistanceTo(new Line(pt + q3 * v1, pt + q4 * v1)), 12);
-            Assert.Equal(expected, (new Line(pt + v2 + q1 * v1, pt + v2 + q2 * v1)).DistanceTo(new Line(pt + q4 * v1, pt + q3 * v1)), 12);
-            Assert.Equal(expected, (new Line(pt + v2 + q2 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q3 * v1, pt + q4 * v1)), 12);
-            Assert.Equal(expected, (new Line(pt + v2 + q2 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q4 * v1, pt + q3 * v1)), 12);
-            //One segment covers another one.
-            Assert.Equal(v2.Length(), (new Line(pt + q1 * v1, pt + q4 * v1)).DistanceTo(new Line(pt + v2 + q2 * v1, pt + v2 + q3 * v1)), 12);
-            Assert.Equal(v2.Length(), (new Line(pt + q1 * v1, pt + q4 * v1)).DistanceTo(new Line(pt + v2 + q3 * v1, pt + v2 + q2 * v1)), 12);
-            Assert.Equal(v2.Length(), (new Line(pt + q4 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q2 * v1, pt + v2 + q3 * v1)), 12);
-            Assert.Equal(v2.Length(), (new Line(pt + q4 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q3 * v1, pt + v2 + q2 * v1)), 12);
-            Assert.Equal(v2.Length(), (new Line(pt + v2 + q1 * v1, pt + v2 + q4 * v1)).DistanceTo(new Line(pt + q2 * v1, pt + q3 * v1)), 12);
-            Assert.Equal(v2.Length(), (new Line(pt + v2 + q1 * v1, pt + v2 + q4 * v1)).DistanceTo(new Line(pt + q3 * v1, pt + q2 * v1)), 12);
-            Assert.Equal(v2.Length(), (new Line(pt + v2 + q4 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q2 * v1, pt + q3 * v1)), 12);
-            Assert.Equal(v2.Length(), (new Line(pt + v2 + q4 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q3 * v1, pt + q2 * v1)), 12);
-            //One segment overlaps with another one.
-            Assert.Equal(v2.Length(), (new Line(pt + q1 * v1, pt + q3 * v1)).DistanceTo(new Line(pt + v2 + q2 * v1, pt + v2 + q4 * v1)), 12);
-            Assert.Equal(v2.Length(), (new Line(pt + q1 * v1, pt + q3 * v1)).DistanceTo(new Line(pt + v2 + q4 * v1, pt + v2 + q2 * v1)), 12);
-            Assert.Equal(v2.Length(), (new Line(pt + q3 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q2 * v1, pt + v2 + q4 * v1)), 12);
-            Assert.Equal(v2.Length(), (new Line(pt + q3 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q4 * v1, pt + v2 + q2 * v1)), 12);
-            Assert.Equal(v2.Length(), (new Line(pt + v2 + q1 * v1, pt + v2 + q3 * v1)).DistanceTo(new Line(pt + q2 * v1, pt + q4 * v1)), 12);
-            Assert.Equal(v2.Length(), (new Line(pt + v2 + q1 * v1, pt + v2 + q3 * v1)).DistanceTo(new Line(pt + q4 * v1, pt + q2 * v1)), 12);
-            Assert.Equal(v2.Length(), (new Line(pt + v2 + q3 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q2 * v1, pt + q4 * v1)), 12);
-            Assert.Equal(v2.Length(), (new Line(pt + v2 + q3 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q4 * v1, pt + q2 * v1)), 12);
+        [Fact]
+        public void LineDistancePointsOnParallelLines()
+        {
+            //Parallel lines that are 'delta' away - delta is orthogonal to v1.
+            Vector3 pt = new Vector3(2.798721214152833, -0.3556044049478837, -2.9550511796484766);
+            Vector3 direction = new Vector3(2.465855774694745, 2.6356139841825836, 0.4933654383536945);
+            Vector3 delta = new Vector3(1.633720404719513, -1.8504262591965435, 1.7198011154858075);
+            //Sorted distance quantities from point by the first vector.
+            double q1 = -1.5791413478212935;
+            double q2 = -0.81511586964034;
+            double q3 = 0.732636303417701;
+            double q4 = 1.9234662064172614;
+            //p1, p2, p3, p4 are on the same line defined by pt + direction * t equation.
+            Vector3 pt1 = pt + q1 * direction;
+            Vector3 pt2 = pt + q2 * direction;
+            Vector3 pt3 = pt + q3 * direction;
+            Vector3 pt4 = pt + q4 * direction;
 
+            //The segments do not overlap. Expected distance is between parallel lines plus endpoints.
+            var expected = (delta + (q3 - q2) * direction).Length();
+            Assert.Equal(expected, (new Line(pt1, pt2)).DistanceTo(new Line(pt3 + delta, pt4 + delta)), 12);
+            Assert.Equal(expected, (new Line(pt1, pt2)).DistanceTo(new Line(pt4 + delta, pt3 + delta)), 12);
+            Assert.Equal(expected, (new Line(pt2, pt1)).DistanceTo(new Line(pt3 + delta, pt4 + delta)), 12);
+            Assert.Equal(expected, (new Line(pt2, pt1)).DistanceTo(new Line(pt4 + delta, pt3 + delta)), 12);
+            Assert.Equal(expected, (new Line(pt1 + delta, pt2 + delta)).DistanceTo(new Line(pt3, pt4)), 12);
+            Assert.Equal(expected, (new Line(pt1 + delta, pt2 + delta)).DistanceTo(new Line(pt4, pt3)), 12);
+            Assert.Equal(expected, (new Line(pt2 + delta, pt1 + delta)).DistanceTo(new Line(pt3, pt4)), 12);
+            Assert.Equal(expected, (new Line(pt2 + delta, pt1 + delta)).DistanceTo(new Line(pt4, pt3)), 12);
+            //One segment covers another one. There is only distance between parallel lines.
+            Assert.Equal(delta.Length(), (new Line(pt1, pt4)).DistanceTo(new Line(pt2 + delta, pt3 + delta)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt1, pt4)).DistanceTo(new Line(pt3 + delta, pt2 + delta)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt4, pt1)).DistanceTo(new Line(pt2 + delta, pt3 + delta)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt4, pt1)).DistanceTo(new Line(pt3 + delta, pt2 + delta)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt1 + delta, pt4 + delta)).DistanceTo(new Line(pt2, pt3)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt1 + delta, pt4 + delta)).DistanceTo(new Line(pt3, pt2)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt4 + delta, pt1 + delta)).DistanceTo(new Line(pt2, pt3)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt4 + delta, pt1 + delta)).DistanceTo(new Line(pt3, pt2)), 12);
+            //One segment overlaps with another one. There is only distance between parallel lines.
+            Assert.Equal(delta.Length(), (new Line(pt1, pt3)).DistanceTo(new Line(pt2 + delta, pt4 + delta)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt1, pt3)).DistanceTo(new Line(pt4 + delta, pt2 + delta)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt3, pt1)).DistanceTo(new Line(pt2 + delta, pt4 + delta)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt3, pt1)).DistanceTo(new Line(pt4 + delta, pt2 + delta)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt1 + delta, pt3 + delta)).DistanceTo(new Line(pt2, pt4)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt1 + delta, pt3 + delta)).DistanceTo(new Line(pt4, pt2)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt3 + delta, pt1 + delta)).DistanceTo(new Line(pt2, pt4)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt3 + delta, pt1 + delta)).DistanceTo(new Line(pt4, pt2)), 12);
+        }
+
+        [Fact]
+        public void LineDistancePointsOnSkewLines()
+        {
             //One line is skew to other - v2 and v3 are orthogonal to v1.
-            pt = new Vector3(-0.500280764727953, -2.9389849832575896, 1.9512390555224588);
-            v1 = new Vector3(-1.2081608688024432, -0.7895298630691459, -1.8380319057295544);
-            v2 = new Vector3(1.561390631684935, -1.268325457190592, -0.48150972505691025);
-            Vector3 v3 = new Vector3(0.4345936745767045, 0.9194325262466677, -0.6806076130136314);
-            q11 = -1.31932651341597884; q12 = 0.8705916819804074; q13 = 2.7483887105972915;
-            q21 = -2.45223540673958955; q22 = 0.2397865438759381;
-            //The segments intersect
-            Assert.Equal(v1.Length(), (new Line(pt + q11 * v2, pt + q12 * v2)).DistanceTo(new Line(pt + v1 + q21 * v3, pt + v1 + q22 * v3)), 12);
-            Assert.Equal(v1.Length(), (new Line(pt + q11 * v2, pt + q12 * v2)).DistanceTo(new Line(pt + v1 + q22 * v3, pt + v1 + q21 * v3)), 12);
-            Assert.Equal(v1.Length(), (new Line(pt + q12 * v2, pt + q11 * v2)).DistanceTo(new Line(pt + v1 + q21 * v3, pt + v1 + q22 * v3)), 12);
-            Assert.Equal(v1.Length(), (new Line(pt + q12 * v2, pt + q11 * v2)).DistanceTo(new Line(pt + v1 + q22 * v3, pt + v1 + q21 * v3)), 12);
-            //The shortest distance is from an endpoint to another segment
-            expected = (q12 * v2).DistanceTo(new Line(v1 + q21 * v3, v1 + q22 * v3));
-            Assert.Equal(expected, (new Line(pt + q12 * v2, pt + q13 * v2)).DistanceTo(new Line(pt + v1 + q21 * v3, pt + v1 + q22 * v3)), 12);
-            Assert.Equal(expected, (new Line(pt + q12 * v2, pt + q13 * v2)).DistanceTo(new Line(pt + v1 + q22 * v3, pt + v1 + q21 * v3)), 12);
-            Assert.Equal(expected, (new Line(pt + q13 * v2, pt + q12 * v2)).DistanceTo(new Line(pt + v1 + q21 * v3, pt + v1 + q22 * v3)), 12);
-            Assert.Equal(expected, (new Line(pt + q13 * v2, pt + q12 * v2)).DistanceTo(new Line(pt + v1 + q22 * v3, pt + v1 + q21 * v3)), 12);
+            Vector3 pt = new Vector3(-0.500280764727953, -2.9389849832575896, 1.9512390555224588);
+            Vector3 delta = new Vector3(-1.2081608688024432, -0.7895298630691459, -1.8380319057295544);
+            Vector3 v1 = new Vector3(1.561390631684935, -1.268325457190592, -0.48150972505691025);
+            Vector3 v2 = new Vector3(0.4345936745767045, 0.9194325262466677, -0.6806076130136314);
+            //Sorted distance quantities from point by the second vector.
+            double q11 = -1.31932651341597884;
+            double q12 = 0.8705916819804074; 
+            double q13 = 2.7483887105972915;
+            //Sorted distance quantities from point by the second vector.
+            double q21 = -2.45223540673958955;
+            double q22 = 0.2397865438759381;
+            //p11, p12, p13 are one the same line defined by pt + v1 * t equation.
+            Vector3 pt11 = pt + q11 * v1;
+            Vector3 pt12 = pt + q12 * v1;
+            Vector3 pt13 = pt + q13 * v1;
+            //p11, p12, p13 are one the same line defined by (pt + delta) + v2 * t equation.
+            Vector3 pt21 = pt + delta + q21 * v2;
+            Vector3 pt22 = pt + delta + q22 * v2;
+            //The segments (pt11, pt12) and (pt21, pt22) would intersect on the shared plane.
+            //The distance is difference between lines.
+            Assert.Equal(delta.Length(), (new Line(pt11, pt12)).DistanceTo(new Line(pt21, pt22)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt11, pt12)).DistanceTo(new Line(pt22, pt21)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt12, pt11)).DistanceTo(new Line(pt21, pt22)), 12);
+            Assert.Equal(delta.Length(), (new Line(pt12, pt11)).DistanceTo(new Line(pt22, pt21)), 12);
+            //The segments (pt12, pt13) and (pt21, pt22) does not intersect.
+            //The shortest distance is from an endpoint to another segment - difference between lines plus between endpoints. 
+            var expected = (q12 * v1).DistanceTo(new Line(delta + q21 * v2, delta + q22 * v2));
+            Assert.Equal(expected, (new Line(pt12, pt13)).DistanceTo(new Line(pt21, pt22)), 12);
+            Assert.Equal(expected, (new Line(pt12, pt13)).DistanceTo(new Line(pt22, pt21)), 12);
+            Assert.Equal(expected, (new Line(pt13, pt12)).DistanceTo(new Line(pt21, pt22)), 12);
+            Assert.Equal(expected, (new Line(pt13, pt12)).DistanceTo(new Line(pt22, pt21)), 12);
         }
     }
 }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -902,5 +902,155 @@ namespace Elements.Geometry.Tests
 
             Assert.Equal(3, offset.Count());
         }
+
+        [Fact]
+        public void LineDistanceSimple()
+        {
+            //Right line has 1/2 slope, so lines should meet at (6, 2, 2)
+            //forming 1 by 2 triangle
+            Line left = new Line((2, 0, 1), (12, 0, 1));
+            Line right = new Line((6, 0, 6), (6, 3, 0));
+            Assert.Equal(Math.Sqrt(5), left.DistanceTo(right));
+
+            //Overlapping
+            left = new Line((3, 3), (6, 3));
+            right = new Line((4, 3), (5, 3));
+            Assert.Equal(0, left.DistanceTo(right));
+            right = new Line((4, 3), (7, 3));
+            Assert.Equal(0, left.DistanceTo(right));
+            right = new Line((2, 3), (5, 3));
+            Assert.Equal(0, left.DistanceTo(right));
+
+            //Collinear
+            left = new Line((3, 3), (6, 3));
+            right = new Line((7, 3), (9, 3));
+            Assert.Equal(1, left.DistanceTo(right));
+
+            //Parallel
+            left = new Line((5, 2), (5, 8));
+            right = new Line((7, 5), (7, 10));
+            Assert.Equal(2, left.DistanceTo(right));
+
+            //Intersecting
+            left = new Line((5, 5), (10, 10));
+            right = new Line((7, 0), (7, 10));
+            Assert.Equal(0, left.DistanceTo(right));
+
+            // Used to fail
+            left = new Line((5, 5), (5, 8));
+            right = new Line((3, 1), (3, 4));
+            Assert.Equal(Math.Sqrt(5), left.DistanceTo(right));
+
+            // the test is for the DistanceTo function (case of the equal lines)
+            Vector3 pt = new Vector3(-2.685818406894334, -2.476879934864206, -0.5565494179776103);
+            Vector3 v = new Vector3(-2.3537985903693657, 2.407193267710168, -2.771078003386066);
+            double q1 = -1.7567568535640823, q2 = -0.21721224020356145, q3 = 1.006813808941921, q4 = 2.112519713576212;
+            Vector3 pt1 = pt + q1 * v, pt2 = pt + q2 * v, pt3 = pt + q3 * v, pt4 = pt + q4 * v;
+            // Segements don't intersect
+            Assert.Equal((pt3 - pt2).Length(), (new Line(pt1, pt2)).DistanceTo(new Line(pt3, pt4)), 12);
+            Assert.Equal((pt3 - pt2).Length(), (new Line(pt2, pt1)).DistanceTo(new Line(pt3, pt4)), 12);
+            Assert.Equal((pt3 - pt2).Length(), (new Line(pt1, pt2)).DistanceTo(new Line(pt4, pt3)), 12);
+            Assert.Equal((pt3 - pt2).Length(), (new Line(pt2, pt1)).DistanceTo(new Line(pt4, pt3)), 12);
+            Assert.Equal((pt3 - pt2).Length(), (new Line(pt3, pt4)).DistanceTo(new Line(pt1, pt2)), 12);
+            Assert.Equal((pt3 - pt2).Length(), (new Line(pt4, pt3)).DistanceTo(new Line(pt1, pt2)), 12);
+            Assert.Equal((pt3 - pt2).Length(), (new Line(pt3, pt4)).DistanceTo(new Line(pt2, pt1)), 12);
+            Assert.Equal((pt3 - pt2).Length(), (new Line(pt4, pt3)).DistanceTo(new Line(pt2, pt1)), 12);
+            // One segment contains another one
+            Assert.Equal(0, (new Line(pt1, pt4)).DistanceTo(new Line(pt2, pt3)), 12);
+            Assert.Equal(0, (new Line(pt1, pt4)).DistanceTo(new Line(pt3, pt2)), 12);
+            Assert.Equal(0, (new Line(pt4, pt1)).DistanceTo(new Line(pt2, pt3)), 12);
+            Assert.Equal(0, (new Line(pt4, pt1)).DistanceTo(new Line(pt3, pt2)), 12);
+            Assert.Equal(0, (new Line(pt2, pt3)).DistanceTo(new Line(pt1, pt4)), 12);
+            Assert.Equal(0, (new Line(pt2, pt3)).DistanceTo(new Line(pt4, pt1)), 12);
+            Assert.Equal(0, (new Line(pt3, pt2)).DistanceTo(new Line(pt1, pt4)), 12);
+            Assert.Equal(0, (new Line(pt3, pt2)).DistanceTo(new Line(pt4, pt1)), 12);
+            // One segement intersects with another one
+            Assert.Equal(0, (new Line(pt1, pt3)).DistanceTo(new Line(pt2, pt4)), 12);
+            Assert.Equal(0, (new Line(pt1, pt3)).DistanceTo(new Line(pt4, pt2)), 12);
+            Assert.Equal(0, (new Line(pt3, pt1)).DistanceTo(new Line(pt2, pt4)), 12);
+            Assert.Equal(0, (new Line(pt3, pt1)).DistanceTo(new Line(pt4, pt2)), 12);
+            Assert.Equal(0, (new Line(pt2, pt4)).DistanceTo(new Line(pt1, pt3)), 12);
+            Assert.Equal(0, (new Line(pt2, pt4)).DistanceTo(new Line(pt3, pt1)), 12);
+            Assert.Equal(0, (new Line(pt4, pt2)).DistanceTo(new Line(pt1, pt3)), 12);
+            Assert.Equal(0, (new Line(pt4, pt2)).DistanceTo(new Line(pt3, pt1)), 12);
+
+            // the test is for the DistanceTo function (case of the intersecting lines)
+            pt = new Vector3(2.798721214152833, -0.3556044049478837, -2.9550511796484766);
+            Vector3 v1 = new Vector3(2.465855774694745, 2.6356139841825836, 0.4933654383536945);
+            Vector3 v2 = new Vector3(1.0293808889279106, -2.4963706389774964, 1.5988855967507778);
+            double q11 = -1.5791413478212935, q12 = 0.81511586964034, q13 = 1.732636303417701;
+            double q21 = -0.9234662064172614, q22 = 0.64387549346853, q23 = 2.083473245643838;
+            Vector3 pt11 = pt + q11 * v1, pt12 = pt + q12 * v1, pt13 = pt + q13 * v1;
+            Vector3 pt21 = pt + q21 * v2, pt22 = pt + q22 * v2, pt23 = pt + q23 * v2;
+            // the segments intersect
+            Assert.Equal(0, (new Line(pt11, pt12)).DistanceTo(new Line(pt21, pt22)), 12);
+            Assert.Equal(0, (new Line(pt11, pt12)).DistanceTo(new Line(pt22, pt21)), 12);
+            Assert.Equal(0, (new Line(pt12, pt11)).DistanceTo(new Line(pt21, pt22)), 12);
+            Assert.Equal(0, (new Line(pt12, pt11)).DistanceTo(new Line(pt22, pt21)), 12);
+            Assert.Equal(0, (new Line(pt21, pt22)).DistanceTo(new Line(pt11, pt12)), 12);
+            Assert.Equal(0, (new Line(pt21, pt22)).DistanceTo(new Line(pt12, pt11)), 12);
+            Assert.Equal(0, (new Line(pt22, pt21)).DistanceTo(new Line(pt11, pt12)), 12);
+            Assert.Equal(0, (new Line(pt22, pt21)).DistanceTo(new Line(pt12, pt11)), 12);
+            // the shortest distance is between an endpoint and another segment
+            Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt12, pt13)).DistanceTo(new Line(pt21, pt22)), 12);
+            Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt12, pt13)).DistanceTo(new Line(pt22, pt21)), 12);
+            Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt13, pt12)).DistanceTo(new Line(pt21, pt22)), 12);
+            Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt13, pt12)).DistanceTo(new Line(pt22, pt21)), 12);
+            Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt21, pt22)).DistanceTo(new Line(pt12, pt13)), 12);
+            Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt21, pt22)).DistanceTo(new Line(pt13, pt12)), 12);
+            Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt22, pt21)).DistanceTo(new Line(pt12, pt13)), 12);
+            Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt22, pt21)).DistanceTo(new Line(pt13, pt12)), 12);
+
+            // the test is for the DistanceTo function (case of the parallel lines)
+            pt = new Vector3(2.798721214152833, -0.3556044049478837, -2.9550511796484766);
+            v1 = new Vector3(2.465855774694745, 2.6356139841825836, 0.4933654383536945);
+            v2 = new Vector3(1.633720404719513, -1.8504262591965435, 1.7198011154858075); // v2 is orthogonal to v1
+            q1 = -1.5791413478212935; q2 = -0.81511586964034; q3 = 0.732636303417701; q4 = 1.9234662064172614;
+            // the segments do not overlap
+            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + q1 * v1, pt + q2 * v1)).DistanceTo(new Line(pt + v2 + q3 * v1, pt + v2 + q4 * v1)), 12);
+            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + q1 * v1, pt + q2 * v1)).DistanceTo(new Line(pt + v2 + q4 * v1, pt + v2 + q3 * v1)), 12);
+            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + q2 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q3 * v1, pt + v2 + q4 * v1)), 12);
+            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + q2 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q4 * v1, pt + v2 + q3 * v1)), 12);
+            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + v2 + q1 * v1, pt + v2 + q2 * v1)).DistanceTo(new Line(pt + q3 * v1, pt + q4 * v1)), 12);
+            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + v2 + q1 * v1, pt + v2 + q2 * v1)).DistanceTo(new Line(pt + q4 * v1, pt + q3 * v1)), 12);
+            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + v2 + q2 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q3 * v1, pt + q4 * v1)), 12);
+            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + v2 + q2 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q4 * v1, pt + q3 * v1)), 12);
+            // one segment covers another one
+            Assert.Equal(v2.Length(), (new Line(pt + q1 * v1, pt + q4 * v1)).DistanceTo(new Line(pt + v2 + q2 * v1, pt + v2 + q3 * v1)), 12);
+            Assert.Equal(v2.Length(), (new Line(pt + q1 * v1, pt + q4 * v1)).DistanceTo(new Line(pt + v2 + q3 * v1, pt + v2 + q2 * v1)), 12);
+            Assert.Equal(v2.Length(), (new Line(pt + q4 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q2 * v1, pt + v2 + q3 * v1)), 12);
+            Assert.Equal(v2.Length(), (new Line(pt + q4 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q3 * v1, pt + v2 + q2 * v1)), 12);
+            Assert.Equal(v2.Length(), (new Line(pt + v2 + q1 * v1, pt + v2 + q4 * v1)).DistanceTo(new Line(pt + q2 * v1, pt + q3 * v1)), 12);
+            Assert.Equal(v2.Length(), (new Line(pt + v2 + q1 * v1, pt + v2 + q4 * v1)).DistanceTo(new Line(pt + q3 * v1, pt + q2 * v1)), 12);
+            Assert.Equal(v2.Length(), (new Line(pt + v2 + q4 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q2 * v1, pt + q3 * v1)), 12);
+            Assert.Equal(v2.Length(), (new Line(pt + v2 + q4 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q3 * v1, pt + q2 * v1)), 12);
+            // one segment overlaps with another one
+            Assert.Equal(v2.Length(), (new Line(pt + q1 * v1, pt + q3 * v1)).DistanceTo(new Line(pt + v2 + q2 * v1, pt + v2 + q4 * v1)), 12);
+            Assert.Equal(v2.Length(), (new Line(pt + q1 * v1, pt + q3 * v1)).DistanceTo(new Line(pt + v2 + q4 * v1, pt + v2 + q2 * v1)), 12);
+            Assert.Equal(v2.Length(), (new Line(pt + q3 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q2 * v1, pt + v2 + q4 * v1)), 12);
+            Assert.Equal(v2.Length(), (new Line(pt + q3 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q4 * v1, pt + v2 + q2 * v1)), 12);
+            Assert.Equal(v2.Length(), (new Line(pt + v2 + q1 * v1, pt + v2 + q3 * v1)).DistanceTo(new Line(pt + q2 * v1, pt + q4 * v1)), 12);
+            Assert.Equal(v2.Length(), (new Line(pt + v2 + q1 * v1, pt + v2 + q3 * v1)).DistanceTo(new Line(pt + q4 * v1, pt + q2 * v1)), 12);
+            Assert.Equal(v2.Length(), (new Line(pt + v2 + q3 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q2 * v1, pt + q4 * v1)), 12);
+            Assert.Equal(v2.Length(), (new Line(pt + v2 + q3 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q4 * v1, pt + q2 * v1)), 12);
+
+            // the test is for the DistanceTo function (case of the skew lines)
+            pt = new Vector3(-0.500280764727953, -2.9389849832575896, 1.9512390555224588);
+            v1 = new Vector3(-1.2081608688024432, -0.7895298630691459, -1.8380319057295544);
+            v2 = new Vector3(1.561390631684935, -1.268325457190592, -0.48150972505691025); // v2 is orthogonal to v1
+            Vector3 v3 = new Vector3(0.4345936745767045, 0.9194325262466677, -0.6806076130136314); // v3 is orthogonal to v1
+            q11 = -1.31932651341597884; q12 = 0.8705916819804074; q13 = 2.7483887105972915;
+            q21 = -2.45223540673958955; q22 = 0.2397865438759381; q23 = 1.9801359475810375;
+            // the segments intersect
+            Assert.Equal(v1.Length(), (new Line(pt + q11 * v2, pt + q12 * v2)).DistanceTo(new Line(pt + v1 + q21 * v3, pt + v1 + q22 * v3)), 12);
+            Assert.Equal(v1.Length(), (new Line(pt + q11 * v2, pt + q12 * v2)).DistanceTo(new Line(pt + v1 + q22 * v3, pt + v1 + q21 * v3)), 12);
+            Assert.Equal(v1.Length(), (new Line(pt + q12 * v2, pt + q11 * v2)).DistanceTo(new Line(pt + v1 + q21 * v3, pt + v1 + q22 * v3)), 12);
+            Assert.Equal(v1.Length(), (new Line(pt + q12 * v2, pt + q11 * v2)).DistanceTo(new Line(pt + v1 + q22 * v3, pt + v1 + q21 * v3)), 12);
+            // the shortest distance is from an endpoint to another segment
+            Assert.Equal((q12 * v2).DistanceTo(new Line(v1 + q21 * v3, v1 + q22 * v3)), (new Line(pt + q12 * v2, pt + q13 * v2)).DistanceTo(new Line(pt + v1 + q21 * v3, pt + v1 + q22 * v3)), 12);
+            Assert.Equal((q12 * v2).DistanceTo(new Line(v1 + q21 * v3, v1 + q22 * v3)), (new Line(pt + q12 * v2, pt + q13 * v2)).DistanceTo(new Line(pt + v1 + q22 * v3, pt + v1 + q21 * v3)), 12);
+            Assert.Equal((q12 * v2).DistanceTo(new Line(v1 + q21 * v3, v1 + q22 * v3)), (new Line(pt + q13 * v2, pt + q12 * v2)).DistanceTo(new Line(pt + v1 + q21 * v3, pt + v1 + q22 * v3)), 12);
+            Assert.Equal((q12 * v2).DistanceTo(new Line(v1 + q21 * v3, v1 + q22 * v3)), (new Line(pt + q13 * v2, pt + q12 * v2)).DistanceTo(new Line(pt + v1 + q22 * v3, pt + v1 + q21 * v3)), 12);
+        }
     }
 }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -930,32 +930,40 @@ namespace Elements.Geometry.Tests
             left = new Line((5, 2), (5, 8));
             right = new Line((7, 5), (7, 10));
             Assert.Equal(2, left.DistanceTo(right));
+            left = new Line((5, 5), (5, 8));
+            right = new Line((3, 1), (3, 4));
+            Assert.Equal(Math.Sqrt(5), left.DistanceTo(right));
 
             //Intersecting
             left = new Line((5, 5), (10, 10));
             right = new Line((7, 0), (7, 10));
             Assert.Equal(0, left.DistanceTo(right));
 
-            // Used to fail
-            left = new Line((5, 5), (5, 8));
-            right = new Line((3, 1), (3, 4));
-            Assert.Equal(Math.Sqrt(5), left.DistanceTo(right));
+            //Perpendicular, 3 units Y away, 1 unit Z away
+            left = new Line((4, 0), (8, 0));
+            right = new Line((6, 3, 1), (6, 4, 1));
+            Assert.Equal(Math.Sqrt(10), left.DistanceTo(right));
+        }
 
-            // the test is for the DistanceTo function (case of the equal lines)
+        [Fact]
+        public void LineDistanceParametric()
+        {
+            //Points on one line.
             Vector3 pt = new Vector3(-2.685818406894334, -2.476879934864206, -0.5565494179776103);
             Vector3 v = new Vector3(-2.3537985903693657, 2.407193267710168, -2.771078003386066);
             double q1 = -1.7567568535640823, q2 = -0.21721224020356145, q3 = 1.006813808941921, q4 = 2.112519713576212;
             Vector3 pt1 = pt + q1 * v, pt2 = pt + q2 * v, pt3 = pt + q3 * v, pt4 = pt + q4 * v;
-            // Segements don't intersect
-            Assert.Equal((pt3 - pt2).Length(), (new Line(pt1, pt2)).DistanceTo(new Line(pt3, pt4)), 12);
-            Assert.Equal((pt3 - pt2).Length(), (new Line(pt2, pt1)).DistanceTo(new Line(pt3, pt4)), 12);
-            Assert.Equal((pt3 - pt2).Length(), (new Line(pt1, pt2)).DistanceTo(new Line(pt4, pt3)), 12);
-            Assert.Equal((pt3 - pt2).Length(), (new Line(pt2, pt1)).DistanceTo(new Line(pt4, pt3)), 12);
-            Assert.Equal((pt3 - pt2).Length(), (new Line(pt3, pt4)).DistanceTo(new Line(pt1, pt2)), 12);
-            Assert.Equal((pt3 - pt2).Length(), (new Line(pt4, pt3)).DistanceTo(new Line(pt1, pt2)), 12);
-            Assert.Equal((pt3 - pt2).Length(), (new Line(pt3, pt4)).DistanceTo(new Line(pt2, pt1)), 12);
-            Assert.Equal((pt3 - pt2).Length(), (new Line(pt4, pt3)).DistanceTo(new Line(pt2, pt1)), 12);
-            // One segment contains another one
+            //Segments don't intersect.
+            var expected = (pt3 - pt2).Length();
+            Assert.Equal(expected, (new Line(pt1, pt2)).DistanceTo(new Line(pt3, pt4)), 12);
+            Assert.Equal(expected, (new Line(pt2, pt1)).DistanceTo(new Line(pt3, pt4)), 12);
+            Assert.Equal(expected, (new Line(pt1, pt2)).DistanceTo(new Line(pt4, pt3)), 12);
+            Assert.Equal(expected, (new Line(pt2, pt1)).DistanceTo(new Line(pt4, pt3)), 12);
+            Assert.Equal(expected, (new Line(pt3, pt4)).DistanceTo(new Line(pt1, pt2)), 12);
+            Assert.Equal(expected, (new Line(pt4, pt3)).DistanceTo(new Line(pt1, pt2)), 12);
+            Assert.Equal(expected, (new Line(pt3, pt4)).DistanceTo(new Line(pt2, pt1)), 12);
+            Assert.Equal(expected, (new Line(pt4, pt3)).DistanceTo(new Line(pt2, pt1)), 12);
+            //One segment covers other one.
             Assert.Equal(0, (new Line(pt1, pt4)).DistanceTo(new Line(pt2, pt3)), 12);
             Assert.Equal(0, (new Line(pt1, pt4)).DistanceTo(new Line(pt3, pt2)), 12);
             Assert.Equal(0, (new Line(pt4, pt1)).DistanceTo(new Line(pt2, pt3)), 12);
@@ -964,7 +972,7 @@ namespace Elements.Geometry.Tests
             Assert.Equal(0, (new Line(pt2, pt3)).DistanceTo(new Line(pt4, pt1)), 12);
             Assert.Equal(0, (new Line(pt3, pt2)).DistanceTo(new Line(pt1, pt4)), 12);
             Assert.Equal(0, (new Line(pt3, pt2)).DistanceTo(new Line(pt4, pt1)), 12);
-            // One segement intersects with another one
+            //One segment overlaps other one.
             Assert.Equal(0, (new Line(pt1, pt3)).DistanceTo(new Line(pt2, pt4)), 12);
             Assert.Equal(0, (new Line(pt1, pt3)).DistanceTo(new Line(pt4, pt2)), 12);
             Assert.Equal(0, (new Line(pt3, pt1)).DistanceTo(new Line(pt2, pt4)), 12);
@@ -974,15 +982,15 @@ namespace Elements.Geometry.Tests
             Assert.Equal(0, (new Line(pt4, pt2)).DistanceTo(new Line(pt1, pt3)), 12);
             Assert.Equal(0, (new Line(pt4, pt2)).DistanceTo(new Line(pt3, pt1)), 12);
 
-            // the test is for the DistanceTo function (case of the intersecting lines)
+            //Two groups of points on two lines.
             pt = new Vector3(2.798721214152833, -0.3556044049478837, -2.9550511796484766);
             Vector3 v1 = new Vector3(2.465855774694745, 2.6356139841825836, 0.4933654383536945);
             Vector3 v2 = new Vector3(1.0293808889279106, -2.4963706389774964, 1.5988855967507778);
             double q11 = -1.5791413478212935, q12 = 0.81511586964034, q13 = 1.732636303417701;
             double q21 = -0.9234662064172614, q22 = 0.64387549346853, q23 = 2.083473245643838;
             Vector3 pt11 = pt + q11 * v1, pt12 = pt + q12 * v1, pt13 = pt + q13 * v1;
-            Vector3 pt21 = pt + q21 * v2, pt22 = pt + q22 * v2, pt23 = pt + q23 * v2;
-            // the segments intersect
+            Vector3 pt21 = pt + q21 * v2, pt22 = pt + q22 * v2;
+            //The segments intersect.
             Assert.Equal(0, (new Line(pt11, pt12)).DistanceTo(new Line(pt21, pt22)), 12);
             Assert.Equal(0, (new Line(pt11, pt12)).DistanceTo(new Line(pt22, pt21)), 12);
             Assert.Equal(0, (new Line(pt12, pt11)).DistanceTo(new Line(pt21, pt22)), 12);
@@ -991,7 +999,7 @@ namespace Elements.Geometry.Tests
             Assert.Equal(0, (new Line(pt21, pt22)).DistanceTo(new Line(pt12, pt11)), 12);
             Assert.Equal(0, (new Line(pt22, pt21)).DistanceTo(new Line(pt11, pt12)), 12);
             Assert.Equal(0, (new Line(pt22, pt21)).DistanceTo(new Line(pt12, pt11)), 12);
-            // the shortest distance is between an endpoint and another segment
+            //The shortest distance is between an endpoint and another segment.
             Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt12, pt13)).DistanceTo(new Line(pt21, pt22)), 12);
             Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt12, pt13)).DistanceTo(new Line(pt22, pt21)), 12);
             Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt13, pt12)).DistanceTo(new Line(pt21, pt22)), 12);
@@ -1001,21 +1009,22 @@ namespace Elements.Geometry.Tests
             Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt22, pt21)).DistanceTo(new Line(pt12, pt13)), 12);
             Assert.Equal(pt12.DistanceTo(new Line(pt21, pt22)), (new Line(pt22, pt21)).DistanceTo(new Line(pt13, pt12)), 12);
 
-            // the test is for the DistanceTo function (case of the parallel lines)
+            //Parallel lines - v2 is orthogonal to v1.
             pt = new Vector3(2.798721214152833, -0.3556044049478837, -2.9550511796484766);
             v1 = new Vector3(2.465855774694745, 2.6356139841825836, 0.4933654383536945);
-            v2 = new Vector3(1.633720404719513, -1.8504262591965435, 1.7198011154858075); // v2 is orthogonal to v1
+            v2 = new Vector3(1.633720404719513, -1.8504262591965435, 1.7198011154858075); 
             q1 = -1.5791413478212935; q2 = -0.81511586964034; q3 = 0.732636303417701; q4 = 1.9234662064172614;
-            // the segments do not overlap
-            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + q1 * v1, pt + q2 * v1)).DistanceTo(new Line(pt + v2 + q3 * v1, pt + v2 + q4 * v1)), 12);
-            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + q1 * v1, pt + q2 * v1)).DistanceTo(new Line(pt + v2 + q4 * v1, pt + v2 + q3 * v1)), 12);
-            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + q2 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q3 * v1, pt + v2 + q4 * v1)), 12);
-            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + q2 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q4 * v1, pt + v2 + q3 * v1)), 12);
-            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + v2 + q1 * v1, pt + v2 + q2 * v1)).DistanceTo(new Line(pt + q3 * v1, pt + q4 * v1)), 12);
-            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + v2 + q1 * v1, pt + v2 + q2 * v1)).DistanceTo(new Line(pt + q4 * v1, pt + q3 * v1)), 12);
-            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + v2 + q2 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q3 * v1, pt + q4 * v1)), 12);
-            Assert.Equal((v2 + (q3 - q2) * v1).Length(), (new Line(pt + v2 + q2 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q4 * v1, pt + q3 * v1)), 12);
-            // one segment covers another one
+            //The segments do not overlap.
+            expected = (v2 + (q3 - q2) * v1).Length();
+            Assert.Equal(expected, (new Line(pt + q1 * v1, pt + q2 * v1)).DistanceTo(new Line(pt + v2 + q3 * v1, pt + v2 + q4 * v1)), 12);
+            Assert.Equal(expected, (new Line(pt + q1 * v1, pt + q2 * v1)).DistanceTo(new Line(pt + v2 + q4 * v1, pt + v2 + q3 * v1)), 12);
+            Assert.Equal(expected, (new Line(pt + q2 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q3 * v1, pt + v2 + q4 * v1)), 12);
+            Assert.Equal(expected, (new Line(pt + q2 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q4 * v1, pt + v2 + q3 * v1)), 12);
+            Assert.Equal(expected, (new Line(pt + v2 + q1 * v1, pt + v2 + q2 * v1)).DistanceTo(new Line(pt + q3 * v1, pt + q4 * v1)), 12);
+            Assert.Equal(expected, (new Line(pt + v2 + q1 * v1, pt + v2 + q2 * v1)).DistanceTo(new Line(pt + q4 * v1, pt + q3 * v1)), 12);
+            Assert.Equal(expected, (new Line(pt + v2 + q2 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q3 * v1, pt + q4 * v1)), 12);
+            Assert.Equal(expected, (new Line(pt + v2 + q2 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q4 * v1, pt + q3 * v1)), 12);
+            //One segment covers another one.
             Assert.Equal(v2.Length(), (new Line(pt + q1 * v1, pt + q4 * v1)).DistanceTo(new Line(pt + v2 + q2 * v1, pt + v2 + q3 * v1)), 12);
             Assert.Equal(v2.Length(), (new Line(pt + q1 * v1, pt + q4 * v1)).DistanceTo(new Line(pt + v2 + q3 * v1, pt + v2 + q2 * v1)), 12);
             Assert.Equal(v2.Length(), (new Line(pt + q4 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q2 * v1, pt + v2 + q3 * v1)), 12);
@@ -1024,7 +1033,7 @@ namespace Elements.Geometry.Tests
             Assert.Equal(v2.Length(), (new Line(pt + v2 + q1 * v1, pt + v2 + q4 * v1)).DistanceTo(new Line(pt + q3 * v1, pt + q2 * v1)), 12);
             Assert.Equal(v2.Length(), (new Line(pt + v2 + q4 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q2 * v1, pt + q3 * v1)), 12);
             Assert.Equal(v2.Length(), (new Line(pt + v2 + q4 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q3 * v1, pt + q2 * v1)), 12);
-            // one segment overlaps with another one
+            //One segment overlaps with another one.
             Assert.Equal(v2.Length(), (new Line(pt + q1 * v1, pt + q3 * v1)).DistanceTo(new Line(pt + v2 + q2 * v1, pt + v2 + q4 * v1)), 12);
             Assert.Equal(v2.Length(), (new Line(pt + q1 * v1, pt + q3 * v1)).DistanceTo(new Line(pt + v2 + q4 * v1, pt + v2 + q2 * v1)), 12);
             Assert.Equal(v2.Length(), (new Line(pt + q3 * v1, pt + q1 * v1)).DistanceTo(new Line(pt + v2 + q2 * v1, pt + v2 + q4 * v1)), 12);
@@ -1034,23 +1043,24 @@ namespace Elements.Geometry.Tests
             Assert.Equal(v2.Length(), (new Line(pt + v2 + q3 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q2 * v1, pt + q4 * v1)), 12);
             Assert.Equal(v2.Length(), (new Line(pt + v2 + q3 * v1, pt + v2 + q1 * v1)).DistanceTo(new Line(pt + q4 * v1, pt + q2 * v1)), 12);
 
-            // the test is for the DistanceTo function (case of the skew lines)
+            //One line is skew to other - v2 and v3 are orthogonal to v1.
             pt = new Vector3(-0.500280764727953, -2.9389849832575896, 1.9512390555224588);
             v1 = new Vector3(-1.2081608688024432, -0.7895298630691459, -1.8380319057295544);
-            v2 = new Vector3(1.561390631684935, -1.268325457190592, -0.48150972505691025); // v2 is orthogonal to v1
-            Vector3 v3 = new Vector3(0.4345936745767045, 0.9194325262466677, -0.6806076130136314); // v3 is orthogonal to v1
+            v2 = new Vector3(1.561390631684935, -1.268325457190592, -0.48150972505691025);
+            Vector3 v3 = new Vector3(0.4345936745767045, 0.9194325262466677, -0.6806076130136314);
             q11 = -1.31932651341597884; q12 = 0.8705916819804074; q13 = 2.7483887105972915;
-            q21 = -2.45223540673958955; q22 = 0.2397865438759381; q23 = 1.9801359475810375;
-            // the segments intersect
+            q21 = -2.45223540673958955; q22 = 0.2397865438759381;
+            //The segments intersect
             Assert.Equal(v1.Length(), (new Line(pt + q11 * v2, pt + q12 * v2)).DistanceTo(new Line(pt + v1 + q21 * v3, pt + v1 + q22 * v3)), 12);
             Assert.Equal(v1.Length(), (new Line(pt + q11 * v2, pt + q12 * v2)).DistanceTo(new Line(pt + v1 + q22 * v3, pt + v1 + q21 * v3)), 12);
             Assert.Equal(v1.Length(), (new Line(pt + q12 * v2, pt + q11 * v2)).DistanceTo(new Line(pt + v1 + q21 * v3, pt + v1 + q22 * v3)), 12);
             Assert.Equal(v1.Length(), (new Line(pt + q12 * v2, pt + q11 * v2)).DistanceTo(new Line(pt + v1 + q22 * v3, pt + v1 + q21 * v3)), 12);
-            // the shortest distance is from an endpoint to another segment
-            Assert.Equal((q12 * v2).DistanceTo(new Line(v1 + q21 * v3, v1 + q22 * v3)), (new Line(pt + q12 * v2, pt + q13 * v2)).DistanceTo(new Line(pt + v1 + q21 * v3, pt + v1 + q22 * v3)), 12);
-            Assert.Equal((q12 * v2).DistanceTo(new Line(v1 + q21 * v3, v1 + q22 * v3)), (new Line(pt + q12 * v2, pt + q13 * v2)).DistanceTo(new Line(pt + v1 + q22 * v3, pt + v1 + q21 * v3)), 12);
-            Assert.Equal((q12 * v2).DistanceTo(new Line(v1 + q21 * v3, v1 + q22 * v3)), (new Line(pt + q13 * v2, pt + q12 * v2)).DistanceTo(new Line(pt + v1 + q21 * v3, pt + v1 + q22 * v3)), 12);
-            Assert.Equal((q12 * v2).DistanceTo(new Line(v1 + q21 * v3, v1 + q22 * v3)), (new Line(pt + q13 * v2, pt + q12 * v2)).DistanceTo(new Line(pt + v1 + q22 * v3, pt + v1 + q21 * v3)), 12);
+            //The shortest distance is from an endpoint to another segment
+            expected = (q12 * v2).DistanceTo(new Line(v1 + q21 * v3, v1 + q22 * v3));
+            Assert.Equal(expected, (new Line(pt + q12 * v2, pt + q13 * v2)).DistanceTo(new Line(pt + v1 + q21 * v3, pt + v1 + q22 * v3)), 12);
+            Assert.Equal(expected, (new Line(pt + q12 * v2, pt + q13 * v2)).DistanceTo(new Line(pt + v1 + q22 * v3, pt + v1 + q21 * v3)), 12);
+            Assert.Equal(expected, (new Line(pt + q13 * v2, pt + q12 * v2)).DistanceTo(new Line(pt + v1 + q21 * v3, pt + v1 + q22 * v3)), 12);
+            Assert.Equal(expected, (new Line(pt + q13 * v2, pt + q12 * v2)).DistanceTo(new Line(pt + v1 + q22 * v3, pt + v1 + q21 * v3)), 12);
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- At one moment I needed a function that calculates distance between two lines. Just taking minimum between endpoints and lines doesn't work in all cases. So, this function was created. At the end of the day was not used but I decided that it may be a good addition to the Elements.

DESCRIPTION:
- Line.DistanceTo(line) compute distance between any two lines, even those that are not on the same plane.
 
TESTING:
- Added two tests: one with simple handwritten lines, one with complex parametric numbers.
  
FUTURE WORK:
- Closest point is not returned but there is enough information to do so. There is no clear closest point for several cases of parallel or overlapping lines. I guess the close end point of other line can be returned in this case. Let me know if this is something you want.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/942)
<!-- Reviewable:end -->
