### PR TITLE
Normalized

### DIFF
--- a/Elements/src/Geometry/BoundedCurve.cs
+++ b/Elements/src/Geometry/BoundedCurve.cs
@@ -124,7 +124,7 @@ namespace Elements.Geometry
         /// Get a transform whose XY plane is perpendicular to the curve, and whose
         /// positive Z axis points along the curve.
         /// </summary>
-        /// <param name="u">The transform at a parameter along the curve between 0.0 and 1.0.</param>
+        /// <param name="u">The parameter along the curve between 0.0 and 1.0.</param>
         /// <returns>A transform.</returns>
         public Transform TransformAtNormalized(double u)
         {

--- a/Elements/src/Geometry/BoundedCurve.cs
+++ b/Elements/src/Geometry/BoundedCurve.cs
@@ -111,6 +111,27 @@ namespace Elements.Geometry
         public abstract double[] GetSubdivisionParameters(double startSetbackDistance = 0, double endSetbackDistance = 0);
 
         /// <summary>
+        /// Get a point along the curve at parameter u.
+        /// </summary>
+        /// <param name="u">A parameter along the curve between 0.0 and 1.0.</param>
+        /// <returns>A point along the curve at parameter u.</returns>
+        public Vector3 PointAtNormalized(double u)
+        {
+            return PointAt(u.MapToDomain(this.Domain));
+        }
+
+        /// <summary>
+        /// Get a transform whose XY plane is perpendicular to the curve, and whose
+        /// positive Z axis points along the curve.
+        /// </summary>
+        /// <param name="u">The transform at a parameter along the curve between 0.0 and 1.0.</param>
+        /// <returns>A transform.</returns>
+        public Transform TransformAtNormalized(double u)
+        {
+            return TransformAt(u.MapToDomain(this.Domain));
+        }
+
+        /// <summary>
         /// Get a collection of vertices used to render the curve.
         /// </summary>
         internal IList<Vector3> RenderVertices()

--- a/Elements/src/Geometry/Curve.cs
+++ b/Elements/src/Geometry/Curve.cs
@@ -1,4 +1,3 @@
-using System;
 using Elements.Geometry.Interfaces;
 using Newtonsoft.Json;
 
@@ -19,20 +18,20 @@ namespace Elements.Geometry
         /// <summary>
         /// Get a point along the curve at parameter u.
         /// </summary>
-        /// <param name="u"></param>
-        /// <returns>A point on the curve at parameter u.</returns>
+        /// <param name="u">A parameter along the curve between domain.min and domain.max.</param>
+        /// <returns>A point along the curve at parameter u.</returns>
         public abstract Vector3 PointAt(double u);
 
         /// <summary>
         /// Get a transform whose XY plane is perpendicular to the curve, and whose
         /// positive Z axis points along the curve.
         /// </summary>
-        /// <param name="u">The parameter along the Line, between 0.0 and 1.0, at which to calculate the Transform.</param>
-        /// <returns>A transform.</returns>
+        /// <param name="u">The transform at a parameter along the curve between domain.min and domain.max.</param>
+        /// <returns>A transform on the curve at parameter u.</returns>
         public abstract Transform TransformAt(double u);
 
         /// <summary>
-        /// Create a transformed copy of this Curve.
+        /// Create a transformed copy of this curve.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
         public abstract Curve Transformed(Transform transform);

--- a/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
+++ b/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
@@ -52,5 +52,20 @@ namespace Elements.Geometry.Interfaces
         /// <param name="endSetbackDistance">An optional setback from the end of the curve.</param>
         /// <returns>A collection of parameter values.</returns>
         double[] GetSubdivisionParameters(double startSetbackDistance = 0, double endSetbackDistance = 0);
+
+        /// <summary>
+        /// Get a point along the curve at parameter u.
+        /// </summary>
+        /// <param name="u">A parameter along the curve between 0.0 and 1.0.</param>
+        /// <returns>A point along the curve at parameter u.</returns>
+        Vector3 PointAtNormalized(double u);
+
+        /// <summary>
+        /// Get a transform whose XY plane is perpendicular to the curve, and whose
+        /// positive Z axis points along the curve.
+        /// </summary>
+        /// <param name="u">The transform at a parameter along the curve between 0.0 and 1.0.</param>
+        /// <returns>A transform.</returns>
+        Transform TransformAtNormalized(double u);
     }
 }

--- a/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
+++ b/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
@@ -64,7 +64,7 @@ namespace Elements.Geometry.Interfaces
         /// Get a transform whose XY plane is perpendicular to the curve, and whose
         /// positive Z axis points along the curve.
         /// </summary>
-        /// <param name="u">The transform at a parameter along the curve between 0.0 and 1.0.</param>
+        /// <param name="u">The parameter along the curve between 0.0 and 1.0.</param>
         /// <returns>A transform.</returns>
         Transform TransformAtNormalized(double u);
     }

--- a/Elements/test/ArcTests.cs
+++ b/Elements/test/ArcTests.cs
@@ -279,5 +279,43 @@ namespace Hypar.Tests
             var lastBeam = new Beam(new Line(allPoints[0], allPoints[1]), profile);
             this.Model.AddElement(lastBeam);
         }
+
+        [Fact]
+        public void PointAtNormalizedReturnsSameValue()
+        {
+            var line = ModelTest.TestLine;
+            Assert.Equal(line.PointAt(line.Domain.Mid()), line.PointAtNormalized(0.5));
+
+            var arc = ModelTest.TestArc;
+            Assert.Equal(arc.PointAt(arc.Domain.Mid()), arc.PointAtNormalized(0.5));
+
+            var ellipticalArc = ModelTest.TestEllipticalArc;
+            Assert.Equal(ellipticalArc.PointAt(ellipticalArc.Domain.Mid()), ellipticalArc.PointAtNormalized(0.5));
+
+            var polyline = ModelTest.TestPolyline;
+            Assert.Equal(polyline.PointAt(polyline.Domain.Mid()), polyline.PointAtNormalized(0.5));
+
+            var polygon = ModelTest.TestPolygon;
+            Assert.Equal(polygon.PointAt(polygon.Domain.Mid()), polygon.PointAtNormalized(0.5));
+        }
+
+        [Fact]
+        public void TransformAtNormalizedReturnsSameValue()
+        {
+            var line = ModelTest.TestLine;
+            Assert.Equal(line.TransformAt(line.Domain.Mid()), line.TransformAtNormalized(0.5));
+
+            var arc = ModelTest.TestArc;
+            Assert.Equal(arc.TransformAt(arc.Domain.Mid()), arc.TransformAtNormalized(0.5));
+
+            var ellipticalArc = ModelTest.TestEllipticalArc;
+            Assert.Equal(ellipticalArc.TransformAt(ellipticalArc.Domain.Mid()), ellipticalArc.TransformAtNormalized(0.5));
+
+            var polyline = ModelTest.TestPolyline;
+            Assert.Equal(polyline.TransformAt(polyline.Domain.Mid()), polyline.TransformAtNormalized(0.5));
+
+            var polygon = ModelTest.TestPolygon;
+            Assert.Equal(polygon.TransformAt(polygon.Domain.Mid()), polygon.TransformAtNormalized(0.5));
+        }
     }
 }

--- a/Elements/test/ArcTests.cs
+++ b/Elements/test/ArcTests.cs
@@ -301,9 +301,26 @@ namespace Hypar.Tests
 
         private void TestPointAtNormalized(BoundedCurve curve)
         {
+            var testParam = 0.24;
+            var equivalentTestParam = 0.0;
+
+            if (curve is Line || curve is Polyline)
+            {
+                equivalentTestParam = curve.Length() * testParam;
+            }
+            else if (curve is Arc || curve is EllipticalArc)
+            {
+                equivalentTestParam = curve.Domain.Min + curve.Domain.Length * testParam;
+            }
+
             Assert.Equal(curve.PointAt(curve.Domain.Mid()), curve.PointAtNormalized(0.5));
             Assert.Equal(curve.PointAt(curve.Domain.Min), curve.PointAtNormalized(0.0));
             Assert.Equal(curve.PointAt(curve.Domain.Max), curve.PointAtNormalized(1.0));
+
+            // The start, end, and mid points are the same, but we also want to ensure
+            // that the curve didn't flip directions as well. We do this by testing
+            // another random parameter. 
+            Assert.Equal(curve.PointAt(equivalentTestParam), curve.PointAtNormalized(testParam));
         }
 
         [Fact]

--- a/Elements/test/ArcTests.cs
+++ b/Elements/test/ArcTests.cs
@@ -284,38 +284,52 @@ namespace Hypar.Tests
         public void PointAtNormalizedReturnsSameValue()
         {
             var line = ModelTest.TestLine;
-            Assert.Equal(line.PointAt(line.Domain.Mid()), line.PointAtNormalized(0.5));
+            TestPointAtNormalized(line);
 
             var arc = ModelTest.TestArc;
-            Assert.Equal(arc.PointAt(arc.Domain.Mid()), arc.PointAtNormalized(0.5));
+            TestPointAtNormalized(arc);
 
             var ellipticalArc = ModelTest.TestEllipticalArc;
-            Assert.Equal(ellipticalArc.PointAt(ellipticalArc.Domain.Mid()), ellipticalArc.PointAtNormalized(0.5));
+            TestPointAtNormalized(ellipticalArc);
 
             var polyline = ModelTest.TestPolyline;
-            Assert.Equal(polyline.PointAt(polyline.Domain.Mid()), polyline.PointAtNormalized(0.5));
+            TestPointAtNormalized(polyline);
 
             var polygon = ModelTest.TestPolygon;
-            Assert.Equal(polygon.PointAt(polygon.Domain.Mid()), polygon.PointAtNormalized(0.5));
+            TestPointAtNormalized(polygon);
+        }
+
+        private void TestPointAtNormalized(BoundedCurve curve)
+        {
+            Assert.Equal(curve.PointAt(curve.Domain.Mid()), curve.PointAtNormalized(0.5));
+            Assert.Equal(curve.PointAt(curve.Domain.Min), curve.PointAtNormalized(0.0));
+            Assert.Equal(curve.PointAt(curve.Domain.Max), curve.PointAtNormalized(1.0));
         }
 
         [Fact]
         public void TransformAtNormalizedReturnsSameValue()
         {
             var line = ModelTest.TestLine;
-            Assert.Equal(line.TransformAt(line.Domain.Mid()), line.TransformAtNormalized(0.5));
+            TestTransformAtNormalized(line);
 
             var arc = ModelTest.TestArc;
-            Assert.Equal(arc.TransformAt(arc.Domain.Mid()), arc.TransformAtNormalized(0.5));
+            TestTransformAtNormalized(arc);
 
             var ellipticalArc = ModelTest.TestEllipticalArc;
-            Assert.Equal(ellipticalArc.TransformAt(ellipticalArc.Domain.Mid()), ellipticalArc.TransformAtNormalized(0.5));
+            TestTransformAtNormalized(ellipticalArc);
 
             var polyline = ModelTest.TestPolyline;
-            Assert.Equal(polyline.TransformAt(polyline.Domain.Mid()), polyline.TransformAtNormalized(0.5));
+            TestTransformAtNormalized(polyline);
 
             var polygon = ModelTest.TestPolygon;
-            Assert.Equal(polygon.TransformAt(polygon.Domain.Mid()), polygon.TransformAtNormalized(0.5));
+            TestTransformAtNormalized(polygon);
+        }
+
+        private void TestTransformAtNormalized(BoundedCurve curve)
+        {
+            Assert.Equal(curve.TransformAt(curve.Domain.Mid()), curve.TransformAtNormalized(0.5));
+            Assert.Equal(curve.TransformAt(curve.Domain.Min), curve.TransformAtNormalized(0.0));
+            Assert.Equal(curve.TransformAt(curve.Domain.Max), curve.TransformAtNormalized(1.0));
         }
     }
 }

--- a/Elements/test/ModelTest.cs
+++ b/Elements/test/ModelTest.cs
@@ -40,6 +40,8 @@ namespace Elements.Tests
         internal static Polyline TestPolyline = new Polyline(new[] { new Vector3(0, 0), new Vector3(0, 2), new Vector3(0, 3, 1) });
         internal static Polygon TestPolygon = Polygon.Ngon(5, 2);
         internal static Circle TestCircle = new Circle(Vector3.Origin, 5);
+        internal static Ellipse TestEllipse = new Ellipse(Vector3.Origin, 5, 2);
+        internal static EllipticalArc TestEllipticalArc = new EllipticalArc(TestEllipse, Math.PI * 0.25, Math.PI * 0.75);
 
         public ModelTest()
         {


### PR DESCRIPTION
BACKGROUND:
During discussion of of the impact of the changes to curve parameterization in 2.0, @wynged said that it would ease the transition for existing code that uses `PointAt`, if we could have replacement methods like `PointAtNormalized`.

DESCRIPTION:
- Adds `PointAtNormalized` and `TransformAtNormalized`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/972)
<!-- Reviewable:end -->
