### PR TITLE
Remove obsolete entities from Message, EdgeInfo, AdaptiveGrid and AdaptiveGraphRouting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,13 @@
 - `Circle` is now parameteried 0->2Pi.
 - `Line` is now parameterized 0->length.
 - `Vector3.DistanceTo(Ray ray)` now returns positive infinity instead of throwing.
+- `Message`: removed obsolete `FromLine` method.
+- `AdaptiveGrid`: removed obsolete `TryGetVertexIndex` with `tolerance` parameter.
+- `EdgeInfo`: obsolete attribute is removed from `HasVerticalChange` property.
+- `RoutingConfiguration`: removed obsolete `MainLayer` and `LayerPenalty` properties.
 
 ### Fixed
+
 - Using Multiple `ModelText`s would sometimes result in a corrupted texture atlas, with cutoff text. This is fixed.
 - #865
 - `Network`: intersections are not created for some E-shape cases

--- a/Elements/src/Annotations/Messages.cs
+++ b/Elements/src/Annotations/Messages.cs
@@ -88,54 +88,6 @@ namespace Elements.Annotations
         }
 
         /// <summary>
-        /// Create a simple message along a line.
-        /// </summary>
-        /// <param name="messageText">The message to the user.</param>
-        /// <param name="line"></param>
-        /// <param name="severity">The severity of the message.</param>
-        /// <param name="sideLength"></param>
-        /// <param name="name">The name given to the message.</param>
-        /// <param name="stackTrace">Any stack trace associated with the message.</param>
-        /// <returns></returns>
-        [Obsolete("Use FromCurve instead.")]
-        public static Message FromLine(string messageText,
-                                       Line line,
-                                       MessageSeverity severity = MessageSeverity.Warning,
-                                       double sideLength = DefaultSideLength,
-                                       string name = null,
-                                       string stackTrace = null)
-        {
-            var xAxis = line.Direction();
-            Vector3 yAxis;
-            if (xAxis.IsParallelTo(Vector3.ZAxis))
-            {
-                yAxis = xAxis.Cross(Vector3.YAxis);
-            }
-            else
-            {
-                yAxis = xAxis.Cross(Vector3.ZAxis);
-            }
-            var zAxis = yAxis.Cross(xAxis);
-            var toPipeLineTransform = new Transform(line.Start, xAxis, yAxis, zAxis);
-
-            var localLine = new Line(new Vector3(0, 0, 0), new Vector3(line.Length(), 0, 0));
-
-            var extrude = new Extrude(localLine.Thicken(sideLength),
-                                      sideLength,
-                                      Vector3.ZAxis,
-                                      false);
-            var message = new Message(messageText,
-                                      stackTrace,
-                                      severity,
-                                      toPipeLineTransform.Moved(new Vector3(0, 0, -sideLength / 2)),
-                                      MaterialForSeverity(severity),
-                                      new Representation(new[] { extrude }),
-                                      id: Guid.NewGuid(),
-                                      name: name ?? DefaultName);
-            return message;
-        }
-
-        /// <summary>
         /// Create a simple message along a curve.
         /// </summary>
         /// <param name="messageText">The message to the user.</param>

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGraphRouting.cs
@@ -49,19 +49,6 @@ namespace Elements.Spatial.AdaptiveGrid
             //global information line boundaries, points, lines and obstacles.
             _grid = grid;
             _configuration = configuration;
-
-            if (!_configuration.LayerPenalty.ApproximatelyEquals(1))
-            {
-                var plane = new Plane(new Vector3(0, 0, _configuration.MainLayer), Vector3.ZAxis);
-                var modifier = new WeightModifier(
-                    "Not Main Layer",
-                    new Func<Vertex, Vertex, bool>((a, b) =>
-                    {
-                        return Math.Abs(a.Point.Z - _configuration.MainLayer) > _grid.Tolerance ||
-                               Math.Abs(b.Point.Z - _configuration.MainLayer) > _grid.Tolerance;
-                    }),
-                    _configuration.LayerPenalty);
-            }
         }
 
         /// <summary>

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -361,20 +361,6 @@ namespace Elements.Spatial.AdaptiveGrid
         }
 
         /// <summary>
-        /// Whether a vertex location already exists in the AdaptiveGrid.
-        /// </summary>
-        /// <param name="point"></param>
-        /// <param name="id">The ID of the Vertex, if a match is found.</param>
-        /// <param name="tolerance">Amount of tolerance in the search against each component of the coordinate.</param>
-        /// <returns>True if any Vertex is close enough.</returns>
-        [Obsolete("Tolerance parameter is obsolete. Grid automatically uses it's internal tolerance.")]
-        public bool TryGetVertexIndex(Vector3 point, out ulong id, double? tolerance)
-        {
-            id = GetFromXYZLookup(point, out _, out _, tolerance: tolerance);
-            return id != 0;
-        }
-
-        /// <summary>
         /// Add a Vertex or return existing one if it's withing grid tolerance.
         /// Doesn't connect new Vertex to the grid with edges.
         /// </summary>

--- a/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/EdgeInfo.cs
@@ -49,7 +49,6 @@ namespace Elements.Spatial.AdaptiveGrid
         /// <summary>
         /// Are edge end points on different elevations.
         /// </summary>
-        [Obsolete("Use HasAnyFlag(EdgeFlags.HasVerticalChange) instead")]
         public bool HasVerticalChange { get => HasAnyFlag(EdgeFlags.HasVerticalChange); }
 
         /// <summary>

--- a/Elements/src/Spatial/AdaptiveGrid/RoutingConfiguration.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/RoutingConfiguration.cs
@@ -12,17 +12,11 @@ namespace Elements.Spatial.AdaptiveGrid
         /// Construct new RoutingConfiguration structure.
         /// </summary>
         /// <param name="turnCost">Travel cost penalty if route changes it's direction.</param>
-        /// <param name="mainLayer">OBSOLETE. Elevation at which route prefers to travel.</param>
-        /// <param name="layerPenalty">OBSOLETE. Penalty if route travels through an elevation different from MainLayer.</param>
         /// <param name="supportedAngles">List of angles route can turn.</param>
         public RoutingConfiguration(double turnCost = 0,
-                                    double mainLayer = 0,
-                                    double layerPenalty = 1,
                                     List<double> supportedAngles = null)
         {
             TurnCost = turnCost;
-            MainLayer = mainLayer;
-            LayerPenalty = layerPenalty;
             SupportedAngles = supportedAngles;
             if (SupportedAngles != null && !SupportedAngles.Contains(0))
             {
@@ -34,18 +28,6 @@ namespace Elements.Spatial.AdaptiveGrid
         /// Travel cost penalty if route changes it's direction.
         /// </summary>
         public readonly double TurnCost;
-
-        /// <summary>
-        /// Elevation at which route prefers to travel.
-        /// </summary>
-        [Obsolete("Use WeightModified instead")]
-        public readonly double MainLayer;
-
-        /// <summary>
-        /// Travel cost penalty if route travels through an elevation different from MainLayer.
-        /// </summary>
-        [Obsolete("Use WeightModified instead")]
-        public readonly double LayerPenalty;
 
         /// <summary>
         /// List of angles route can turn. Angles are between 0 and 90. 0 is auto-included.


### PR DESCRIPTION
BACKGROUND:
- Since Elements is now in 2.0 alpha stage, it's good opportunity to remove obsolete items, I introduced.

DESCRIPTION:
- `Message`: removed obsolete `FromLine` method.
- `AdaptiveGrid`: removed obsolete `TryGetVertexIndex` with `tolerance` parameter.
- `EdgeInfo`: obsolete attribute is removed from `HasVerticalChange` property.
- `RoutingConfiguration`: removed obsolete `MainLayer` and `LayerPenalty` properties.

TESTING:
- No impact on Elements tests.
  
FUTURE WORK:
- Removed methods and properties must be removed from downstream repos in order to use Elements 2.0

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/974)
<!-- Reviewable:end -->
