### PR TITLE
Improve ForceAngleCompliance in case of plane change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.6.0
+
+### Changed
+
+- `Grid2D.GetCellGeometry` return type changed from `Curve` to `Polygon`.
+- `Grid2D.GetTrimmedCellGeometry` return type changed from `Curve[]` to `Polygon[]`.
+- `Polyline.ForceAngleCompliance` improved the case when two segments that need to be aligned are perpendicular to previous segment.
+
 ## 1.5.0
 
 ### Added
@@ -8,6 +16,7 @@
 - `MappingBase` and first Revit mapping class to support mapping data for a Revit Converter.
 
 ### Changed
+
 - Element deserialization no longer requires `Name` to be present — it can be omitted.
 
 ## 1.4.0

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -1257,9 +1257,9 @@ namespace Elements.Geometry
                     {
                         var before = (normalized[i - 1] - normalized[i - 2]).Unitized();
                         referenceVector = before.Cross(incomingDirection);
-                        // If previous segment was in different plane than two next segments, it's better to use
-                        // triangle that include those two segment instead, since segment on the other plane will
-                        // have correct angle with any configuration of that triangle.
+                        // If there are two segments that need to be aligned but previous segment is perpendicular
+                        // to both of them, it's better to use triangle that include those two segment instead,
+                        // since perpendicular segment will have correct angle with any configuration of that triangle.
                         if (direction.Cross(incomingDirection).IsParallelTo(before))
                         {
                             useEndCorner = true;

--- a/Elements/src/Spatial/Grid2d.cs
+++ b/Elements/src/Spatial/Grid2d.cs
@@ -693,7 +693,7 @@ namespace Elements.Spatial
         /// Get a rectangular polygon representing this untrimmed cell boundary.
         /// </summary>
         /// <returns>A rectangle representing this cell in world coordinates.</returns>
-        public Curve GetCellGeometry()
+        public Polygon GetCellGeometry()
         {
             var baseRect = GetBaseRectangleTransformed();
             return baseRect.TransformedPolygon(fromGrid);
@@ -704,7 +704,7 @@ namespace Elements.Spatial
         /// If the cell falls completely outside of the boundary, an empty array will be returned.
         /// </summary>
         /// <returns>Curves representing this cell in world coordinates.</returns>
-        public Curve[] GetTrimmedCellGeometry()
+        public Polygon[] GetTrimmedCellGeometry()
         {
             if (boundariesInGridSpace == null || boundariesInGridSpace.Count == 0)
             {
@@ -718,7 +718,7 @@ namespace Elements.Spatial
                 return fromGrid.OfPolygons(trimmedRect);
 
             }
-            return new Curve[0];
+            return new Polygon[0];
         }
 
         /// <summary>

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -733,6 +733,27 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
+        public void PolylineForceAngleCompliancePathChangesPlane()
+        {
+            var path = new List<Vector3>
+            {
+                (0, 5, 5),
+                (0, 5, 0),
+                (5, 5.1, 0),
+                (5, 0, 0)
+            };
+
+            var angles = new List<double> { 90, 45, 0 };
+            var polyline = new Polyline(path);
+            var normalizedPath = polyline.ForceAngleCompliance(angles, Vector3.ZAxis);
+            Model.AddElement(new ModelCurve(polyline, BuiltInMaterials.Black));
+            Model.AddElement(new ModelCurve(normalizedPath, BuiltInMaterials.XAxis));
+
+            Assert.True(CheckPolylineAngles(angles, normalizedPath));
+            Assert.Equal(new Vector3(5, 5, 0), normalizedPath.Vertices[2]);
+        }
+
+        [Fact]
         public void PolylineForceAngleComplianceWithCollinearPoints()
         {
             Name = nameof(PolylineForceAngleComplianceWithCollinearPoints);


### PR DESCRIPTION
BACKGROUND:
- While working with the function I have found that although it produces correct angles, it does unnecessary deviations sometimes.

DESCRIPTION:
- If there are two segments that need to be aligned but previous segment is perpendicular to both of them, it's better to use triangle that include those two segment instead, since perpendicular segment will have correct angle with any configuration of that triangle.

TESTING:
- Added new test PolylineForceAngleCompliancePathChangesPlane that shows a case new changes does better.
  
FUTURE WORK:

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- I also included new cast fixes in Grid2d that were in my repo for a while. They don't break any build but help avoid unnecessary up casts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/958)
<!-- Reviewable:end -->
