### PR TITLE
Fix changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.6.0
+
+### Fixed
+
+- #965
+
 ## 1.5.0
 
 ### Added
@@ -9,9 +15,6 @@
 
 ### Changed
 - Element deserialization no longer requires `Name` to be present — it can be omitted.
-
-### Fixed
-- #965
 
 ## 1.4.0
 


### PR DESCRIPTION
One note had mistakenly been put in 1.5 in the changelog. This PR updates that note to 1.6.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/966)
<!-- Reviewable:end -->
