### PR TITLE
don't break deserialization if the `Name` property is missing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - `Extrude` Solid Operation supports an optional `Flipped` parameter to purposely turn its normals inside out.
 - `MappingBase` and first Revit mapping class to support mapping data for a Revit Converter.
 
+### Changed
+- Element deserialization no longer requires `Name` to be present — it can be omitted.
+
 ## 1.4.0
 
 ### Added

--- a/Elements/src/Element.cs
+++ b/Elements/src/Element.cs
@@ -47,7 +47,7 @@ namespace Elements
         }
 
         /// <summary>A name.</summary>
-        [JsonProperty("Name", Required = Required.AllowNull)]
+        [JsonProperty("Name", Required = Required.Default)]
         public string Name
         {
             get { return _name; }


### PR DESCRIPTION
BACKGROUND:
- even though `Name` can be null, deserialization was failing if it was omitted from the JSON. This was happening sometimes in `Profile`s produced on the Hypar web app.

DESCRIPTION:
- Uses default settings for the `Name` property, instead of `AllowNull`. 

TESTING:
- I tested in a function utilizing this version of elements, making sure it no longer exploded if name was missing. 
  
FUTURE WORK:
- There's a lot more we can do to make deserialization less fragile.

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/951)
<!-- Reviewable:end -->
