### PR TITLE
Add group name to WeightModifier. Add ability to use custom factor ag…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,19 @@
 
 - `Extrude` Solid Operation supports an optional `ReverseWinding` parameter to purposely turn its normals inside out.
 - `MappingBase` and first Revit mapping class to support mapping data for a Revit Converter.
+- `WeightModifier.Group`
+- `AdaptiveGrid.SetWeightModifiersGroupAggregator(string groupName, Func<double, double, double> groupFactorAggregator)`
+- `AdaptiveGrid.GetWeightModifiersGroup(string groupName)`
+- `AdaptiveGrid.AddPolylineWeightModifier(string name, Polyline polyline, double factor, double influenceDistance, bool is2D, string group = null)`
+- `AdaptiveGrid.AggregateFactorMin(double a, double b)`
+- `AdaptiveGrid.AggregateFactorMax(double a, double b)`
+- `AdaptiveGrid.AggregateFactorMultiply(double a, double b)`
 
 ### Changed
 - Element deserialization no longer requires `Name` to be present — it can be omitted.
+- `AdaptiveGrid.AddPlanarWeightModifier` - added `group` parameter.
+- `WeightModifier` - added `group` parameter to constructor.
+- Changed the logic for calculating the edge modifier factor. If an edge meets the condition of several WeightModifier objects, factor aggregator function will be applied to factors of each WeightModifiers group. By default - the lowest factor of group is chosen. Finally, factors of all groups will be multiplied.
 
 ## 1.4.0
 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -455,6 +455,7 @@ namespace Elements.Spatial.AdaptiveGrid
         {
             var weights = new Dictionary<ulong, EdgeInfo>();
             var mainAxis = _grid.Transform.XAxis;
+            var modifiersGroups = GroupWeightModifiers();
             foreach (var e in _grid.GetEdges())
             {
                 var v0 = _grid.GetVertex(e.StartId);
@@ -477,7 +478,7 @@ namespace Elements.Spatial.AdaptiveGrid
                 {
                     double hintFactor = 1;
                     double offsetFactor = 1;
-                    double modifierFactor = ModifierFactor(v0, v1);
+                    double modifierFactor = ModifierFactor(v0, v1, modifiersGroups);
 
                     //TODO: consider unifying hint line, offset line and modifiers as single concept.
                     //There will still be functions for adding hint/offset lines but everything will be processed inside

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -455,7 +455,7 @@ namespace Elements.Spatial.AdaptiveGrid
         {
             var weights = new Dictionary<ulong, EdgeInfo>();
             var mainAxis = _grid.Transform.XAxis;
-            var modifiersGroups = GroupWeightModifiers();
+            var modifiersGroups = GroupedWeightModifiers();
             foreach (var e in _grid.GetEdges())
             {
                 var v0 = _grid.GetVertex(e.StartId);

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -89,6 +89,7 @@ namespace Elements.Spatial.AdaptiveGrid
             var normalEdgesCheap = new List<(Line, double)>();
             var normalEdgesExpensive = new List<(Line, double)>();
             var hintEdges = new List<(Line, double)>();
+            var hintEdgesExpensive = new List<(Line, double)>();
             var offsetEdges = new List<(Line, double)>();
 
             var infos = CalculateEdgeInfos(hintLines);
@@ -108,7 +109,14 @@ namespace Elements.Spatial.AdaptiveGrid
                 var info = infos[edge.Id];
                 if (info.HasAnyFlag(EdgeFlags.UserDefinedHint))
                 {
-                    hintEdges.Add((l, info.Factor));
+                    if (info.Factor > 1 + _grid.Tolerance)
+                    {
+                        hintEdgesExpensive.Add((l, info.Factor));
+                    }
+                    else
+                    {
+                        hintEdges.Add((l, info.Factor));
+                    }
                 }
                 else if (info.HasAnyFlag(EdgeFlags.HiddenHint))
                 {
@@ -152,6 +160,7 @@ namespace Elements.Spatial.AdaptiveGrid
             add(normalEdgesExpensive, "Normal Edges Expensive", Colors.Purple);
             add(offsetEdges, "Offset Edges Main", Colors.Orange);
             add(hintEdges, "Hint Edges Main", Colors.Green);
+            add(hintEdgesExpensive, "Hint Edges Expensive", Colors.Yellow);
 
             return visualizations;
         }

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRoutingWeightModifier.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRoutingWeightModifier.cs
@@ -1,6 +1,7 @@
 ﻿using Elements.Geometry;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Elements.Spatial.AdaptiveGrid
@@ -9,6 +10,9 @@ namespace Elements.Spatial.AdaptiveGrid
     {
         private Dictionary<string, WeightModifier> _weightModifiers =
             new Dictionary<string, WeightModifier>();
+
+        private Dictionary<string, Func<double, double, double>> _groupFactorAggregators =
+            new Dictionary<string, Func<double, double, double>>();
 
         /// <summary>
         /// Get WeightModifier with given name.
@@ -52,13 +56,42 @@ namespace Elements.Spatial.AdaptiveGrid
         }
 
         /// <summary>
+        /// Set factor aggregator function for weight modifiers group.
+        /// <see cref="AggregateFactorMin"/>
+        /// <see cref="AggregateFactorMax"/>
+        /// <see cref="AggregateFactorMultiply"/>
+        /// </summary>
+        /// <param name="groupName">Group name.</param>
+        /// <param name="groupFactorAggregator">Factor aggregator function.</param>
+        public void SetWeightModifiersGroupFactorAggregator(string groupName, Func<double, double, double> groupFactorAggregator)
+        {
+            _groupFactorAggregators[groupName] = groupFactorAggregator;
+        }
+
+        /// <summary>
+        /// Get list of WeightModifier with specified group name.
+        /// </summary>
+        /// <param name="groupName">Group name. Must be not null.</param>
+        /// <returns>List of WeightModifier with the specified group name.</returns>
+        /// <exception cref="ArgumentNullException">Throws if <paramref name="groupName"/> is null.</exception>
+        public List<WeightModifier> GetGroupWeightModifiers(string groupName)
+        {
+            if (groupName == null)
+            {
+                throw new ArgumentNullException(nameof(groupName));
+            }
+            return _weightModifiers.Values.Where(m => groupName.Equals(m.Group)).ToList();
+        }
+
+        /// <summary>
         /// Create WeightModifier that sets the factor on all edges lying on a given plane.
         /// </summary>
         /// <param name="name">Name of new WeightModifier.</param>
         /// <param name="plane">Plane to check if edge lays on.</param>
         /// <param name="factor">Factor of new WeightModifier.</param>
+        /// <param name="group">Group name of new WeightModifier.</param>
         /// <returns>Created WeightModifier.</returns>
-        public WeightModifier AddPlanarWeightModifier(string name, Plane plane, double factor)
+        public WeightModifier AddPlanarWeightModifier(string name, Plane plane, double factor, string group = null)
         {
             var modifier = new WeightModifier(
                 name,
@@ -67,29 +100,118 @@ namespace Elements.Spatial.AdaptiveGrid
                     return Math.Abs(plane.SignedDistanceTo(a.Point)) < _grid.Tolerance &&
                            Math.Abs(plane.SignedDistanceTo(b.Point)) < _grid.Tolerance;
                 }),
-                factor);
+                factor,
+                group);
             AddWeightModifier(modifier);
             return modifier;
         }
 
         /// <summary>
-        /// Check if edge passes any modifier check and returns the lowest value among them.
+        /// Create WeightModifier that sets the factor on all edges
+        /// parallel(both points must be withing influence radius of the polyline) or intersecting with given polyline.
+        /// </summary>
+        /// <param name="name">Name of new WeightModifier.</param>
+        /// <param name="polyline">Polyline to check if edge is affected or intersected.</param>
+        /// <param name="factor">Factor of new WeightModifier.</param>
+        /// <param name="influenceDistance">Influence radius of polyline.</param>
+        /// <param name="is2D">Whether edge and polyline comparison should be considered in 2d or 3d.</param>
+        /// <param name="group">Group name of new WeightModifier.</param>
+        /// <returns>Created WeightModifier.</returns>
+        public WeightModifier AddPolylineWeightModifier(string name, Polyline polyline, double factor, double influenceDistance, bool is2D, string group = null)
+        {
+            var modifier = new WeightModifier(
+                name,
+                new Func<Vertex, Vertex, bool>((a, b) =>
+                {
+                    var line = new Line(a.Point, b.Point);
+                    if (is2D)
+                    {
+                        try
+                        {
+                            polyline = new Polyline(polyline.Vertices.Select(v => new Vector3(v.X, v.Y)).ToList());
+                            line = new Line(new Vector3(a.Point.X, a.Point.Y), new Vector3(b.Point.X, b.Point.Y));
+                        }
+                        catch
+                        {
+                            return false;
+                        }
+                    }
+                    var hintLine = new RoutingHintLine(polyline, factor, influenceDistance, true, is2D);
+                    var isAffectedParallely = hintLine.Affects(a.Point, b.Point);
+                    var isIntersected = polyline.Intersects(line, out _, includeEnds: true);
+                    return isAffectedParallely || isIntersected;
+                }),
+                factor,
+                group);
+            AddWeightModifier(modifier);
+            return modifier;
+        }
+
+        /// <summary>
+        /// Check if edge passes any modifier check and returns the aggregated value among them.
+        /// If an edge meets the condition of several WeightModifier objects
+        /// they will be grouped by group name and factor aggregator function will be applied to WeightModifiers factors. <see cref="SetWeightModifiersGroupFactorAggregator"/>.
+        /// By default - the lowest factor of group is chosen.
+        /// Finally, factors of all groups will be multiplied.
         /// Returns 1 if no modifiers applied.
         /// </summary>
         /// <param name="a">Start Vertex</param>
         /// <param name="b">End Vertex</param>
         private double ModifierFactor(Vertex a, Vertex b)
         {
-            double modifierFactor = double.MaxValue;
-            foreach (var modifier in _weightModifiers)
+            var modifiersGroups = _weightModifiers.Values.GroupBy(m => m.Group);
+            var modifierFactors = new List<double>();
+            foreach (var modifiersGroup in modifiersGroups)
             {
-                if (modifier.Value.Condition(a, b))
+                var appliedModifiers = modifiersGroup.Where(modifier => modifier.Condition(a, b));
+                if (!appliedModifiers.Any())
                 {
-                    modifierFactor = Math.Min(modifierFactor, modifier.Value.Factor);
+                    modifierFactors.Add(1);
+                    continue;
                 }
+
+                if (!_groupFactorAggregators.TryGetValue(modifiersGroup.Key, out var aggregateFactorFunc))
+                {
+                    aggregateFactorFunc = AggregateFactorMin;
+                }
+                var modifierFactor = appliedModifiers.Select(m => m.Factor).Aggregate(aggregateFactorFunc);
+                modifierFactors.Add(modifierFactor);
             }
 
-            return modifierFactor != double.MaxValue ? modifierFactor : 1;
+            return modifierFactors.Any() ? modifierFactors.Aggregate(AggregateFactorMultiply) : 1;
+        }
+
+        /// <summary>
+        /// Return minimum of factors.
+        /// </summary>
+        /// <param name="a">First factor.</param>
+        /// <param name="b">Second factor.</param>
+        /// <returns>Minimum of factors.</returns>
+        public static double AggregateFactorMin(double a, double b)
+        {
+            return Math.Min(a, b);
+        }
+
+        /// <summary>
+        /// Return maximum of factors.
+        /// </summary>
+        /// <param name="a">First factor.</param>
+        /// <param name="b">Second factor.</param>
+        /// <returns>Maximum of factors.</returns>
+        public static double AggregateFactorMax(double a, double b)
+        {
+            return Math.Max(a, b);
+        }
+
+        /// <summary>
+        /// Multiply factors.
+        /// </summary>
+        /// <param name="a">First factor.</param>
+        /// <param name="b">Second factor.</param>
+        /// <returns>Result of multiplication of factors.</returns>
+        public static double AggregateFactorMultiply(double a, double b)
+        {
+            return a * b;
         }
     }
 }

--- a/Elements/src/Spatial/AdaptiveGrid/RoutingHintLine.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/RoutingHintLine.cs
@@ -161,5 +161,26 @@ namespace Elements.Spatial.AdaptiveGrid
             }
             return false;
         }
+
+        /// <summary>
+        /// Check if hint line intersects the line represented by two points withing influence radius of the polyline.
+        /// </summary>
+        /// <param name="start">Start of the line point.</param>
+        /// <param name="end">End of the line point.</param>
+        public bool Intersects(Vector3 start, Vector3 end)
+        {
+            Vector3 vs = Is2D ? new Vector3(start.X, start.Y) : start;
+            Vector3 ve = Is2D ? new Vector3(end.X, end.Y) : end;
+
+            if (vs.IsAlmostEqualTo(ve))
+            {
+                return false;
+            }
+
+            var line = new Line(vs, ve);
+            var lineDir = line.Direction();
+            return Polyline.Segments().Any(s => !s.Direction().IsParallelTo(lineDir)
+                                                && line.DistanceTo(s) < InfluenceDistance);
+        }
     }
 }

--- a/Elements/src/Spatial/AdaptiveGrid/WeightModifier.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/WeightModifier.cs
@@ -6,7 +6,10 @@ namespace Elements.Spatial.AdaptiveGrid
 {
     /// <summary>
     /// Object that lets you apply an edge weight factor to edges that meet a Condition filter function.
-    /// If an edge meets the condition of several WeightModifier objects the lowest factor is chosen.
+    /// If an edge meets the condition of several WeightModifier objects
+    /// they will be grouped by group name and factor aggregator function will be applied to WeightModifiers <see cref="AdaptiveGraphRouting.SetWeightModifiersGroupFactorAggregator"/>.
+    /// By default - the lowest factor of group is chosen.
+    /// Factors of all groups will be multiplied.
     /// </summary>
     public class WeightModifier
     {
@@ -16,11 +19,13 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <param name="name">Name of the modifier.</param>
         /// <param name="condition">Filter function.</param>
         /// <param name="factor">Weight to be applied.</param>
-        public WeightModifier(string name, Func<Vertex, Vertex, bool> condition, double factor)
+        /// <param name="group">Group name of the modifier.</param>
+        public WeightModifier(string name, Func<Vertex, Vertex, bool> condition, double factor, string group = null)
         {
             Name = name;
             Condition = condition;
             Factor = factor;
+            Group = group ?? "default";
         }
 
         /// <summary>
@@ -37,5 +42,10 @@ namespace Elements.Spatial.AdaptiveGrid
         /// Weight to be applied according to this WeightModifier.
         /// </summary>
         public double Factor;
+
+        /// <summary>
+        /// Group name of the modifier.
+        /// </summary>
+        public readonly string Group;
     }
 }

--- a/Elements/src/Spatial/AdaptiveGrid/WeightModifier.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/WeightModifier.cs
@@ -7,7 +7,7 @@ namespace Elements.Spatial.AdaptiveGrid
     /// <summary>
     /// Object that lets you apply an edge weight factor to edges that meet a Condition filter function.
     /// If an edge meets the condition of several WeightModifier objects
-    /// they will be grouped by group name and factor aggregator function will be applied to WeightModifiers <see cref="AdaptiveGraphRouting.SetWeightModifiersGroupFactorAggregator"/>.
+    /// they will be grouped by group name and factor aggregator function will be applied to WeightModifiers <see cref="AdaptiveGraphRouting.SetWeightModifiersGroupAggregator"/>.
     /// By default - the lowest factor of group is chosen.
     /// Factors of all groups will be multiplied.
     /// </summary>


### PR DESCRIPTION
…gregator function for weight modifiers groups

BACKGROUND:
- Sometimes need to find max(not min as usual) factor for edge with several WeightModifiers. Need polyline weight modifier

DESCRIPTION:
- Add group name to WeightModifier
- Add ability to use custom factor aggregator function for weight modifiers groups. If an edge meets the condition of several WeightModifier objects they will be grouped by group name and factor aggregator function will be applied to WeightModifiers factors. By default - the lowest factor of group is chosen. Finally, factors of all groups will be multiplied.
- Add `SetWeightModifiersGroupFactorAggregator` method for setting factor aggregator functions for different groups. `AggregateFactorMin`, `AggregateFactorMax`, `AggregateFactorMultiply` can be used.
- Add method for creating polyline weight modifier

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/963)
<!-- Reviewable:end -->
