### PR TITLE
Fix coplanar check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Using Multiple `ModelText`s would sometimes result in a corrupted texture atlas, with cutoff text. This is fixed.
 - #865
 - `Network`: intersections are not created for some E-shape cases
+- `Vector3.AreCoplanar` would sometimes return false negatives.
 
 ## 1.6.0
 

--- a/Elements/src/Geometry/Vector3Extensions.cs
+++ b/Elements/src/Geometry/Vector3Extensions.cs
@@ -283,7 +283,7 @@ namespace Elements.Geometry
             {
                 if (output.Any(x => x.IsAlmostEqualTo(vector, tolerance)))
                 {
-                    continue; ;
+                    continue;
                 }
                 output.Add(vector);
             }

--- a/Elements/src/Geometry/Vector3Extensions.cs
+++ b/Elements/src/Geometry/Vector3Extensions.cs
@@ -10,17 +10,18 @@ namespace Elements.Geometry
     public static class Vector3Extensions
     {
         /// <summary>
-        /// Returns the indices of the first three non-collinear points in a list.
+        /// Check if a collection of points has at least three non-collinear points. Returns true if it does, false otherwise.
         /// </summary>
         /// <param name="points">The list of points to search.</param>
-        /// <returns>A tuple of three integers representing the indices of the first three non-collinear points in the list.
-        /// If there are fewer than three non-collinear points in the list, the corresponding index will be -1. The first index is always 0.</returns>
-        public static (int p0Index, int p1Index, int p2Index) GetFirstThreeNonCollinearPointIndices(this IList<Vector3> points)
+        /// <param name="p1Index">The index of the first non-collinear point after index 0.</param>
+        /// <param name="p2Index">The index of the second non-collinear point after index 0.</param>
+        /// <returns>True if there are three non-collinear points.</returns>
+        public static bool TryGetThreeNonCollinearPoints(this IList<Vector3> points, out int p1Index, out int p2Index)
         {
             // Choose the first three non-collinear points
             var p0 = points[0];
-            int p1Index = -1;
-            int p2Index = -1;
+            p1Index = -1;
+            p2Index = -1;
             for (int i = 1; i < points.Count; i++)
             {
                 if (p1Index == -1 && (points[i] - p0).Length() > Vector3.EPSILON)
@@ -33,7 +34,7 @@ namespace Elements.Geometry
                     break;
                 }
             }
-            return (0, p1Index, p2Index);
+            return p2Index == -1;
         }
 
         /// <summary>
@@ -52,10 +53,13 @@ namespace Elements.Geometry
             if (points.Count < 4) return true; // all sets of less than four points are coplanar
 
             // Choose the first three non-collinear points
-            (int p0Index, int p1Index, int p2Index) = points.GetFirstThreeNonCollinearPointIndices();
-            var p0 = points[p0Index];
+            if (!points.TryGetThreeNonCollinearPoints(out var p1Index, out var p2Index))
+            {
+                // all points are collinear or coincident, so must be coplanar.
+                return true;
+            }
 
-            if (p2Index == -1) return true; // All points are collinear or coincident
+            var p0 = points[0];
 
             if (p2Index == points.Count - 1)
             {

--- a/Elements/src/Geometry/Vector3Extensions.cs
+++ b/Elements/src/Geometry/Vector3Extensions.cs
@@ -37,7 +37,7 @@ namespace Elements.Geometry
             if (p1Index == -1) return true; // All points are coincident
             if (p2Index == -1) return true; // All points are collinear
 
-            if (p2Index == points.Count - 1) // p2 is the last point
+            if (p2Index == points.Count - 1) // p2 is the last point, which means all the other points are collinear.
             {
                 return true;
             }

--- a/Elements/src/Geometry/Vector3Extensions.cs
+++ b/Elements/src/Geometry/Vector3Extensions.cs
@@ -15,26 +15,27 @@ namespace Elements.Geometry
         /// <param name="points"></param>
         public static bool AreCoplanar(this IList<Vector3> points)
         {
-            if (points.Count < 3) return true;
+            if (points.Count < 4) return true; // all sets of less than four points are coplanar
 
-            //TODO: https://github.com/hypar-io/sdk/issues/54
-            // Ensure that all triple products are equal to 0.
-            // a.Dot(b.Cross(c));
-            var a = points[0];
-            var b = points[1];
-            var c = points[2];
-            var ab = b - a;
-            var ac = c - a;
-            for (var i = 3; i < points.Count; i++)
+            // Choose the first three non-collinear points
+            var p0 = points[0];
+            var p1 = points.FirstOrDefault(p => (p - p0).Length() > Vector3.EPSILON);
+            if (p1 == default) return true; // All points are coincident
+            var p2 = points.FirstOrDefault(p => (p1 - p0).Cross(p - p0).Length() > Vector3.EPSILON);
+            if (p2 == default) return true; // All points are collinear
+
+            var normal = (p1 - p0).Cross(p2 - p0).Unitized();
+
+            for (int i = 3; i < points.Count; i++)
             {
-                var d = points[i];
-                var cd = d - a;
-                var tp = ab.Dot(ac.Cross(cd).Unitized());
-                if (Math.Abs(tp) > Vector3.EPSILON)
+                var pi = points[i];
+                var dot = normal.Dot(pi - p0);
+                if (Math.Abs(dot) > Vector3.EPSILON)
                 {
                     return false;
                 }
             }
+
             return true;
         }
 
@@ -80,8 +81,8 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Return an approximate fit line through a set of points. 
-        /// Not intended for statistical regression purposes. 
+        /// Return an approximate fit line through a set of points.
+        /// Not intended for statistical regression purposes.
         /// Note that the line is unit length: it shouldn't be expected
         /// to span the length of the points.
         /// </summary>
@@ -251,7 +252,7 @@ namespace Elements.Geometry
             }
             return normal.Unitized();
         }
-        
+
         /// <summary>
         /// De-duplicate a collection of Vectors, such that no two vectors in the result are within tolerance of each other.
         /// </summary>
@@ -265,7 +266,7 @@ namespace Elements.Geometry
             {
                 if (output.Any(x => x.IsAlmostEqualTo(vector, tolerance)))
                 {
-                    continue;;
+                    continue; ;
                 }
                 output.Add(vector);
             }

--- a/Elements/src/Geometry/Vector3Extensions.cs
+++ b/Elements/src/Geometry/Vector3Extensions.cs
@@ -19,14 +19,30 @@ namespace Elements.Geometry
 
             // Choose the first three non-collinear points
             var p0 = points[0];
-            var p1 = points.FirstOrDefault(p => (p - p0).Length() > Vector3.EPSILON);
-            if (p1 == default) return true; // All points are coincident
-            var p2 = points.FirstOrDefault(p => (p1 - p0).Cross(p - p0).Length() > Vector3.EPSILON);
-            if (p2 == default) return true; // All points are collinear
+            int p1Index = -1, p2Index = -1;
+            for (int i = 1; i < points.Count; i++)
+            {
+                if (p1Index == -1 && (points[i] - p0).Length() > Vector3.EPSILON)
+                {
+                    p1Index = i;
+                }
+                else if (p1Index != -1 && (points[p1Index] - p0).Cross(points[i] - p0).Length() > Vector3.EPSILON)
+                {
+                    p2Index = i;
+                    break;
+                }
+            }
 
-            var normal = (p1 - p0).Cross(p2 - p0).Unitized();
+            if (p1Index == -1) return true; // All points are coincident
+            if (p2Index == -1) return true; // All points are collinear
 
-            for (int i = 3; i < points.Count; i++)
+            if (p2Index == points.Count - 1) // p2 is the last point
+            {
+                return true;
+            }
+            var normal = (points[p1Index] - p0).Cross(points[p2Index] - p0).Unitized();
+
+            for (int i = p2Index + 1; i < points.Count; i++)
             {
                 var pi = points[i];
                 var dot = normal.Dot(pi - p0);

--- a/Elements/src/Geometry/Vector3Extensions.cs
+++ b/Elements/src/Geometry/Vector3Extensions.cs
@@ -19,7 +19,8 @@ namespace Elements.Geometry
 
             // Choose the first three non-collinear points
             var p0 = points[0];
-            int p1Index = -1, p2Index = -1;
+            int p1Index = -1;
+            int p2Index = -1;
             for (int i = 1; i < points.Count; i++)
             {
                 if (p1Index == -1 && (points[i] - p0).Length() > Vector3.EPSILON)

--- a/Elements/src/Geometry/Vector3Extensions.cs
+++ b/Elements/src/Geometry/Vector3Extensions.cs
@@ -10,11 +10,16 @@ namespace Elements.Geometry
     public static class Vector3Extensions
     {
         /// <summary>
-        /// Check if a collection of points has at least three non-collinear points. Returns true if it does, false otherwise.
+        /// Check if a collection of points has at least three non-collinear
+        /// points. Returns true if it does, false otherwise. The first two
+        /// points which form a valid triangle with the first point are
+        /// returned via out parameters.
         /// </summary>
         /// <param name="points">The list of points to search.</param>
-        /// <param name="p1Index">The index of the first non-collinear point after index 0.</param>
-        /// <param name="p2Index">The index of the second non-collinear point after index 0.</param>
+        /// <param name="p1Index">The index of the first non-collinear point
+        /// after index 0.</param>
+        /// <param name="p2Index">The index of the second non-collinear point
+        /// after index 0.</param>
         /// <returns>True if there are three non-collinear points.</returns>
         public static bool TryGetThreeNonCollinearPoints(this IList<Vector3> points, out int p1Index, out int p2Index)
         {
@@ -34,7 +39,7 @@ namespace Elements.Geometry
                     break;
                 }
             }
-            return p2Index == -1;
+            return p2Index != -1;
         }
 
         /// <summary>

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -577,6 +577,9 @@ namespace Elements.Tests
             var ptsSerialized = "[{\"X\":0.0,\"Y\":0.0,\"Z\":0.0},{\"X\":20.0,\"Y\":0.0,\"Z\":-8.43769498715119E-15},{\"X\":19.999999999999996,\"Y\":20.0,\"Z\":-1.021405182655144E-14},{\"X\":9.999999999999995,\"Y\":20.0,\"Z\":-3.096967127191874E-13},{\"X\":10.0,\"Y\":10.0,\"Z\":-4.218847493575595E-15},{\"X\":1.7763568394002505E-15,\"Y\":9.999999999999998,\"Z\":0.0}]";
             var pts = JsonConvert.DeserializeObject<List<Vector3>>(ptsSerialized);
             Assert.True(pts.AreCoplanar());
+
+            var triangleWithExtraPoints = new List<Vector3> { (0, 0), (0.0001, 0), (0.0002, 0), (1, 0), (2, 0), (3, 0), (4, 5) };
+            Assert.True(triangleWithExtraPoints.AreCoplanar());
         }
     }
 }

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -1,4 +1,5 @@
 using Elements.Geometry;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using Xunit;
@@ -568,6 +569,14 @@ namespace Elements.Tests
             Assert.Collection(result,
                 x => x.IsAlmostEqualTo(Vector3.Origin, tolerance),
                 x => x.IsAlmostEqualTo(new Vector3(5, 5), tolerance));
+        }
+
+        [Fact]
+        public void PointsAreCoplanarWithinTolerance()
+        {
+            var ptsSerialized = "[{\"X\":0.0,\"Y\":0.0,\"Z\":0.0},{\"X\":20.0,\"Y\":0.0,\"Z\":-8.43769498715119E-15},{\"X\":19.999999999999996,\"Y\":20.0,\"Z\":-1.021405182655144E-14},{\"X\":9.999999999999995,\"Y\":20.0,\"Z\":-3.096967127191874E-13},{\"X\":10.0,\"Y\":10.0,\"Z\":-4.218847493575595E-15},{\"X\":1.7763568394002505E-15,\"Y\":9.999999999999998,\"Z\":0.0}]";
+            var pts = JsonConvert.DeserializeObject<List<Vector3>>(ptsSerialized);
+            Assert.True(pts.AreCoplanar());
         }
     }
 }

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -574,11 +574,50 @@ namespace Elements.Tests
         [Fact]
         public void PointsAreCoplanarWithinTolerance()
         {
+            // Test with three points that are collinear.
+            var points = new List<Vector3> { (0, 0, 0), (1, 1, 1), (2, 2, 2) };
+            Assert.True(points.AreCoplanar());
+
+            // Test with three points that are not collinear.
+            points = new List<Vector3> { (0, 0, 0), (1, 1, 1), (0, 1, 0) };
+            Assert.True(points.AreCoplanar());
+
+            // Test with four points that are coplanar.
+            points = new List<Vector3> { (0, 0, 0), (1, 1, 1), (0, 1, 0), (1, 0, 1) };
+            Assert.True(points.AreCoplanar());
+
+            // Test with four points that are not coplanar.
+            points = new List<Vector3> { (0, 0, 0), (1, 1, 1), (0, 1, 0), (2, 0, 0) };
+            Assert.False(points.AreCoplanar());
+
+            // Test with five points that are coplanar.
+
+            points = new List<Vector3> {
+                    (-0.126164, -0.168248, 0.344318),
+                    (-0.463355, 0.438143, 0.122335),
+                    (-0.413036, 0.529648, -0.041386),
+                    (-0.148225, -0.11257, 0.312485),
+                    (-0.296069, 0.586723, -0.253626)
+                };
+            Assert.True(points.AreCoplanar());
+
+            // Test with five points that are not coplanar.
+            points = new List<Vector3> {
+                    (0, 0, 0),
+                    (1, 1, 1),
+                    (0, 1, 0),
+                    (2, 0, 0),
+                    (1, 1, 0)
+                };
+            Assert.False(points.AreCoplanar());
+
+            // Test with a real-world output from Hypar that was failing.
             var ptsSerialized = "[{\"X\":0.0,\"Y\":0.0,\"Z\":0.0},{\"X\":20.0,\"Y\":0.0,\"Z\":-8.43769498715119E-15},{\"X\":19.999999999999996,\"Y\":20.0,\"Z\":-1.021405182655144E-14},{\"X\":9.999999999999995,\"Y\":20.0,\"Z\":-3.096967127191874E-13},{\"X\":10.0,\"Y\":10.0,\"Z\":-4.218847493575595E-15},{\"X\":1.7763568394002505E-15,\"Y\":9.999999999999998,\"Z\":0.0}]";
             var pts = JsonConvert.DeserializeObject<List<Vector3>>(ptsSerialized);
             Assert.True(pts.AreCoplanar());
 
-            var triangleWithExtraPoints = new List<Vector3> { (0, 0), (0.0001, 0), (0.0002, 0), (1, 0), (2, 0), (3, 0), (4, 5) };
+            // Test with a shape that has a lot of coincident and collinear points.
+            var triangleWithExtraPoints = new List<Vector3> { (0, 0), (0.000001, 0), (0.000002, 0), (1, 0), (2, 0), (3, 0), (4, 5) };
             Assert.True(triangleWithExtraPoints.AreCoplanar());
         }
     }


### PR DESCRIPTION
BACKGROUND:
- Our Vector3 coplanarity check failed for certain input that it should have accepted, which was causing immediate failures on deserialization, breaking several functions. 

DESCRIPTION:
- Rewrites the coplanarity check to use a dot product method instead of a triple-product method. The triple-product computes a _volume_, which means there's no sensible way to think about it in terms of `Vector3.EPSILON` — the dot product lends itself nicely to the interpretation of "check that the points are within EPSILON distance of a plane passing through the first three non-coplanar points" 

TESTING:
- I added some tests, including one that would definitely have failed with the old method. 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/973)
<!-- Reviewable:end -->
