### PR TITLE
Notebook

### DIFF
--- a/Elements/src/extension.dib
+++ b/Elements/src/extension.dib
@@ -1,3 +1,7 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"aliases":[],"name":"csharp"}]}}
+
 #!markdown
 
 This script is packaged with the NuGet package, and only
@@ -141,7 +145,7 @@ string GetModelViewerSrc(Model model, double? width=null, double? height=null) {
     .Replace("DIV_ID", Guid.NewGuid().ToString());
 }
 
-Formatter.Register<Curve>((crv, writer) => {
+Formatter.Register<BoundedCurve>((crv, writer) => {
     var model = new Model();
     model.AddElement(new ModelCurve(crv, DEFAULT_CURVE_MATERIAL));
     var src = GetModelViewerSrc(model);
@@ -170,7 +174,7 @@ Formatter.Register<IEnumerable<Element>>((elements, writer) => {
     writer.Write(src);
 }, "text/html");
 
-Formatter.Register<IEnumerable<Curve>>((crvs, writer) => {
+Formatter.Register<IEnumerable<BoundedCurve>>((crvs, writer) => {
     var model = new Model();
     model.AddElements(crvs.Select(crv => new ModelCurve(crv, DEFAULT_CURVE_MATERIAL)));
     var src = GetModelViewerSrc(model);

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ We couldn't find anything quite right. So we started building this.
 In IFC, Revit, and other "BIM" applications, the building element ontology is fixed. If you want to introduce a new element which is key to your work process, you need to find the most closely matching category and put your element there. In Revit you might use the "Generic" category. In IFC you might use the `IFCBuildingElementProxy` type. This makes it very difficult for the recipient of a model to reason about the model semantically. Elements enables the user to create "first class" element types in the system. If you want to create a Curtain Wall Bracket, you simply create a class `CurtainWallBracket : Element` and users can search for your element by its defined type.
 
 ## Geometry
-Elements contains a very simple BREP geometry kernel, and a small set of geometric types like vectors, lines, arcs, and polygons. Elements uses a right-handed coordinate system with +Z "up". Elements is unitless except as indicated when calling a geometric method. For example, arcs requires angles in degrees.
+Elements contains a very simple hybrid BREP/CSG geometry kernel, and a small set of geometric types like vectors, lines, arcs, and polygons. Elements uses a right-handed coordinate system with +Z "up". Elements is unitless except as indicated when calling a geometric method. For example, arcs requires angles in degrees.
 
 The geometry kernel that we've created for Elements is a very simple BREP kernel which does "flat stuff with holes in it" really well. We think Nurbs are sexy, and we'll definitely support more curvy stuff in the future, it's just that the effort required to support arbitrarily complex geometry for micro-services running in the cloud is not small. Professional geometry kernels, like the kind found in mechanical modeling applications, are also usually large, expensive, and not open source. They introduce cost and complexity, and restrict the open nature of code that you write with Elements.
 
@@ -102,20 +102,6 @@ cd doc
 docfx -f --serve
 ```
 
-## Third Party Libraries and Specifications
-
-- [LibTessDotNet](https://github.com/speps/LibTessDotNet)
-- [Clipper](http://www.angusj.com/delphi/clipper.php)
-- [GeoJson](http://geojson.org/)
-- [glTF](https://www.khronos.org/gltf/).
-- [SixLabors.ImageSharp](https://github.com/SixLabors/ImageSharp)
-- [SixLabors.ImageSharp.Drawing](https://github.com/SixLabors/ImageSharp.Drawing)
-- [SixLabors.Fonts](https://github.com/SixLabors/Fonts)
-- [NJsonSchema](https://github.com/RicoSuter/NJsonSchema)
-- [Csg](https://github.com/praeclarum/Csg) We work with a customized fork of this project.  Currently using branch `hypars-branch`
-- [NetOctree](https://github.com/mcserep/NetOctree)
-- [Svg.NET](https://github.com/svg-net/SVG)
-
 ## Updating the Changelog
 We use [`CHANGELOG.md`](CHANGELOG.md) to provide a list of changes to Elements. The easiest way to compile this log for new releases is to look at the commits that occurred between changes. This can be done as follows: `git log --pretty=oneline v0.3.6...v0.3.7`, where the tags are changed appropriately.
 
@@ -133,3 +119,17 @@ To test against a local build of Elements, add the following to the top of your 
 #r "nuget:glTF2Loader, 1.1.3-alpha"
 #r "nuget:Unofficial.LibTessDotNet, 2.0.0"
 ```
+
+## Third Party Libraries and Specifications
+
+- [LibTessDotNet](https://github.com/speps/LibTessDotNet)
+- [Clipper](http://www.angusj.com/delphi/clipper.php)
+- [GeoJson](http://geojson.org/)
+- [glTF](https://www.khronos.org/gltf/).
+- [SixLabors.ImageSharp](https://github.com/SixLabors/ImageSharp)
+- [SixLabors.ImageSharp.Drawing](https://github.com/SixLabors/ImageSharp.Drawing)
+- [SixLabors.Fonts](https://github.com/SixLabors/Fonts)
+- [NJsonSchema](https://github.com/RicoSuter/NJsonSchema)
+- [Csg](https://github.com/praeclarum/Csg) We work with a customized fork of this project.  Currently using branch `hypars-branch`
+- [NetOctree](https://github.com/mcserep/NetOctree)
+- [Svg.NET](https://github.com/svg-net/SVG)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ![Tag and Publish Alpha](https://github.com/hypar-io/Elements/workflows/Tag%20and%20Publish%20Alpha/badge.svg)
 ![Build and Test on PR](https://github.com/hypar-io/Elements/workflows/Build%20and%20Test%20on%20PR/badge.svg)
 ![NuGet](https://img.shields.io/nuget/v/Hypar.Elements.svg)
-[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=3HBW7BYRSBZYE)
 
 # Projects
 |Name|Description|

--- a/README.md
+++ b/README.md
@@ -62,16 +62,12 @@ We couldn't find anything quite right. So we started building this.
 In IFC, Revit, and other "BIM" applications, the building element ontology is fixed. If you want to introduce a new element which is key to your work process, you need to find the most closely matching category and put your element there. In Revit you might use the "Generic" category. In IFC you might use the `IFCBuildingElementProxy` type. This makes it very difficult for the recipient of a model to reason about the model semantically. Elements enables the user to create "first class" element types in the system. If you want to create a Curtain Wall Bracket, you simply create a class `CurtainWallBracket : Element` and users can search for your element by its defined type.
 
 ## Geometry
-Elements contains a very simple BREP geometry kernel, and a small set of geometric types like vectors, lines, and polygons. Elements uses a right-handed coordinate system with +Z "up". Elements is unitless except as indicated when calling a geometric method. For example, arcs requires angles in degrees.
+Elements contains a very simple BREP geometry kernel, and a small set of geometric types like vectors, lines, arcs, and polygons. Elements uses a right-handed coordinate system with +Z "up". Elements is unitless except as indicated when calling a geometric method. For example, arcs requires angles in degrees.
 
 The geometry kernel that we've created for Elements is a very simple BREP kernel which does "flat stuff with holes in it" really well. We think Nurbs are sexy, and we'll definitely support more curvy stuff in the future, it's just that the effort required to support arbitrarily complex geometry for micro-services running in the cloud is not small. Professional geometry kernels, like the kind found in mechanical modeling applications, are also usually large, expensive, and not open source. They introduce cost and complexity, and restrict the open nature of code that you write with Elements.
 
 ## Precision
 Geometry operations in Elements use `Vector3.Epsilon=1e-05` to compare values that should be considered equal. This is important as geometric operations using floating point numbers are imprecise. In addition, .NET will return different values for these operations _on different systems_. We have seen intersection tests that pass on a mac and fail on linux. Please use the provided methods like `double.IsAlmostEqualTo(...)`, `Vector3.IsZero()`, and `Vector3.IsAlmostEqualTo(...)` which account for precision.
-
-## Donate
-Hypar Elements is open source and will remain so **forever**. Your donation will directly support the development of the Hypar Elements. Hypar Elements has been demonstrated to work in Revit add-ins, Unity projects, and as Lambdas running on AWS. Send us a donation and open a feature request telling us what you'd like it to do.
-[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=3HBW7BYRSBZYE)
 
 ## Build
 You'll only need to do this if you want to contribute to the library, otherwise you can use the [NuGet package](https://www.nuget.org/) that is published regularly.
@@ -99,6 +95,7 @@ When adding sample code you need to add a special block of text to the class or 
         /// </example>
 ```
 You may add up to one sample glb file per class, and when you name it the name must match the namespace, and class you are trying to demonstrate with `_` instead of `.`.  For example `Elements.Spatial.Grid2d` sample glb is named `Elements_Spatial_Grid2d`.
+
 ### Building the Documentation
 ```
 cd doc
@@ -121,3 +118,18 @@ docfx -f --serve
 
 ## Updating the Changelog
 We use [`CHANGELOG.md`](CHANGELOG.md) to provide a list of changes to Elements. The easiest way to compile this log for new releases is to look at the commits that occurred between changes. This can be done as follows: `git log --pretty=oneline v0.3.6...v0.3.7`, where the tags are changed appropriately.
+
+## Testing with Notebooks
+Elements can be tested in a [Polyglot Notebook](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode).
+
+To test against a released Elements package, add the following to the top of your notebook.
+```
+#r "nuget:Hypar.Elements, *-*"
+```
+
+To test against a local build of Elements, add the following to the top of your notebook.
+```
+#r "/Users/iankeough/dev/Hypar/Elements/Elements/src/bin/Debug/netstandard2.0/Hypar.Elements.dll"
+#r "nuget:glTF2Loader, 1.1.3-alpha"
+#r "nuget:Unofficial.LibTessDotNet, 2.0.0"
+```


### PR DESCRIPTION
BACKGROUND:
The introduction of `BoundedCurve` caused the notebook extension to fail.

DESCRIPTION:
- Fixes the notebook extension.
- Adds documentation for using the notebooks.
- Removes the donate link from the readme.
- Adds information about arcs and csg to the readme.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/971)
<!-- Reviewable:end -->
