### PR TITLE
Fix: wall intersections where bounded areas are not being created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Fixed
 - Using Multiple `ModelText`s would sometimes result in a corrupted texture atlas, with cutoff text. This is fixed.
 - #865
+- `Network`: intersections are not created for some E-shape cases
 
 ## 1.6.0
 

--- a/Elements/src/Search/Network.cs
+++ b/Elements/src/Search/Network.cs
@@ -192,7 +192,7 @@ namespace Elements.Search
             {
                 if (x.X.ApproximatelyEquals(y.X))
                 {
-                    return y.Y.CompareTo(x.Y);
+                    return x.Y.CompareTo(y.Y);
                 }
 
                 return x.X.CompareTo(y.X);
@@ -233,7 +233,7 @@ namespace Elements.Search
                 }
                 else if (segment.Start.X.ApproximatelyEquals(segment.End.X))
                 {
-                    leftMost = segment.Start.Y < segment.End.Y ? segment.End : segment.Start;
+                    leftMost = segment.Start.Y > segment.End.Y ? segment.End : segment.Start;
                 }
                 return new (Vector3 location, int index, bool isLeftMost, T item)[]{
                     (segment.Start, i, segment.Start == leftMost, item),

--- a/Elements/test/NetworkTests.cs
+++ b/Elements/test/NetworkTests.cs
@@ -484,6 +484,179 @@ namespace Elements.Tests
             DrawNetwork(network, allNodeLocations, this.Model, regions);
         }
 
+        [Fact]
+        public void EShapeNetwork1()
+        {
+            //      |
+            //      |
+            // -----|
+            //      |
+            //      |
+            // -----|
+            //      |
+            //      |
+
+            this.Name = nameof(EShapeNetwork1);
+
+            var lines = new List<Line> {
+                new Line((10, 0), (10, 10)),
+                new Line((0, 5), (10, 5)),
+                new Line((0, 7), (10, 7)),
+            };
+            var network = Network<Line>.FromSegmentableItems(lines,
+                                                                      (line) => { return line; },
+                                                                      out var allNodeLocations,
+                                                                      out var allIntersectionLocations);
+
+
+            Assert.Equal(network.EdgesAt(0).Select(i => i.Item1), new List<int>() { 1 });
+            Assert.Equal(network.EdgesAt(1).Select(i => i.Item1), new List<int>() { 0, 2, 4 });
+            Assert.Equal(network.EdgesAt(2).Select(i => i.Item1), new List<int>() { 1, 3, 5 });
+            Assert.Equal(network.EdgesAt(3).Select(i => i.Item1), new List<int>() { 2 });
+            Assert.Equal(network.EdgesAt(4).Select(i => i.Item1), new List<int>() { 1 });
+            Assert.Equal(network.EdgesAt(5).Select(i => i.Item1), new List<int>() { 2 });
+
+            DrawNetwork(network, allNodeLocations, this.Model);
+        }
+
+        [Fact]
+        public void EShapeNetwork2()
+        {
+            //       |
+            //       |
+            //  -----|
+            //       |
+            //       |
+            // ------|
+            //       |
+            //       |
+
+            this.Name = nameof(EShapeNetwork2);
+
+            var lines = new List<Line> {
+                new Line((10, 0), (10, 10)),
+                new Line((0, 5), (10, 5)),
+                new Line((-2, 7), (10, 7)),
+            };
+            var network = Network<Line>.FromSegmentableItems(lines,
+                                                                      (line) => { return line; },
+                                                                      out var allNodeLocations,
+                                                                      out var allIntersectionLocations);
+
+
+            Assert.Equal(network.EdgesAt(0).Select(i => i.Item1), new List<int>() { 1 });
+            Assert.Equal(network.EdgesAt(1).Select(i => i.Item1), new List<int>() { 0, 2, 4 });
+            Assert.Equal(network.EdgesAt(2).Select(i => i.Item1), new List<int>() { 1, 3, 5 });
+            Assert.Equal(network.EdgesAt(3).Select(i => i.Item1), new List<int>() { 2 });
+            Assert.Equal(network.EdgesAt(4).Select(i => i.Item1), new List<int>() { 1 });
+            Assert.Equal(network.EdgesAt(5).Select(i => i.Item1), new List<int>() { 2 });
+
+            DrawNetwork(network, allNodeLocations, this.Model);
+        }
+
+        [Fact]
+        public void EShapeNetwork3()
+        {
+            // |
+            // |
+            // |-----
+            // |
+            // |
+            // |-----
+            // |
+            // |
+
+            this.Name = nameof(EShapeNetwork3);
+
+            var lines = new List<Line> {
+                new Line((0, 0), (0, 10)),
+                new Line((0, 5), (10, 5)),
+                new Line((0, 7), (10, 7)),
+            };
+            var network = Network<Line>.FromSegmentableItems(lines,
+                                                                      (line) => { return line; },
+                                                                      out var allNodeLocations,
+                                                                      out var allIntersectionLocations);
+
+
+            Assert.Equal(network.EdgesAt(0).Select(i => i.Item1), new List<int>() { 1 });
+            Assert.Equal(network.EdgesAt(1).Select(i => i.Item1), new List<int>() { 0, 2, 4 });
+            Assert.Equal(network.EdgesAt(2).Select(i => i.Item1), new List<int>() { 1, 3, 5 });
+            Assert.Equal(network.EdgesAt(3).Select(i => i.Item1), new List<int>() { 2 });
+            Assert.Equal(network.EdgesAt(4).Select(i => i.Item1), new List<int>() { 1 });
+            Assert.Equal(network.EdgesAt(5).Select(i => i.Item1), new List<int>() { 2 });
+
+            DrawNetwork(network, allNodeLocations, this.Model);
+        }
+
+        [Fact]
+        public void EShapeNetwork4()
+        {
+            // |
+            // |
+            // |-----
+            // |
+            // |
+            // |--------
+            // |
+            // |
+
+            this.Name = nameof(EShapeNetwork4);
+
+            var lines = new List<Line> {
+                new Line((0, 0), (0, 10)),
+                new Line((0, 5), (10, 5)),
+                new Line((0, 7), (12, 7)),
+            };
+            var network = Network<Line>.FromSegmentableItems(lines,
+                                                                      (line) => { return line; },
+                                                                      out var allNodeLocations,
+                                                                      out var allIntersectionLocations);
+
+
+            Assert.Equal(network.EdgesAt(0).Select(i => i.Item1), new List<int>() { 1 });
+            Assert.Equal(network.EdgesAt(1).Select(i => i.Item1), new List<int>() { 0, 2, 4 });
+            Assert.Equal(network.EdgesAt(2).Select(i => i.Item1), new List<int>() { 1, 3, 5 });
+            Assert.Equal(network.EdgesAt(3).Select(i => i.Item1), new List<int>() { 2 });
+            Assert.Equal(network.EdgesAt(4).Select(i => i.Item1), new List<int>() { 1 });
+            Assert.Equal(network.EdgesAt(5).Select(i => i.Item1), new List<int>() { 2 });
+
+            DrawNetwork(network, allNodeLocations, this.Model);
+        }
+
+
+        [Fact]
+        public void EShapeNetwork5()
+        {
+            // ----------------
+            //    |     |
+            //    |     |
+            //    |     |
+
+
+            this.Name = nameof(EShapeNetwork5);
+
+            var lines = new List<Line> {
+                new Line((0, 0), (10, 0)),
+                new Line((5, 0), (5, 10)),
+                new Line((7, 0), (7, 10)),
+            };
+            var network = Network<Line>.FromSegmentableItems(lines,
+                                                                      (line) => { return line; },
+                                                                      out var allNodeLocations,
+                                                                      out var allIntersectionLocations);
+
+
+            Assert.Equal(network.EdgesAt(0).Select(i => i.Item1), new List<int>() { 1 });
+            Assert.Equal(network.EdgesAt(1).Select(i => i.Item1), new List<int>() { 0, 2, 4 });
+            Assert.Equal(network.EdgesAt(2).Select(i => i.Item1), new List<int>() { 1, 3, 5 });
+            Assert.Equal(network.EdgesAt(3).Select(i => i.Item1), new List<int>() { 2 });
+            Assert.Equal(network.EdgesAt(4).Select(i => i.Item1), new List<int>() { 1 });
+            Assert.Equal(network.EdgesAt(5).Select(i => i.Item1), new List<int>() { 2 });
+
+            DrawNetwork(network, allNodeLocations, this.Model);
+        }
+
         private static void DrawNetwork<T>(Network<T> network, List<Vector3> allNodeLocations, Model model, List<List<int>> regions = null)
         {
             var random = new Random(11);


### PR DESCRIPTION
BACKGROUND:
The wall intersections were not created inside some visibly bound areas:

![image](https://user-images.githubusercontent.com/88673491/232590637-c25dbd2a-2f97-450c-bd68-4085818c8391.png)

![image](https://user-images.githubusercontent.com/88673491/232590856-18635b4b-7394-4d95-89f2-968f8a7834c4.png)

It happens on some E-shaped intersections:
![image](https://user-images.githubusercontent.com/88673491/232591208-11149de5-7099-4e94-b687-7903f116affd.png)

The problem occurs when building a tree. The order of vertexes looks like this:
![image](https://user-images.githubusercontent.com/88673491/232591851-600d7870-d747-4ec2-a307-eb90a481fa1e.png)

And the tree traversal with LeftMostPointComparer:
![image](https://user-images.githubusercontent.com/88673491/232592184-937d7101-e613-4cd8-b40f-c2a9ac4f1e42.png)
 On step 2 the line on the right site is not added, because it's not the leftMost point. On step 3 the bottom line is removed as successor to  upper line. So point 4 is never added to the tree:
![image](https://user-images.githubusercontent.com/88673491/232593342-9836d3c5-0864-4b85-8152-4533a172da5c.png)

The solution is two change events order and change the LeftMost point location for lines || to Y axis:
![image](https://user-images.githubusercontent.com/88673491/232596567-51766f22-26ef-4c71-831d-f8318f44d53a.png)

DESCRIPTION:
- This PR contains changes above and tests with different E-shaped networks

TESTING:
- A added tests

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/970)
<!-- Reviewable:end -->
