### PR TITLE
Improve zero angle handling in Polyline.ForceAngleCompliance

### DIFF
--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -1300,6 +1300,20 @@ namespace Elements.Geometry
                     normalized[i], normalized[i + 1], incomingDirection, bestFitAngle, out var cornerPoint);
                 var directionalVector = normalized[i] - cornerPoint;
 
+                if (bestFitAngle.ApproximatelyEquals(0))
+                {
+                    switch (localType)
+                    {
+                        case NormalizationType.Start:
+                        case NormalizationType.Middle:
+                            normalized[i] = cornerPoint;
+                            break;
+                        default:
+                            normalized[i + 1] = cornerPoint;
+                            break;
+                    }
+                    continue;
+                }
                 switch (localType)
                 {
                     case NormalizationType.Start:

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -753,5 +753,27 @@ namespace Elements.Geometry.Tests
             Assert.False(CheckPolylineAngles(angles, normalizedPathEnd));
             Assert.True(CheckPolylineAngles(angles, normalizedPathEndYAxisReferenceVector));
         }
+
+
+        [Fact]
+        public void PolylineForceAngleComplianceWithZeroAngle()
+        {
+            Name = nameof(PolylineForceAngleComplianceWithZeroAngle);
+            var angles = new List<double> { 0, 45, 90 };
+            var polyline = new Polyline(new List<Vector3> { new Vector3(), new Vector3(1, 3), new Vector3(5, 3.05), new Vector3(10, 3) });
+
+            var normalizedPathMiddle = polyline.ForceAngleCompliance(angles, Vector3.ZAxis, out var distanceMiddle, NormalizationType.Middle);
+            var normalizedPathEnd = polyline.ForceAngleCompliance(angles, Vector3.ZAxis, out var distanceEnd, NormalizationType.End);
+            var normalizedPathEndYAxisReferenceVector = polyline.ForceAngleCompliance(angles, new Vector3(0, 1), out var distanceStartYAxis, NormalizationType.End);
+
+            Model.AddElement(new ModelCurve(polyline, BuiltInMaterials.Black));
+            Model.AddElement(new ModelCurve(normalizedPathMiddle, BuiltInMaterials.XAxis));
+            Model.AddElement(new ModelCurve(normalizedPathEnd, BuiltInMaterials.YAxis));
+            Model.AddElement(new ModelCurve(normalizedPathEndYAxisReferenceVector, BuiltInMaterials.ZAxis));
+
+            Assert.True(CheckPolylineAngles(angles, normalizedPathMiddle));
+            Assert.True(CheckPolylineAngles(angles, normalizedPathEnd));
+            Assert.True(CheckPolylineAngles(angles, normalizedPathEndYAxisReferenceVector));
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- The `ForceAngleCompliance` method didn't work with 0 angle because in `AngleAlignedDistance` zero value was used in denominator 

DESCRIPTION:
- Add special handling for zero angle

TESTING:
- Added `PolylineForceAngleComplianceWithZeroAngle` test to `PolylineTests`
  
REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/943)
<!-- Reviewable:end -->
