### PR TITLE
Add "Level" property to floor constructor

### DIFF
--- a/Elements/src/Floor.cs
+++ b/Elements/src/Floor.cs
@@ -56,7 +56,7 @@ namespace Elements
         /// <param name="name">The floor's name.</param>
         public Floor(Profile profile,
                      double thickness,
-                     Guid? level = null,
+                     Guid? level,
                      Transform transform = null,
                      Material material = null,
                      Representation representation = null,

--- a/Elements/src/Floor.cs
+++ b/Elements/src/Floor.cs
@@ -37,6 +37,43 @@ namespace Elements
         public List<Opening> Openings { get; } = new List<Opening>();
 
         /// <summary>
+        /// The Level this floor belongs to.
+        /// </summary>
+        /// <value></value>
+        public Guid? Level { get; set; }
+
+        /// <summary>
+        /// Create a floor.
+        /// </summary>
+        /// <param name="profile">The perimeter of the floor.</param>
+        /// <param name="thickness">The thickness of the floor.</param>
+        /// <param name="level">The level this floor belongs to.</param>
+        /// <param name="transform">The floor's transform. Create a transform with a Z coordinate for the origin, to define the elevation of the floor.</param>
+        /// <param name="material">The floor's material.</param>
+        /// <param name="representation">The floor's representation.</param>
+        /// <param name="isElementDefinition">Is this an element definition?</param>
+        /// <param name="id">The floor's id.</param>
+        /// <param name="name">The floor's name.</param>
+        public Floor(Profile profile,
+                     double thickness,
+                     Guid? level = null,
+                     Transform transform = null,
+                     Material material = null,
+                     Representation representation = null,
+                     bool isElementDefinition = false,
+                     Guid id = default,
+                     string name = null) : base(transform ?? new Transform(),
+                                                material ?? BuiltInMaterials.Concrete,
+                                                representation ?? new Representation(new List<SolidOperation>()),
+                                                isElementDefinition,
+                                                id != default ? id : Guid.NewGuid(),
+                                                name)
+        {
+            this.Level = level;
+            SetProperties(profile, thickness);
+        }
+
+        /// <summary>
         /// Create a floor.
         /// </summary>
         /// <param name="profile">The perimeter of the floor.</param>


### PR DESCRIPTION
BACKGROUND:
- I need to add a `Level` property to the floor schema, so that floors can have relationships to levels.
- This broke codegen code for types which inherit from floor, like `CirculationSegment`, because the constructor positional arguments were wrong. 

DESCRIPTION:
- Adds an additional constructor with arguments that match the ones in the updated schema.

TESTING:
- Haven't tested. If we merge and it's still broken, I will own cleanup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/949)
<!-- Reviewable:end -->
