### PR TITLE
Indexed polycurve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `Arc.Fillet`
 - `Ellipse`
 - `EllipticalArc`
+- `IndexedPolycurve`
 
 ### Changed
 

--- a/Elements/src/GeometricElement.cs
+++ b/Elements/src/GeometricElement.cs
@@ -361,8 +361,8 @@ namespace Elements
             var solidItems = solids.ToArray();
             var voidItems = voids.ToArray();
 
-            // Don't try CSG booleans if we only have one one solid and no voids.
-            if (solids.Count() == 1 && voids.Count() == 0)
+            // Don't try CSG booleans if we only have one one solid.
+            if (solids.Count() == 1)
             {
                 csg = solids.First();
             }
@@ -370,10 +370,7 @@ namespace Elements
             {
                 csg = csg.Union(solidItems);
             }
-            else
-            {
-                return csg;
-            }
+
 
             if (voids.Count() > 0)
             {

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -13,6 +13,12 @@ namespace Elements.Geometry
     /// </example>
     public partial class Arc : TrimmedCurve<Circle>, IEquatable<Arc>
     {
+        /// <summary>
+        /// The domain of the curve.
+        /// </summary>
+        [JsonIgnore]
+        public override Domain1d Domain => new Domain1d(Units.DegreesToRadians(this.StartAngle), Units.DegreesToRadians(this.EndAngle));
+
         /// <summary>The angle from 0.0, in degrees, at which the arc will start with respect to the positive X axis.</summary>
         [JsonProperty("StartAngle", Required = Required.Always)]
         [System.ComponentModel.DataAnnotations.Range(0.0D, 360.0D)]
@@ -71,7 +77,6 @@ namespace Elements.Geometry
             this.BasisCurve = new Circle();
             this.StartAngle = 0;
             this.EndAngle = 360;
-            this.Domain = new Domain1d(Units.DegreesToRadians(this.StartAngle), Units.DegreesToRadians(this.EndAngle));
         }
 
         /// <summary>
@@ -88,7 +93,6 @@ namespace Elements.Geometry
             this.BasisCurve = new Circle(@center, @radius);
             this.StartAngle = @startAngle;
             this.EndAngle = @endAngle;
-            this.Domain = new Domain1d(Units.DegreesToRadians(@startAngle), Units.DegreesToRadians(@endAngle));
         }
 
         private void Validate(double startAngle, double endAngle, double radius)
@@ -127,7 +131,6 @@ namespace Elements.Geometry
             this.BasisCurve = new Circle(radius);
             this.StartAngle = startAngle;
             this.EndAngle = endAngle;
-            this.Domain = new Domain1d(Units.DegreesToRadians(@startAngle), Units.DegreesToRadians(@endAngle));
         }
 
         /// <summary>
@@ -140,7 +143,6 @@ namespace Elements.Geometry
         {
             Validate(Units.RadiansToDegrees(startParameter), Units.RadiansToDegrees(endParameter), circle.Radius);
             this.BasisCurve = circle;
-            this.Domain = new Domain1d(startParameter, endParameter);
             this.StartAngle = Units.RadiansToDegrees(this.Domain.Min);
             this.EndAngle = Units.RadiansToDegrees(this.Domain.Max);
         }
@@ -160,7 +162,6 @@ namespace Elements.Geometry
         {
             Validate(Units.RadiansToDegrees(startParameter), Units.RadiansToDegrees(endParameter), radius);
             this.BasisCurve = new Circle(transform, radius);
-            this.Domain = new Domain1d(startParameter, endParameter);
             this.StartAngle = Units.RadiansToDegrees(this.Domain.Min);
             this.EndAngle = Units.RadiansToDegrees(this.Domain.Max);
         }

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -143,8 +143,8 @@ namespace Elements.Geometry
         {
             Validate(Units.RadiansToDegrees(startParameter), Units.RadiansToDegrees(endParameter), circle.Radius);
             this.BasisCurve = circle;
-            this.StartAngle = Units.RadiansToDegrees(this.Domain.Min);
-            this.EndAngle = Units.RadiansToDegrees(this.Domain.Max);
+            this.StartAngle = Units.RadiansToDegrees(startParameter);
+            this.EndAngle = Units.RadiansToDegrees(endParameter);
         }
 
         /// <summary>
@@ -162,8 +162,8 @@ namespace Elements.Geometry
         {
             Validate(Units.RadiansToDegrees(startParameter), Units.RadiansToDegrees(endParameter), radius);
             this.BasisCurve = new Circle(transform, radius);
-            this.StartAngle = Units.RadiansToDegrees(this.Domain.Min);
-            this.EndAngle = Units.RadiansToDegrees(this.Domain.Max);
+            this.StartAngle = Units.RadiansToDegrees(startParameter);
+            this.EndAngle = Units.RadiansToDegrees(endParameter);
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -433,7 +433,7 @@ namespace Elements.Geometry
         /// <param name="transform">The transform to apply.</param>
         public Arc TransformedArc(Transform transform)
         {
-            return new Arc(transform.OfPoint(this.BasisCurve.Transform.Origin), this.BasisCurve.Radius, StartAngle, EndAngle);
+            return new Arc(BasisCurve.Transform.Concatenated(transform), this.BasisCurve.Radius, Units.DegreesToRadians(StartAngle), Units.DegreesToRadians(EndAngle));
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -419,10 +419,7 @@ namespace Elements.Geometry
             return new Arc(this.BasisCurve.Transform.Origin, this.BasisCurve.Radius, newStart, newEnd);
         }
 
-        /// <summary>
-        /// Construct a transformed copy of this Curve.
-        /// </summary>
-        /// <param name="transform">The transform to apply.</param>
+        /// <inheritdoc/>
         public override Curve Transformed(Transform transform)
         {
             return TransformedArc(transform);

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -350,8 +350,7 @@ namespace Elements.Geometry
 
         /// <inheritdoc/>
         public override double[] GetSubdivisionParameters(double startSetbackDistance = 0.0,
-                                                          double endSetbackDistance = 0.0,
-                                                          double minimumChordLength = 0.01)
+                                                          double endSetbackDistance = 0.0)
         {
             var min = this.Domain.Min;
             var max = this.Domain.Max;
@@ -374,7 +373,7 @@ namespace Elements.Geometry
             // d = 2 * r * sin(t/2)
             var r = this.BasisCurve.Radius;
             var two_r = 2 * r;
-            var d = Math.Min(minimumChordLength, two_r);
+            var d = Math.Min(DefaultMinimumChordLength, two_r);
             var t = 2 * Math.Asin(d / two_r);
             var div = (int)Math.Ceiling(angleSpan / t);
 

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -348,13 +348,10 @@ namespace Elements.Geometry
             return BasisCurve.Transform.XY();
         }
 
-        /// <summary>
-        /// Get parameters to be used to find points along the curve for visualization.
-        /// </summary>
-        /// <param name="startSetbackDistance">An optional setback from the start of the curve.</param>
-        /// <param name="endSetbackDistance">An optional setback from the end of the curve.</param>
+        /// <inheritdoc/>
         public override double[] GetSubdivisionParameters(double startSetbackDistance = 0.0,
-                                                       double endSetbackDistance = 0.0)
+                                                          double endSetbackDistance = 0.0,
+                                                          double minimumChordLength = 0.01)
         {
             var min = this.Domain.Min;
             var max = this.Domain.Max;
@@ -377,7 +374,7 @@ namespace Elements.Geometry
             // d = 2 * r * sin(t/2)
             var r = this.BasisCurve.Radius;
             var two_r = 2 * r;
-            var d = Math.Min(MinimumChordLength, two_r);
+            var d = Math.Min(minimumChordLength, two_r);
             var t = 2 * Math.Asin(d / two_r);
             var div = (int)Math.Ceiling(angleSpan / t);
 

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -295,7 +295,7 @@ namespace Elements.Geometry
         /// <summary>
         /// Calculate the length of the arc between start and end parameters.
         /// </summary>
-        public override double Length(double start, double end)
+        public override double ArcLength(double start, double end)
         {
             if (!Domain.Includes(start, true))
             {

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -450,20 +450,6 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Get a point at parameter u on the arc.
-        /// </summary>
-        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
-        /// <returns>A point on the curve at parameter u.</returns>
-        public override Vector3 PointAtNormalized(double u)
-        {
-            if (u < 0 || u > 1)
-            {
-                throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between 0.0 and 1.0.");
-            }
-            return this.BasisCurve.PointAt(this.Domain.Min + u * this.Domain.Length);
-        }
-
-        /// <summary>
         /// Get the transform at parameter u.
         /// </summary>
         /// <returns>The transform at parameter u if us is within the trim, otherwise an exception is thrown.</returns>

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -429,6 +429,20 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Get a point at parameter u on the arc.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>A point on the curve at parameter u.</returns>
+        public override Vector3 PointAtNormalized(double u)
+        {
+            if (u < 0 || u > 1)
+            {
+                throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between 0.0 and 1.0.");
+            }
+            return this.BasisCurve.PointAt(this.Domain.Min + u * this.Domain.Length);
+        }
+
+        /// <summary>
         /// Get the transform at parameter u.
         /// </summary>
         /// <returns>The transform at parameter u if us is within the trim, otherwise an exception is thrown.</returns>

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -286,7 +286,28 @@ namespace Elements.Geometry
         /// </summary>
         public override double Length()
         {
-            return 2 * Math.PI * this.BasisCurve.Radius * (Math.Abs(this.EndAngle - this.StartAngle)) / 360.0;
+            // Arc length = theta * radius
+            var theta = Units.DegreesToRadians(Math.Abs(this.EndAngle - this.StartAngle));
+            return this.BasisCurve.Radius * theta;
+        }
+
+        /// <summary>
+        /// Calculate the length of the arc between start and end parameters.
+        /// </summary>
+        public override double Length(double start, double end)
+        {
+            if (!Domain.Includes(start, true))
+            {
+                throw new ArgumentOutOfRangeException("start", $"The start parameter {start} must be between {Domain.Min} and {Domain.Max}.");
+            }
+            if (!Domain.Includes(end, true))
+            {
+                throw new ArgumentOutOfRangeException("end", $"The end parameter {end} must be between {Domain.Min} and {Domain.Max}.");
+            }
+
+            // Arc length = theta * radius
+            var theta = Math.Abs(end - start);
+            return this.BasisCurve.Radius * theta;
         }
 
         /// <summary>
@@ -453,6 +474,16 @@ namespace Elements.Geometry
                 throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between {Domain.Min} and {Domain.Max}.");
             }
             return this.BasisCurve.TransformAt(u);
+        }
+
+        /// <summary>
+        /// Get the frame from the curve at parameter u.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>The transform of the curve at parameter u, with the transform's Z axis tangent to the curve.</returns>
+        public override Transform TransformAtNormalized(double u)
+        {
+            return TransformAt(this.Domain.Min + u * Domain.Length);
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -477,16 +477,6 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Get the frame from the curve at parameter u.
-        /// </summary>
-        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
-        /// <returns>The transform of the curve at parameter u, with the transform's Z axis tangent to the curve.</returns>
-        public override Transform TransformAtNormalized(double u)
-        {
-            return TransformAt(this.Domain.Min + u * Domain.Length);
-        }
-
-        /// <summary>
         /// Create a polyline through a set of points along the curve.
         /// </summary>
         /// <param name="divisions">The number of divisions of the curve.</param>

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -25,7 +25,7 @@ namespace Elements.Geometry
 
     /// <summary>
     /// A Bezier curve.
-    /// Parameterization of the curve is 0->1.
+    /// Parameterization of the curve is 0 -> 1.
     /// </summary>
     /// <example>
     /// [!code-csharp[Main](../../Elements/test/BezierTests.cs?name=example)]
@@ -94,6 +94,26 @@ namespace Elements.Geometry
                 last = pt;
             }
             return length;
+        }
+
+        /// <summary>
+        /// Calculate the length of the bezier between start and end parameters.
+        /// </summary>
+        /// <returns>The length of the bezier between start and end.</returns>
+        public override double Length(double start, double end)
+        {
+            if (!Domain.Includes(start, true))
+            {
+                throw new ArgumentOutOfRangeException("start", $"The start parameter {start} must be between {Domain.Min} and {Domain.Max}.");
+            }
+            if (!Domain.Includes(end, true))
+            {
+                throw new ArgumentOutOfRangeException("end", $"The end parameter {end} must be between {Domain.Min} and {Domain.Max}.");
+            }
+
+            // TODO: We use max value here so that the calculation will continue
+            // until at least the end of the curve. This is not a nice solution.
+            return ArcLengthUntil(start, double.MaxValue, out end);
         }
 
         private double ArcLengthUntil(double start, double distance, out double end)

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -142,6 +142,20 @@ namespace Elements.Geometry
             return p;
         }
 
+        /// <summary>
+        /// Get a point on the curve at parameter u.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>A point on the curve at parameter u.</returns>
+        public override Vector3 PointAtNormalized(double u)
+        {
+            if (u < 0 || u > 1)
+            {
+                throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between 0.0 and 1.0.");
+            }
+            return this.PointAt(u);
+        }
+
         private double BinomialCoefficient(int n, int i)
         {
             return Factorial(n) / (Factorial(i) * Factorial(n - i));

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -33,7 +33,7 @@ namespace Elements.Geometry
     /// </example>
     public class Bezier : BoundedCurve
     {
-        private int _lengthSamples = 500;
+        private readonly int _lengthSamples = 500;
 
         /// <summary>
         /// The domain of the curve.

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -312,23 +312,20 @@ namespace Elements.Geometry
             return TransformedBezier(transform);
         }
 
-        /// <summary>
-        /// Get parameters to be used to find points along the curve for visualization.
-        /// </summary>
-        /// <param name="startSetbackDistance">An optional setback from the start of the curve.</param>
-        /// <param name="endSetbackDistance">An optional setback from the end of the curve.</param>
+        /// <inheritdoc/>
         public override double[] GetSubdivisionParameters(double startSetbackDistance = 0.0,
-                                                       double endSetbackDistance = 0.0)
+                                                          double endSetbackDistance = 0.0,
+                                                          double minimumChordLength = 0.01)
         {
-            var parameters = new double[_lengthSamples + 1];
-
             var l = this.Length();
+            var div = (int)Math.Round(l / minimumChordLength);
 
+            var parameters = new double[div + 1];
             var startParam = startSetbackDistance == 0.0 ? this.Domain.Min : ParameterAtDistanceFromParameter(startSetbackDistance, this.Domain.Min);
             var endParam = startSetbackDistance == 0.0 ? this.Domain.Max : ParameterAtDistanceFromParameter(l - endSetbackDistance, this.Domain.Min);
 
-            var step = Math.Abs(endParam - startParam) / _lengthSamples;
-            for (var i = 0; i <= _lengthSamples; i++)
+            var step = Math.Abs(endParam - startParam) / div;
+            for (var i = 0; i <= div; i++)
             {
                 parameters[i] = startParam + i * step;
             }

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -106,7 +106,7 @@ namespace Elements.Geometry
         /// Calculate the length of the bezier between start and end parameters.
         /// </summary>
         /// <returns>The length of the bezier between start and end.</returns>
-        public override double Length(double start, double end)
+        public override double ArcLength(double start, double end)
         {
             if (!Domain.Includes(start, true))
             {

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -162,20 +162,6 @@ namespace Elements.Geometry
             return p;
         }
 
-        /// <summary>
-        /// Get a point on the curve at parameter u.
-        /// </summary>
-        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
-        /// <returns>A point on the curve at parameter u.</returns>
-        public override Vector3 PointAtNormalized(double u)
-        {
-            if (u < 0 || u > 1)
-            {
-                throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between 0.0 and 1.0.");
-            }
-            return this.PointAt(u);
-        }
-
         private double BinomialCoefficient(int n, int i)
         {
             return Factorial(n) / (Factorial(i) * Factorial(n - i));

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Elements.Geometry
 {
@@ -35,6 +36,12 @@ namespace Elements.Geometry
         private int _lengthSamples = 500;
 
         /// <summary>
+        /// The domain of the curve.
+        /// </summary>
+        [JsonIgnore]
+        public override Domain1d Domain => new Domain1d(0, 1);
+
+        /// <summary>
         /// A collection of points describing the bezier's frame.
         /// https://en.wikipedia.org/wiki/B%C3%A9zier_curve
         /// </summary>
@@ -59,7 +66,6 @@ namespace Elements.Geometry
 
             this.ControlPoints = controlPoints;
             this.FrameType = frameType;
-            this.Domain = new Domain1d(0, 1);
             this.Start = PointAt(0);
             this.End = PointAt(1);
         }

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -314,11 +314,10 @@ namespace Elements.Geometry
 
         /// <inheritdoc/>
         public override double[] GetSubdivisionParameters(double startSetbackDistance = 0.0,
-                                                          double endSetbackDistance = 0.0,
-                                                          double minimumChordLength = 0.01)
+                                                          double endSetbackDistance = 0.0)
         {
             var l = this.Length();
-            var div = (int)Math.Round(l / minimumChordLength);
+            var div = (int)Math.Round(l / DefaultMinimumChordLength);
 
             var parameters = new double[div + 1];
             var startParam = startSetbackDistance == 0.0 ? this.Domain.Min : ParameterAtDistanceFromParameter(startSetbackDistance, this.Domain.Min);

--- a/Elements/src/Geometry/BooleanMode.cs
+++ b/Elements/src/Geometry/BooleanMode.cs
@@ -1,0 +1,25 @@
+namespace Elements.Geometry
+{
+    /// <summary>
+    /// Mode to apply a boolean operation
+    /// </summary>
+    public enum BooleanMode
+    {
+        /// <summary>
+        /// A and not B
+        /// </summary>
+        Difference,
+        /// <summary>
+        /// A or B
+        /// </summary>
+        Union,
+        /// <summary>
+        /// A and B
+        /// </summary>
+        Intersection,
+        /// <summary>
+        /// Exclusive or — either A or B but not both.
+        /// </summary>
+        XOr
+    }
+}

--- a/Elements/src/Geometry/BoundedCurve.cs
+++ b/Elements/src/Geometry/BoundedCurve.cs
@@ -58,18 +58,13 @@ namespace Elements.Geometry
         [JsonIgnore]
         public virtual bool IsClosedForRendering => false;
 
-        /// <summary>
-        /// Get a collection of transforms which represent frames along this curve.
-        /// </summary>
-        /// <param name="startSetbackDistance">The offset parameter from the start of the curve.</param>
-        /// <param name="endSetbackDistance">The offset parameter from the end of the curve.</param>
-        /// <param name="additionalRotation">An additional rotation of the frame at each point.</param>
-        /// <returns>A collection of transforms.</returns>
+        /// <inheritdoc/>
         public virtual Transform[] Frames(double startSetbackDistance = 0.0,
                                           double endSetbackDistance = 0.0,
-                                          double additionalRotation = 0.0)
+                                          double additionalRotation = 0.0,
+                                          double minimumChordLength = 0.01)
         {
-            var parameters = GetSubdivisionParameters(startSetbackDistance, endSetbackDistance);
+            var parameters = GetSubdivisionParameters(startSetbackDistance, endSetbackDistance, minimumChordLength);
             var transforms = new Transform[parameters.Length];
             for (var i = 0; i < parameters.Length; i++)
             {
@@ -109,13 +104,10 @@ namespace Elements.Geometry
         /// <param name="c">The bounded curve to convert.</param>
         public static implicit operator ModelCurve(BoundedCurve c) => new ModelCurve(c);
 
-        /// <summary>
-        /// Get parameters to be used to find points along the curve for visualization.
-        /// </summary>
-        /// <param name="startSetbackDistance">An optional setback from the start of the curve.</param>
-        /// <param name="endSetbackDistance">An optional setback from the end of the curve.</param>
-        /// <returns>A collection of parameter values.</returns>
-        public abstract double[] GetSubdivisionParameters(double startSetbackDistance = 0, double endSetbackDistance = 0);
+        /// <inheritdoc/>
+        public abstract double[] GetSubdivisionParameters(double startSetbackDistance = 0,
+                                                          double endSetbackDistance = 0,
+                                                          double minimumChordLength = 0.01);
 
         /// <summary>
         /// Get a point along the curve at parameter u.

--- a/Elements/src/Geometry/BoundedCurve.cs
+++ b/Elements/src/Geometry/BoundedCurve.cs
@@ -40,7 +40,7 @@ namespace Elements.Geometry
         /// <summary>
         /// Calculate the length of the curve between two parameters.
         /// </summary>
-        public abstract double Length(double start, double end);
+        public abstract double ArcLength(double start, double end);
 
         /// <summary>
         /// The mid point of the curve.

--- a/Elements/src/Geometry/BoundedCurve.cs
+++ b/Elements/src/Geometry/BoundedCurve.cs
@@ -116,6 +116,16 @@ namespace Elements.Geometry
         public abstract double[] GetSubdivisionParameters(double startSetbackDistance = 0, double endSetbackDistance = 0);
 
         /// <summary>
+        /// Get the frame from the curve at parameter u.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>The transform of the curve at parameter u, with the transform's Z axis tangent to the curve.</returns>
+        public Transform TransformAtNormalized(double u)
+        {
+            return TransformAt(this.Domain.Min + u * Domain.Length);
+        }
+
+        /// <summary>
         /// Get a collection of vertices used to render the curve.
         /// </summary>
         internal IList<Vector3> RenderVertices()

--- a/Elements/src/Geometry/BoundedCurve.cs
+++ b/Elements/src/Geometry/BoundedCurve.cs
@@ -37,6 +37,11 @@ namespace Elements.Geometry
         public abstract double Length();
 
         /// <summary>
+        /// Calculate the length of the curve between two parameters.
+        /// </summary>
+        public abstract double Length(double start, double end);
+
+        /// <summary>
         /// The mid point of the curve.
         /// </summary>
         public virtual Vector3 Mid()

--- a/Elements/src/Geometry/BoundedCurve.cs
+++ b/Elements/src/Geometry/BoundedCurve.cs
@@ -55,6 +55,7 @@ namespace Elements.Geometry
         /// Curves marked true will use LINE_LOOP mode for rendering.
         /// Curves marked false will use LINE_STRIP for rendering.
         /// </summary>
+        [JsonIgnore]
         public virtual bool IsClosedForRendering => false;
 
         /// <summary>

--- a/Elements/src/Geometry/BoundedCurve.cs
+++ b/Elements/src/Geometry/BoundedCurve.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Elements.Geometry.Interfaces;
 using Newtonsoft.Json;
@@ -122,7 +123,26 @@ namespace Elements.Geometry
         /// <returns>The transform of the curve at parameter u, with the transform's Z axis tangent to the curve.</returns>
         public Transform TransformAtNormalized(double u)
         {
+            if (u < 0 || u > 1)
+            {
+                throw new ArgumentOutOfRangeException($"The parameter {u} must be between 0.0 and 1.0.");
+            }
+
             return TransformAt(this.Domain.Min + u * Domain.Length);
+        }
+
+        /// <summary>
+        /// Get a point at parameter u on the arc.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>A point on the curve at parameter u.</returns>
+        public override Vector3 PointAtNormalized(double u)
+        {
+            if (u < 0 || u > 1)
+            {
+                throw new ArgumentOutOfRangeException($"The parameter {u} must be between 0.0 and 1.0.");
+            }
+            return this.PointAt(this.Domain.Min + u * this.Domain.Length);
         }
 
         /// <summary>

--- a/Elements/src/Geometry/BoundedCurve.cs
+++ b/Elements/src/Geometry/BoundedCurve.cs
@@ -11,6 +11,11 @@ namespace Elements.Geometry
     public abstract class BoundedCurve : Curve, IBoundedCurve
     {
         /// <summary>
+        /// The minimum chord length allowed for subdivision of the curve. A smaller MinimumChordLength results in smoother curves. For polylines and polygons this parameter will have no effect.
+        /// </summary>
+        public const double DefaultMinimumChordLength = 0.01;
+
+        /// <summary>
         /// The start of the curve.
         /// </summary>
         public virtual Vector3 Start { get; protected set; }
@@ -61,10 +66,9 @@ namespace Elements.Geometry
         /// <inheritdoc/>
         public virtual Transform[] Frames(double startSetbackDistance = 0.0,
                                           double endSetbackDistance = 0.0,
-                                          double additionalRotation = 0.0,
-                                          double minimumChordLength = 0.01)
+                                          double additionalRotation = 0.0)
         {
-            var parameters = GetSubdivisionParameters(startSetbackDistance, endSetbackDistance, minimumChordLength);
+            var parameters = GetSubdivisionParameters(startSetbackDistance, endSetbackDistance);
             var transforms = new Transform[parameters.Length];
             for (var i = 0; i < parameters.Length; i++)
             {
@@ -106,8 +110,7 @@ namespace Elements.Geometry
 
         /// <inheritdoc/>
         public abstract double[] GetSubdivisionParameters(double startSetbackDistance = 0,
-                                                          double endSetbackDistance = 0,
-                                                          double minimumChordLength = 0.01);
+                                                          double endSetbackDistance = 0);
 
         /// <summary>
         /// Get a point along the curve at parameter u.

--- a/Elements/src/Geometry/BoundedCurve.cs
+++ b/Elements/src/Geometry/BoundedCurve.cs
@@ -128,7 +128,7 @@ namespace Elements.Geometry
                 throw new ArgumentOutOfRangeException($"The parameter {u} must be between 0.0 and 1.0.");
             }
 
-            return TransformAt(this.Domain.Min + u * Domain.Length);
+            return TransformAt(u.MapToDomain(this.Domain));
         }
 
         /// <summary>
@@ -136,13 +136,13 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
         /// <returns>A point on the curve at parameter u.</returns>
-        public override Vector3 PointAtNormalized(double u)
+        public Vector3 PointAtNormalized(double u)
         {
             if (u < 0 || u > 1)
             {
                 throw new ArgumentOutOfRangeException($"The parameter {u} must be between 0.0 and 1.0.");
             }
-            return this.PointAt(this.Domain.Min + u * this.Domain.Length);
+            return this.PointAt(u.MapToDomain(this.Domain));
         }
 
         /// <summary>

--- a/Elements/src/Geometry/BoundedCurve.cs
+++ b/Elements/src/Geometry/BoundedCurve.cs
@@ -13,7 +13,12 @@ namespace Elements.Geometry
         /// <summary>
         /// The minimum chord length allowed for subdivision of the curve. A smaller MinimumChordLength results in smoother curves. For polylines and polygons this parameter will have no effect.
         /// </summary>
-        public const double DefaultMinimumChordLength = 0.01;
+        /// TODO: This should not live here. Curve resolution for rendering should
+        /// live in the rendering code. Unfortunately, we current build BREPs using
+        /// this subdivision. When we have non-planar BREP surfaces, we will be able
+        /// to decouple BREPs and tessellation and this setting can be passed into
+        /// the glTF serializer.
+        public const double DefaultMinimumChordLength = 0.1;
 
         /// <summary>
         /// The start of the curve.

--- a/Elements/src/Geometry/BoundedCurve.cs
+++ b/Elements/src/Geometry/BoundedCurve.cs
@@ -24,7 +24,7 @@ namespace Elements.Geometry
         /// The domain of the curve.
         /// </summary>
         [JsonIgnore]
-        public Domain1d Domain { get; protected set; }
+        public virtual Domain1d Domain => new Domain1d(0, Length());
 
         /// <summary>
         /// Get the bounding box for this curve.

--- a/Elements/src/Geometry/Circle.cs
+++ b/Elements/src/Geometry/Circle.cs
@@ -72,7 +72,11 @@ namespace Elements.Geometry
             var pts = new List<Vector3>();
             var twoPi = Math.PI * 2;
             var step = twoPi / divisions;
-            for (var t = 0.0; t < twoPi; t += step)
+            // We use epsilon here because for larger numbers of divisions,
+            // we can creep right up to 2pi, close enough that we'll
+            // get a point at not exactly 2pi, but other code will see the point
+            // found as equivalent to the point at parameter 0.
+            for (var t = 0.0; t < twoPi - Vector3.EPSILON; t += step)
             {
                 pts.Add(this.PointAt(t));
             }

--- a/Elements/src/Geometry/Circle.cs
+++ b/Elements/src/Geometry/Circle.cs
@@ -100,6 +100,20 @@ namespace Elements.Geometry
             return Transform.OfPoint(PointAtUntransformed(u));
         }
 
+        /// <summary>
+        /// Get a point at parameter u on the circle.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>A point on the curve at parameter u.</returns>
+        public override Vector3 PointAtNormalized(double u)
+        {
+            if (u < 0 || u > 1)
+            {
+                throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between 0.0 and 1.0.");
+            }
+            return Transform.OfPoint(PointAtUntransformed(u * Math.PI * 2));
+        }
+
         private Vector3 PointAtUntransformed(double u)
         {
             var x = this.Radius * Math.Cos(u);

--- a/Elements/src/Geometry/Circle.cs
+++ b/Elements/src/Geometry/Circle.cs
@@ -124,9 +124,7 @@ namespace Elements.Geometry
             return new Transform(p, x, y, x.Cross(y)).Concatenated(this.Transform);
         }
 
-        /// <summary>
-        /// Return a new circle transformed by the provided transform.
-        /// </summary>
+        /// <inheritdoc/>
         public override Curve Transformed(Transform transform)
         {
             return new Circle(transform.Concatenated(this.Transform), this.Radius);

--- a/Elements/src/Geometry/Circle.cs
+++ b/Elements/src/Geometry/Circle.cs
@@ -100,20 +100,6 @@ namespace Elements.Geometry
             return Transform.OfPoint(PointAtUntransformed(u));
         }
 
-        /// <summary>
-        /// Get a point at parameter u on the circle.
-        /// </summary>
-        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
-        /// <returns>A point on the curve at parameter u.</returns>
-        public override Vector3 PointAtNormalized(double u)
-        {
-            if (u < 0 || u > 1)
-            {
-                throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between 0.0 and 1.0.");
-            }
-            return Transform.OfPoint(PointAtUntransformed(u * Math.PI * 2));
-        }
-
         private Vector3 PointAtUntransformed(double u)
         {
             var x = this.Radius * Math.Cos(u);

--- a/Elements/src/Geometry/Contour.cs
+++ b/Elements/src/Geometry/Contour.cs
@@ -11,6 +11,7 @@ namespace Elements.Geometry
     /// <example>
     /// [!code-csharp[Main](../../Elements/test/ContourTests.cs?name=example)]
     /// </example>
+    [Obsolete("Please use IndexedPolycurve instead.")]
     public class Contour : IEnumerable<Curve>
     {
         private List<BoundedCurve> _curves = new List<BoundedCurve>();

--- a/Elements/src/Geometry/Curve.cs
+++ b/Elements/src/Geometry/Curve.cs
@@ -10,12 +10,6 @@ namespace Elements.Geometry
     public abstract partial class Curve : ICurve, ITransformable<Curve>
     {
         /// <summary>
-        /// The minimum chord length allowed for subdivision of the curve.
-        /// A lower MinimumChordLength results in smoother curves.
-        /// </summary>
-        public static double MinimumChordLength = 0.1;
-
-        /// <summary>
         /// Get a point along the curve at parameter u.
         /// </summary>
         /// <param name="u">A parameter along the curve between domain.min and domain.max.</param>

--- a/Elements/src/Geometry/Curve.cs
+++ b/Elements/src/Geometry/Curve.cs
@@ -1,4 +1,3 @@
-using System;
 using Elements.Geometry.Interfaces;
 using Newtonsoft.Json;
 
@@ -22,13 +21,6 @@ namespace Elements.Geometry
         /// <param name="u">A parameter on the curve between domain.min and domain.max</param>
         /// <returns>A point on the curve at parameter u.</returns>
         public abstract Vector3 PointAt(double u);
-
-        /// <summary>
-        /// Get a point along the curve at parameter u.
-        /// </summary>
-        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
-        /// <returns>A point on the curve at parameter u.</returns>
-        public abstract Vector3 PointAtNormalized(double u);
 
         /// <summary>
         /// Get a transform whose XY plane is perpendicular to the curve, and whose

--- a/Elements/src/Geometry/Curve.cs
+++ b/Elements/src/Geometry/Curve.cs
@@ -32,6 +32,8 @@ namespace Elements.Geometry
 
         /// <summary>
         /// Create a transformed copy of this curve.
+        /// Use of non-euclidean transforms (i.e. scale) will
+        /// result in unpredictable results for curve methods such as Length().
         /// </summary>
         /// <param name="transform">The transform to apply.</param>
         public abstract Curve Transformed(Transform transform);

--- a/Elements/src/Geometry/Curve.cs
+++ b/Elements/src/Geometry/Curve.cs
@@ -39,6 +39,13 @@ namespace Elements.Geometry
         public abstract Transform TransformAt(double u);
 
         /// <summary>
+        /// Get the frame from the curve at parameter u.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>The transform of the curve at parameter u, with the transform's Z axis tangent to the curve.</returns>
+        public abstract Transform TransformAtNormalized(double u);
+
+        /// <summary>
         /// Create a transformed copy of this Curve.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>

--- a/Elements/src/Geometry/Curve.cs
+++ b/Elements/src/Geometry/Curve.cs
@@ -19,9 +19,16 @@ namespace Elements.Geometry
         /// <summary>
         /// Get a point along the curve at parameter u.
         /// </summary>
-        /// <param name="u"></param>
+        /// <param name="u">A parameter on the curve between domain.min and domain.max</param>
         /// <returns>A point on the curve at parameter u.</returns>
         public abstract Vector3 PointAt(double u);
+
+        /// <summary>
+        /// Get a point along the curve at parameter u.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>A point on the curve at parameter u.</returns>
+        public abstract Vector3 PointAtNormalized(double u);
 
         /// <summary>
         /// Get a transform whose XY plane is perpendicular to the curve, and whose

--- a/Elements/src/Geometry/Curve.cs
+++ b/Elements/src/Geometry/Curve.cs
@@ -32,7 +32,7 @@ namespace Elements.Geometry
 
         /// <summary>
         /// Create a transformed copy of this curve.
-        /// Use of non-euclidean transforms (i.e. scale) will
+        /// Use of non-affine transforms (i.e. scale) will
         /// result in unpredictable results for curve methods such as Length().
         /// </summary>
         /// <param name="transform">The transform to apply.</param>

--- a/Elements/src/Geometry/Curve.cs
+++ b/Elements/src/Geometry/Curve.cs
@@ -13,7 +13,7 @@ namespace Elements.Geometry
         /// The minimum chord length allowed for subdivision of the curve.
         /// A lower MinimumChordLength results in smoother curves.
         /// </summary>
-        public static double MinimumChordLength = 0.01;
+        public static double MinimumChordLength = 0.1;
 
         /// <summary>
         /// Get a point along the curve at parameter u.

--- a/Elements/src/Geometry/Curve.cs
+++ b/Elements/src/Geometry/Curve.cs
@@ -39,13 +39,6 @@ namespace Elements.Geometry
         public abstract Transform TransformAt(double u);
 
         /// <summary>
-        /// Get the frame from the curve at parameter u.
-        /// </summary>
-        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
-        /// <returns>The transform of the curve at parameter u, with the transform's Z axis tangent to the curve.</returns>
-        public abstract Transform TransformAtNormalized(double u);
-
-        /// <summary>
         /// Create a transformed copy of this Curve.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>

--- a/Elements/src/Geometry/Ellipse.cs
+++ b/Elements/src/Geometry/Ellipse.cs
@@ -1,5 +1,6 @@
 using System;
 using Elements.Geometry.Interfaces;
+using Newtonsoft.Json;
 
 namespace Elements.Geometry
 {
@@ -12,6 +13,7 @@ namespace Elements.Geometry
         /// <summary>
         /// The center of the ellipse.
         /// </summary>
+        [JsonIgnore]
         public Vector3 Center
         {
             get
@@ -55,7 +57,7 @@ namespace Elements.Geometry
         /// <param name="center">The center of the ellipse.</param>
         /// <param name="majorAxis">The dimension of the major axis (X) of the ellipse.</param>
         /// <param name="minorAxis">The dimension of the minor axis (Y) of the ellipse.</param>
-        public Ellipse(Vector3 center, double majorAxis = 1.0, double minorAxis = 2.0)
+        public Ellipse(Vector3 center, double majorAxis = 2.0, double minorAxis = 1.0)
         {
             CheckAndThrow(minorAxis, majorAxis);
 
@@ -70,7 +72,8 @@ namespace Elements.Geometry
         /// <param name="transform">The coordinate system of the plane containing the ellipse.</param>
         /// <param name="majorAxis">The dimension of the major axis (X) of the ellipse.</param>
         /// <param name="minorAxis">The dimension of the minor axis (Y) of the ellipse.</param>
-        public Ellipse(Transform transform, double majorAxis = 1.0, double minorAxis = 2.0)
+        [JsonConstructor]
+        public Ellipse(Transform transform, double majorAxis = 2.0, double minorAxis = 1.0)
         {
             CheckAndThrow(minorAxis, majorAxis);
 

--- a/Elements/src/Geometry/Ellipse.cs
+++ b/Elements/src/Geometry/Ellipse.cs
@@ -102,6 +102,20 @@ namespace Elements.Geometry
             return Transform.OfPoint(PointAtUntransformed(u));
         }
 
+        /// <summary>
+        /// Get a point at parameter u on the ellipse.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>A point on the curve at parameter u.</returns>
+        public override Vector3 PointAtNormalized(double u)
+        {
+            if (u < 0 || u > 1)
+            {
+                throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between 0.0 and 1.0.");
+            }
+            return Transform.OfPoint(PointAtUntransformed(u * Math.PI * 2));
+        }
+
         private Vector3 PointAtUntransformed(double u)
         {
             var x = this.MajorAxis * Math.Cos(u);

--- a/Elements/src/Geometry/Ellipse.cs
+++ b/Elements/src/Geometry/Ellipse.cs
@@ -102,20 +102,6 @@ namespace Elements.Geometry
             return Transform.OfPoint(PointAtUntransformed(u));
         }
 
-        /// <summary>
-        /// Get a point at parameter u on the ellipse.
-        /// </summary>
-        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
-        /// <returns>A point on the curve at parameter u.</returns>
-        public override Vector3 PointAtNormalized(double u)
-        {
-            if (u < 0 || u > 1)
-            {
-                throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between 0.0 and 1.0.");
-            }
-            return Transform.OfPoint(PointAtUntransformed(u * Math.PI * 2));
-        }
-
         private Vector3 PointAtUntransformed(double u)
         {
             var x = this.MajorAxis * Math.Cos(u);

--- a/Elements/src/Geometry/Ellipse.cs
+++ b/Elements/src/Geometry/Ellipse.cs
@@ -151,10 +151,7 @@ namespace Elements.Geometry
             return new Transform(p, x, y, x.Cross(y)).Concatenated(this.Transform);
         }
 
-        /// <summary>
-        /// Create a transformed copy of the ellipse.
-        /// </summary>
-        /// <param name="transform">The transform to apply.</param>
+        /// <inheritdoc/>
         public override Curve Transformed(Transform transform)
         {
             return new Ellipse(transform.Concatenated(this.Transform), this.MajorAxis, this.MinorAxis);

--- a/Elements/src/Geometry/EllipticalArc.cs
+++ b/Elements/src/Geometry/EllipticalArc.cs
@@ -10,6 +10,22 @@ namespace Elements.Geometry
     public class EllipticalArc : TrimmedCurve<Ellipse>
     {
         /// <summary>
+        /// The domain of the curve.
+        /// </summary>
+        [JsonIgnore]
+        public override Domain1d Domain => new Domain1d(Units.DegreesToRadians(this.StartAngle), Units.DegreesToRadians(this.EndAngle));
+
+        /// <summary>The angle from 0.0, in degrees, at which the arc will start with respect to the positive X axis.</summary>
+        [JsonProperty("StartAngle", Required = Required.Always)]
+        [System.ComponentModel.DataAnnotations.Range(0.0D, 360.0D)]
+        public double StartAngle { get; protected set; }
+
+        /// <summary>The angle from 0.0, in degrees, at which the arc will end with respect to the positive X axis.</summary>
+        [JsonProperty("EndAngle", Required = Required.Always)]
+        [System.ComponentModel.DataAnnotations.Range(0.0D, 360.0D)]
+        public double EndAngle { get; protected set; }
+
+        /// <summary>
         /// Create an elliptical arc.
         /// </summary>
         /// <param name="majorAxis">The major axis (X) of the ellipse.</param>
@@ -21,7 +37,8 @@ namespace Elements.Geometry
         public EllipticalArc(Vector3 center, double majorAxis, double minorAxis, double startAngle, double endAngle)
         {
             this.BasisCurve = new Ellipse(new Transform(center), majorAxis, minorAxis);
-            this.Domain = new Domain1d(Units.DegreesToRadians(startAngle), Units.DegreesToRadians(endAngle));
+            this.StartAngle = startAngle;
+            this.EndAngle = endAngle;
             this.Start = this.PointAt(this.Domain.Min);
             this.End = this.PointAt(this.Domain.Max);
         }
@@ -35,7 +52,8 @@ namespace Elements.Geometry
         public EllipticalArc(Ellipse ellipse, double @startAngle, double @endAngle)
         {
             this.BasisCurve = ellipse;
-            this.Domain = new Domain1d(Units.DegreesToRadians(startAngle), Units.DegreesToRadians(endAngle));
+            this.StartAngle = startAngle;
+            this.EndAngle = endAngle;
             this.Start = this.PointAt(this.Domain.Min);
             this.End = this.PointAt(this.Domain.Max);
         }

--- a/Elements/src/Geometry/EllipticalArc.cs
+++ b/Elements/src/Geometry/EllipticalArc.cs
@@ -134,14 +134,10 @@ namespace Elements.Geometry
             return new EllipticalArc((Ellipse)this.BasisCurve.Transformed(transform), this.Domain.Min, this.Domain.Max);
         }
 
-        /// <summary>
-        /// Get parameters to be used to find points along the curve for visualization.
-        /// </summary>
-        /// <param name="startSetbackDistance">An optional setback from the start of the curve.</param>
-        /// <param name="endSetbackDistance">An optional setback from the end of the curve.</param>
-        /// <returns>A collection of parameter values.</returns>
+        /// <inheritdoc/>
         public override double[] GetSubdivisionParameters(double startSetbackDistance = 0.0,
-                                                       double endSetbackDistance = 0.0)
+                                                          double endSetbackDistance = 0.0,
+                                                          double minimumChordLength = 0.01)
         {
             var min = ParameterAtDistanceFromParameter(startSetbackDistance, this.Domain.Min);
             var max = ParameterAtDistanceFromParameter(this.Length() - endSetbackDistance, this.Domain.Min);
@@ -158,7 +154,7 @@ namespace Elements.Geometry
             // requires the use of an elliptic integral and solving with
             // newton's method to find exactly the right values. For now,
             // we'll do a very simple subdivision of the arc.
-            var div = 50;
+            var div = (int)Math.Round(this.Length() / minimumChordLength);
             var parameters = new double[div + 1];
             var step = (max - min) / div;
             for (var i = 0; i <= div; i++)

--- a/Elements/src/Geometry/EllipticalArc.cs
+++ b/Elements/src/Geometry/EllipticalArc.cs
@@ -91,20 +91,6 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Get a point at parameter u on the arc.
-        /// </summary>
-        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
-        /// <returns>A point on the curve at parameter u.</returns>
-        public override Vector3 PointAtNormalized(double u)
-        {
-            if (u < 0 || u > 1)
-            {
-                throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between 0.0 and 1.0.");
-            }
-            return this.BasisCurve.PointAt(this.Domain.Min + u * this.Domain.Length);
-        }
-
-        /// <summary>
         /// Get a transform at a parameter on the elliptical arc.
         /// </summary>
         /// <param name="u">The parameter at which to find a transform.</param>

--- a/Elements/src/Geometry/EllipticalArc.cs
+++ b/Elements/src/Geometry/EllipticalArc.cs
@@ -86,7 +86,7 @@ namespace Elements.Geometry
         /// Calculate the length of the elliptical arc between start and end parameters.
         /// </summary>
         /// <returns>The length of the elliptical arc between start and end.</returns>
-        public override double Length(double start, double end)
+        public override double ArcLength(double start, double end)
         {
             if (!Domain.Includes(start, true))
             {

--- a/Elements/src/Geometry/EllipticalArc.cs
+++ b/Elements/src/Geometry/EllipticalArc.cs
@@ -136,8 +136,7 @@ namespace Elements.Geometry
 
         /// <inheritdoc/>
         public override double[] GetSubdivisionParameters(double startSetbackDistance = 0.0,
-                                                          double endSetbackDistance = 0.0,
-                                                          double minimumChordLength = 0.01)
+                                                          double endSetbackDistance = 0.0)
         {
             var min = ParameterAtDistanceFromParameter(startSetbackDistance, this.Domain.Min);
             var max = ParameterAtDistanceFromParameter(this.Length() - endSetbackDistance, this.Domain.Min);
@@ -154,7 +153,7 @@ namespace Elements.Geometry
             // requires the use of an elliptic integral and solving with
             // newton's method to find exactly the right values. For now,
             // we'll do a very simple subdivision of the arc.
-            var div = (int)Math.Round(this.Length() / minimumChordLength);
+            var div = (int)Math.Round(this.Length() / DefaultMinimumChordLength);
             var parameters = new double[div + 1];
             var step = (max - min) / div;
             for (var i = 0; i <= div; i++)

--- a/Elements/src/Geometry/EllipticalArc.cs
+++ b/Elements/src/Geometry/EllipticalArc.cs
@@ -55,8 +55,25 @@ namespace Elements.Geometry
         /// <returns>The length of the elliptical arc.</returns>
         public override double Length()
         {
-            // Define the function to be integrated (arc length formula)
             return this.BasisCurve.ArcLength(this.Domain.Min, this.Domain.Max);
+        }
+
+        /// <summary>
+        /// Calculate the length of the elliptical arc between start and end parameters.
+        /// </summary>
+        /// <returns>The length of the elliptical arc between start and end.</returns>
+        public override double Length(double start, double end)
+        {
+            if (!Domain.Includes(start, true))
+            {
+                throw new ArgumentOutOfRangeException("start", $"The start parameter {start} must be between {Domain.Min} and {Domain.Max}.");
+            }
+            if (!Domain.Includes(end, true))
+            {
+                throw new ArgumentOutOfRangeException("end", $"The end parameter {end} must be between {Domain.Min} and {Domain.Max}.");
+            }
+
+            return this.BasisCurve.ArcLength(start, end);
         }
 
         /// <summary>
@@ -68,7 +85,7 @@ namespace Elements.Geometry
         {
             if (!this.Domain.Includes(u, true))
             {
-                throw new ArgumentException($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between {Domain.Min} and {Domain.Max}.");
+                throw new ArgumentOutOfRangeException($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between {Domain.Min} and {Domain.Max}.");
             }
             return this.BasisCurve.PointAt(u);
         }

--- a/Elements/src/Geometry/EllipticalArc.cs
+++ b/Elements/src/Geometry/EllipticalArc.cs
@@ -74,6 +74,20 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Get a point at parameter u on the arc.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>A point on the curve at parameter u.</returns>
+        public override Vector3 PointAtNormalized(double u)
+        {
+            if (u < 0 || u > 1)
+            {
+                throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between 0.0 and 1.0.");
+            }
+            return this.BasisCurve.PointAt(this.Domain.Min + u * this.Domain.Length);
+        }
+
+        /// <summary>
         /// Get a transform at a parameter on the elliptical arc.
         /// </summary>
         /// <param name="u">The parameter at which to find a transform.</param>

--- a/Elements/src/Geometry/EllipticalArc.cs
+++ b/Elements/src/Geometry/EllipticalArc.cs
@@ -131,7 +131,7 @@ namespace Elements.Geometry
         /// <inheritdoc/>
         public override Curve Transformed(Transform transform)
         {
-            return new EllipticalArc((Ellipse)this.BasisCurve.Transformed(transform), this.Domain.Min, this.Domain.Max);
+            return new EllipticalArc((Ellipse)this.BasisCurve.Transformed(transform), this.StartAngle, this.EndAngle);
         }
 
         /// <inheritdoc/>

--- a/Elements/src/Geometry/EllipticalArc.cs
+++ b/Elements/src/Geometry/EllipticalArc.cs
@@ -128,11 +128,7 @@ namespace Elements.Geometry
             return this.BasisCurve.TransformAt(u);
         }
 
-        /// <summary>
-        /// Get a curve that is the result of applying the provided transform to this curve.
-        /// </summary>
-        /// <param name="transform">The transform to apply.</param>
-        /// <returns>A transformed curve.</returns>
+        /// <inheritdoc/>
         public override Curve Transformed(Transform transform)
         {
             return new EllipticalArc((Ellipse)this.BasisCurve.Transformed(transform), this.Domain.Min, this.Domain.Max);

--- a/Elements/src/Geometry/EllipticalArc.cs
+++ b/Elements/src/Geometry/EllipticalArc.cs
@@ -34,7 +34,11 @@ namespace Elements.Geometry
         /// <param name="startAngle">The start parameter of the trim.</param>
         /// <param name="endAngle">The end parameter of the trim.</param>
         [JsonConstructor]
-        public EllipticalArc(Vector3 center, double majorAxis, double minorAxis, double startAngle, double endAngle)
+        public EllipticalArc(Vector3 center,
+                             double majorAxis,
+                             double minorAxis,
+                             double startAngle,
+                             double endAngle)
         {
             this.BasisCurve = new Ellipse(new Transform(center), majorAxis, minorAxis);
             this.StartAngle = startAngle;
@@ -49,7 +53,9 @@ namespace Elements.Geometry
         /// <param name="ellipse">The ellipse on which this trim is based.</param>
         /// <param name="startAngle">The start angle of the trim in degrees.</param>
         /// <param name="endAngle">The end parameter of the trim in degrees.</param>
-        public EllipticalArc(Ellipse ellipse, double @startAngle, double @endAngle)
+        public EllipticalArc(Ellipse ellipse,
+                             double @startAngle,
+                             double @endAngle)
         {
             this.BasisCurve = ellipse;
             this.StartAngle = startAngle;

--- a/Elements/src/Geometry/EndType.cs
+++ b/Elements/src/Geometry/EndType.cs
@@ -1,0 +1,21 @@
+namespace Elements.Geometry
+{
+    /// <summary>
+    /// Offset end types
+    /// </summary>
+    public enum EndType
+    {
+        /// <summary>
+        /// Open ends are extended by the offset distance and squared off
+        /// </summary>
+        Square,
+        /// <summary>
+        /// Ends are squared off with no extension
+        /// </summary>
+        Butt,
+        /// <summary>
+        /// If open, ends are joined and treated as a closed polygon
+        /// </summary>
+        ClosedPolygon,
+    }
+}

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -406,8 +406,7 @@ namespace Elements.Geometry
 
             if (curveIndex == _curves.Count)
             {
-                curveIndex = _curves.Count - 1;
-                return _curves[_curves.Count - 1].PointAtNormalized(1);
+                return End;
             }
 
             if (curveIndex == Vertices.Count)
@@ -415,10 +414,7 @@ namespace Elements.Geometry
                 // The polygon case.
                 return Start;
             }
-            else if (curveIndex == Vertices.Count - 1)
-            {
-                return End;
-            }
+
             var t = u - curveIndex;
             return _curves[curveIndex].PointAtNormalized(t);
         }

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -78,6 +78,39 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="vertices">A collection of vertices.</param>
         /// <param name="curveIndices">A collection of collections of indices.</param>
+        [JsonConstructor]
+        public IndexedPolycurve(IList<Vector3> vertices,
+                                IList<IList<int>> curveIndices)
+        {
+            Vertices = vertices;
+
+            if (!Validator.DisableValidationOnConstruction)
+            {
+                ValidateVertices();
+            }
+
+            CurveIndices = curveIndices;
+
+            _bounds = Bounds();
+
+            var count = 0;
+            foreach (var curveIndexSet in CurveIndices)
+            {
+                if (curveIndexSet.Count < 2 || curveIndexSet.Count > 3)
+                {
+                    throw new ArgumentException("curveIndices", $"Curve indices must reference 2 or 3 vertices. The curve index at {count} references {curveIndexSet.Count} vertices.");
+                }
+                count++;
+            }
+
+            _curves = CreateCurves(CurveIndices, Vertices);
+        }
+
+        /// <summary>
+        /// Create an indexed polycurve.
+        /// </summary>
+        /// <param name="vertices">A collection of vertices.</param>
+        /// <param name="curveIndices">A collection of collections of indices.</param>
         /// <param name="transform">An optional transform to apply to each vertex.</param>
         /// <param name="disableValidation"></param>
         public IndexedPolycurve(IList<Vector3> vertices,

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -243,16 +243,6 @@ namespace Elements.Geometry
             return TransformAt(1);
         }
 
-        /// <summary>
-        /// Get the frame from the curve at parameter u.
-        /// </summary>
-        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
-        /// <returns>The transform of the curve at parameter u, with the transform's Z axis tangent to the curve.</returns>
-        public override Transform TransformAtNormalized(double u)
-        {
-            return this.TransformAt(u);
-        }
-
         public override Curve Transformed(Transform transform)
         {
             throw new System.NotImplementedException();

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -475,10 +475,7 @@ namespace Elements.Geometry
             return _curves[curveIndex].TransformAtNormalized(t);
         }
 
-        /// <summary>
-        /// Create new polycurve transformed by transform.
-        /// </summary>
-        /// <param name="transform">The transform to apply.</param>
+        /// <inheritdoc/>
         public override Curve Transformed(Transform transform)
         {
             return new IndexedPolycurve(_curves, transform);

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace Elements.Geometry
 {
     /// <summary>
-    /// A curves made up of a collection of line and arc segments.
+    /// A curve composed of a collection of line and arc segments.
     /// Parameterization of the curve is 0->n-1 where n is the number of vertices.
     /// </summary>
     [JsonObject]
@@ -287,7 +287,7 @@ namespace Elements.Geometry
         /// <summary>
         /// Calculate the length of the polycurve between two parameters.
         /// </summary>
-        public override double Length(double start, double end)
+        public override double ArcLength(double start, double end)
         {
             PointAtInternal(start, out var startCurveIndex);
             return end - start;
@@ -322,7 +322,7 @@ namespace Elements.Geometry
                 // the start parameter is located, or it will be 0.0.
                 var normalizedStartParameter = i == startCurveIndex ? start - i : 0.0;
                 var localStartParameter = normalizedStartParameter.MapToDomain(curve.Domain);
-                var distanceToEndOfCurve = Length(localStartParameter, curve.Domain.Max);
+                var distanceToEndOfCurve = ArcLength(localStartParameter, curve.Domain.Max);
                 if (trackingLength + distanceToEndOfCurve > distance)
                 {
                     // Find the parameter at exactly the distance.

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -1,0 +1,66 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Elements.Geometry
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class IndexedPolycurve : BoundedCurve
+    {
+        /// <summary>
+        /// A bounding box created once during the polyline's construction.
+        /// This will not be updated when a polyline's vertices are changed.
+        /// </summary>
+        internal BBox3 _bounds;
+
+        /// <summary>
+        /// A collection of collections of indices of polycurve segments.
+        /// Line segments are represented with two indices.
+        /// Arc segments are represented with three indices.
+        /// </summary>
+        /// <returns></returns>
+        public IList<IList<uint>> Segments { get; set; } = new List<IList<uint>>();
+
+        /// <summary>The vertices of the polygon.</summary>
+        [JsonProperty("Vertices", Required = Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        [System.ComponentModel.DataAnnotations.MinLength(2)]
+        public IList<Vector3> Vertices { get; set; } = new List<Vector3>();
+
+        public override BBox3 Bounds()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override double[] GetSubdivisionParameters(double startSetbackDistance = 0, double endSetbackDistance = 0)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override double Length()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override double ParameterAtDistanceFromParameter(double distance, double start)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override Vector3 PointAt(double u)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override Transform TransformAt(double u)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override Curve Transformed(Transform transform)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -288,7 +288,7 @@ namespace Elements.Geometry
         /// Get the parameter at a distance from the start parameter along the curve.
         /// </summary>
         /// <param name="distance">The distance from the start parameter.</param>
-        /// <param name="start">The parameter from which to measure the distance between 0.0 and 1.0.</param>
+        /// <param name="start">The parameter from which to measure the distance between domain.min and domain.max.</param>
         public override double ParameterAtDistanceFromParameter(double distance, double start)
         {
             if (!Domain.Includes(start, true))
@@ -323,26 +323,26 @@ namespace Elements.Geometry
         /// <summary>
         /// Get a point on the polycurve at parameter u.
         /// </summary>
-        /// <param name="u">A value between 0.0 and 1.0.</param>
+        /// <param name="u">A value between domain.min and domain.max.</param>
         /// <returns>Returns a Vector3 indicating a point along the Polygon length from its start vertex.</returns>
         public override Vector3 PointAt(double u)
-        {
-            return PointAtInternal(u, out _);
-        }
-
-        /// <summary>
-        /// Get a point on the polycurve at parameter u.
-        /// </summary>
-        /// <param name="u">A value between 0.0 and length.</param>
-        /// <param name="curveIndex">The index of the segment containing parameter u.</param>
-        /// <returns>Returns a Vector3 indicating a point along the Polygon length from its start vertex.</returns>
-        protected virtual Vector3 PointAtInternal(double u, out int curveIndex)
         {
             if (!Domain.Includes(u, true))
             {
                 throw new Exception($"The parameter {u} must be between {Domain.Min} and {Domain.Max}.");
             }
 
+            return PointAtInternal(u, out _);
+        }
+
+        /// <summary>
+        /// Get a point on the polycurve at parameter u.
+        /// </summary>
+        /// <param name="u">A value between domain.min and domain.max.</param>
+        /// <param name="curveIndex">The index of the segment containing parameter u.</param>
+        /// <returns>Returns a Vector3 indicating a point along the Polygon length from its start vertex.</returns>
+        protected virtual Vector3 PointAtInternal(double u, out int curveIndex)
+        {
             curveIndex = (int)Math.Floor(u);
             if (curveIndex == _curves.Count)
             {
@@ -355,7 +355,7 @@ namespace Elements.Geometry
         /// <summary>
         /// Get the transform at the specified parameter along the polyline.
         /// </summary>
-        /// <param name="u">The parameter on the Polygon between 0.0 and length.</param>
+        /// <param name="u">The parameter on the Polygon between domain.min and domain.max.</param>
         /// <returns>A transform with its Z axis aligned trangent to the polycurve.</returns>
         public override Transform TransformAt(double u)
         {

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -23,8 +23,8 @@ namespace Elements.Geometry
         private List<BoundedCurve> _curves;
 
         /// <summary>
-        /// A bounding box created once during the polyline's construction.
-        /// This will not be updated when a polyline's vertices are changed.
+        /// A bounding box created once during the polycurve's construction.
+        /// This will not be updated when a polycurve's vertices are changed.
         /// </summary>
         internal BBox3 _bounds;
 
@@ -35,7 +35,7 @@ namespace Elements.Geometry
         public override Domain1d Domain => new Domain1d(0, CurveIndices.Count);
 
         /// <summary>
-        /// The start of the polyline.
+        /// The start of the polycurve.
         /// </summary>
         [JsonIgnore]
         public override Vector3 Start
@@ -44,7 +44,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// The end of the polyline.
+        /// The end of the polycurve.
         /// </summary>
         [JsonIgnore]
         public override Vector3 End
@@ -420,7 +420,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Get the transform at the specified parameter along the polyline.
+        /// Get the transform at the specified parameter along the polycurve.
         /// </summary>
         /// <param name="u">The parameter on the Polygon between domain.min and domain.max.</param>
         /// <returns>A transform with its Z axis aligned trangent to the polycurve.</returns>
@@ -501,7 +501,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Get a string representation of this polyline.
+        /// Get a string representation of this polycurve.
         /// </summary>
         /// <returns></returns>
         public override string ToString()
@@ -517,7 +517,7 @@ namespace Elements.Geometry
             return new Polygon(RenderVertices());
         }
 
-        // TODO: Investigate converting Polyline to IEnumerable<(Vector3, Vector3)>
+        // TODO: Investigate converting polycurve to IEnumerable<(Vector3, Vector3)>
         virtual internal IEnumerable<(Vector3 from, Vector3 to)> Edges(Transform transform = null)
         {
             for (var i = 0; i < Vertices.Count - 1; i++)
@@ -553,7 +553,7 @@ namespace Elements.Geometry
                     }
                     if (vertices[i].IsAlmostEqualTo(vertices[j]))
                     {
-                        throw new ArgumentException($"The polyline could not be created. Two vertices were almost equal: {i} {vertices[i]} {j} {vertices[j]}.");
+                        throw new ArgumentException($"The polycurve could not be created. Two vertices were almost equal: {i} {vertices[i]} {j} {vertices[j]}.");
                     }
                 }
             }
@@ -568,7 +568,7 @@ namespace Elements.Geometry
             {
                 if (from.DistanceTo(to) == 0)
                 {
-                    throw new ArgumentException("A segment of the polyline has zero length.");
+                    throw new ArgumentException("A segment of the polycurve has zero length.");
                 }
             }
         }
@@ -600,7 +600,7 @@ namespace Elements.Geometry
 
                     if (Line.Intersects2d(s1.from, s1.to, s2.from, s2.to))
                     {
-                        throw new ArgumentException($"The polyline could not be created. Segments {i} and {j} intersect.");
+                        throw new ArgumentException($"The polycurve could not be created. Segments {i} and {j} intersect.");
                     }
                 }
             }

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -170,7 +170,13 @@ namespace Elements.Geometry
                 {
                     // The curve domain may be 0->2Pi. We need to map that 
                     // into a domain that is a subsection of the larger domain.
-                    parameters.Add(localParameter.MapBetweenDomains(curve.Domain, localDomain));
+                    var remapped = localParameter.MapBetweenDomains(curve.Domain, localDomain);
+
+                    // De-duplicate the end vertices.
+                    if (!parameters[parameters.Count - 1].ApproximatelyEquals(remapped))
+                    {
+                        parameters.Add(remapped);
+                    }
                 }
             }
             return parameters.ToArray();

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -8,7 +8,7 @@ namespace Elements.Geometry
 {
     /// <summary>
     /// A curve composed of a collection of line and arc segments.
-    /// Parameterization of the curve is 0->n-1 where n is the number of vertices.
+    /// Parameterization of the curve is 0->n where n is the number of curves.
     /// </summary>
     /// [!code-csharp[Main](../../Elements/test/IndexedPolycurveTests.cs?name=example)]
     [JsonObject]

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -273,8 +273,7 @@ namespace Elements.Geometry
 
         /// <inheritdoc/>
         public override double[] GetSubdivisionParameters(double startSetbackDistance = 0,
-                                                          double endSetbackDistance = 0,
-                                                          double minimumChordLength = 0.01)
+                                                          double endSetbackDistance = 0)
         {
             var parameters = new List<double>();
             for (var i = 0; i < _curves.Count; i++)

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -356,8 +356,8 @@ namespace Elements.Geometry
                 // the start parameter is located, or it will be 0.0.
                 var normalizedStartParameter = i == startCurveIndex ? start - i : 0.0;
                 var localStartParameter = normalizedStartParameter.MapToDomain(curve.Domain);
-                var distanceToEndOfCurve = ArcLength(localStartParameter, curve.Domain.Max);
-                if (trackingLength + distanceToEndOfCurve > distance)
+                var distanceToEndOfCurve = curve.ArcLength(localStartParameter, curve.Domain.Max);
+                if (trackingLength + distanceToEndOfCurve >= distance)
                 {
                     // Find the parameter at exactly the distance.
                     return i + curve.ParameterAtDistanceFromParameter(distance - trackingLength, localStartParameter).MapFromDomain(curve.Domain);

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -326,7 +326,7 @@ namespace Elements.Geometry
                 if (trackingLength + distanceToEndOfCurve > distance)
                 {
                     // Find the parameter at exactly the distance.
-                    return curve.ParameterAtDistanceFromParameter(localStartParameter, distance - trackingLength);
+                    return i + curve.ParameterAtDistanceFromParameter(distance - trackingLength, localStartParameter).MapFromDomain(curve.Domain);
                 }
 
                 trackingLength += distanceToEndOfCurve;

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -1,12 +1,16 @@
+using Elements.Validators;
 using Newtonsoft.Json;
+using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Elements.Geometry
 {
     /// <summary>
-    /// 
+    /// A curves made up of a collection of line and arc segments.
+    /// Parameterization of the curve is 0->length.
     /// </summary>
-    public class IndexedPolycurve : BoundedCurve
+    public class IndexedPolycurve : BoundedCurve, IEnumerable<BoundedCurve>, IEquatable<IndexedPolycurve>
     {
         /// <summary>
         /// A bounding box created once during the polyline's construction.
@@ -15,12 +19,29 @@ namespace Elements.Geometry
         internal BBox3 _bounds;
 
         /// <summary>
-        /// A collection of collections of indices of polycurve segments.
+        /// The start of the polyline.
+        /// </summary>
+        [JsonIgnore]
+        public override Vector3 Start
+        {
+            get { return this.Vertices[0]; }
+        }
+
+        /// <summary>
+        /// The end of the polyline.
+        /// </summary>
+        [JsonIgnore]
+        public override Vector3 End
+        {
+            get { return this.Vertices[this.Vertices.Count - 1]; }
+        }
+
+        /// <summary>
+        /// An optional collection of collections of indices of polycurve segments.
         /// Line segments are represented with two indices.
         /// Arc segments are represented with three indices.
         /// </summary>
-        /// <returns></returns>
-        public IList<IList<uint>> Segments { get; set; } = new List<IList<uint>>();
+        public IList<IList<int>> CurveIndices { get; set; }
 
         /// <summary>The vertices of the polygon.</summary>
         [JsonProperty("Vertices", Required = Required.Always)]
@@ -28,9 +49,47 @@ namespace Elements.Geometry
         [System.ComponentModel.DataAnnotations.MinLength(2)]
         public IList<Vector3> Vertices { get; set; } = new List<Vector3>();
 
+        /// <summary>
+        /// Create an indexed polycurve.
+        /// </summary>
+        /// <param name="vertices">A collection of vertices.</param>
+        /// <param name="curveIndices">A collection of collections of indices.</param>
+        /// <param name="disableValidation"></param>
+        [JsonConstructor]
+        public IndexedPolycurve(IList<Vector3> vertices,
+                                IList<IList<int>> curveIndices = null,
+                                bool disableValidation = false)
+        {
+            if (!Validator.DisableValidationOnConstruction && !disableValidation)
+            {
+                ValidateVertices();
+            }
+
+            if (curveIndices != null)
+            {
+                var count = 0;
+                foreach (var curveIndexSet in curveIndices)
+                {
+                    if (curveIndexSet.Count < 2 || curveIndexSet.Count > 3)
+                    {
+                        throw new ArgumentException("curveIndices", $"Curve indices must reference 2 or 3 vertices. The curve index at {count} references {curveIndexSet.Count} vertices.");
+                    }
+                    count++;
+                }
+            }
+
+            this.Vertices = vertices;
+            this.CurveIndices = curveIndices;
+            this.Domain = new Domain1d(0, this.Length());
+            _bounds = new BBox3(Vertices);
+        }
+
+        /// <summary>
+        /// Get the bounding box for this curve.
+        /// </summary>
         public override BBox3 Bounds()
         {
-            throw new System.NotImplementedException();
+            return new BBox3(this.Vertices);
         }
 
         public override double[] GetSubdivisionParameters(double startSetbackDistance = 0, double endSetbackDistance = 0)
@@ -38,9 +97,17 @@ namespace Elements.Geometry
             throw new System.NotImplementedException();
         }
 
+        /// <summary>
+        /// Calculate the length of the indexed polycurve.
+        /// </summary>
         public override double Length()
         {
-            throw new System.NotImplementedException();
+            var length = 0.0;
+            foreach (var curve in this)
+            {
+                length += curve.Length();
+            }
+            return length;
         }
 
         public override double ParameterAtDistanceFromParameter(double distance, double start)
@@ -48,9 +115,25 @@ namespace Elements.Geometry
             throw new System.NotImplementedException();
         }
 
+        /// <summary>
+        /// Get a point on the polycurve at parameter u.
+        /// </summary>
+        /// <param name="u">A value between 0.0 and 1.0.</param>
+        /// <returns>Returns a Vector3 indicating a point along the Polygon length from its start vertex.</returns>
         public override Vector3 PointAt(double u)
         {
-            throw new System.NotImplementedException();
+            return PointAtInternal(u, out _);
+        }
+
+        /// <summary>
+        /// Get a point on the polycurve at parameter u.
+        /// </summary>
+        /// <param name="u">A value between 0.0 and length.</param>
+        /// <param name="curveIndex">The index of the segment containing parameter u.</param>
+        /// <returns>Returns a Vector3 indicating a point along the Polygon length from its start vertex.</returns>
+        protected virtual Vector3 PointAtInternal(double u, out int curveIndex)
+        {
+            throw new NotImplementedException();
         }
 
         public override Transform TransformAt(double u)
@@ -62,5 +145,165 @@ namespace Elements.Geometry
         {
             throw new System.NotImplementedException();
         }
+
+        /// <summary>
+        /// Does this polyline equal the provided polyline?
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns>True if the two curves are equal, otherwise false.</returns>
+        public bool Equals(IndexedPolycurve other)
+        {
+            if (this.Vertices.Count != other.Vertices.Count)
+            {
+                return false;
+            }
+            for (var i = 0; i < Vertices.Count; i++)
+            {
+                if (!this.Vertices[i].Equals(other.Vertices[i]))
+                {
+                    return false;
+                }
+            }
+
+            if (this.CurveIndices != null)
+            {
+                if (this.CurveIndices.Count != other.CurveIndices.Count)
+                {
+                    return false;
+                }
+                for (var i = 0; i < this.CurveIndices.Count; i++)
+                {
+                    if (!this.CurveIndices[i].Equals(other.CurveIndices[i]))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Get a string representation of this polyline.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return string.Join<Vector3>(",", this.Vertices);
+        }
+
+        // TODO: Investigate converting Polyline to IEnumerable<(Vector3, Vector3)>
+        virtual internal IEnumerable<(Vector3 from, Vector3 to)> Edges(Transform transform = null)
+        {
+            for (var i = 0; i < Vertices.Count - 1; i++)
+            {
+                var from = Vertices[i];
+                var to = Vertices[i + 1];
+                yield return transform != null ? (transform.OfPoint(from), transform.OfPoint(to)) : (from, to);
+            }
+        }
+
+        /// <summary>
+        /// Clean up any duplicate vertices, and warn about any vertices that are too close to each other.
+        /// </summary>
+        protected virtual void ValidateVertices()
+        {
+            Vertices = Vector3.RemoveSequentialDuplicates(Vertices);
+            CheckSegmentLengthAndThrow(Edges());
+        }
+
+        /// <summary>
+        /// Check for coincident vertices in the supplied vertex collection.
+        /// </summary>
+        /// <param name="vertices"></param>
+        protected void CheckCoincidenceAndThrow(IList<Vector3> vertices)
+        {
+            for (var i = 0; i < vertices.Count; i++)
+            {
+                for (var j = 0; j < vertices.Count; j++)
+                {
+                    if (i == j)
+                    {
+                        continue;
+                    }
+                    if (vertices[i].IsAlmostEqualTo(vertices[j]))
+                    {
+                        throw new ArgumentException($"The polyline could not be created. Two vertices were almost equal: {i} {vertices[i]} {j} {vertices[j]}.");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Check if any of the polygon segments have zero length.
+        /// </summary>
+        internal static void CheckSegmentLengthAndThrow(IEnumerable<(Vector3 from, Vector3 to)> segments)
+        {
+            foreach (var (from, to) in segments)
+            {
+                if (from.DistanceTo(to) == 0)
+                {
+                    throw new ArgumentException("A segment of the polyline has zero length.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Check for self-intersection in the supplied line segment collection.
+        /// </summary>
+        /// <param name="t">The transform representing the plane of the polygon.</param>
+        /// <param name="segments"></param>
+        internal static void CheckSelfIntersectionAndThrow(Transform t, IEnumerable<(Vector3 from, Vector3 to)> segments)
+        {
+            var segmentsT = new List<(Vector3 from, Vector3 to)>();
+            foreach (var (from, to) in segments)
+            {
+                segmentsT.Add((t.OfPoint(from), t.OfPoint(to)));
+            }
+
+            for (var i = 0; i < segmentsT.Count; i++)
+            {
+                for (var j = 0; j < segmentsT.Count; j++)
+                {
+                    if (i == j)
+                    {
+                        // Don't check against itself.
+                        continue;
+                    }
+                    var s1 = segmentsT[i];
+                    var s2 = segmentsT[j];
+
+                    if (Line.Intersects2d(s1.from, s1.to, s2.from, s2.to))
+                    {
+                        throw new ArgumentException($"The polyline could not be created. Segments {i} and {j} intersect.");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get the enumerator for this indexed polycurve.
+        /// </summary>
+        /// <returns>An enumerator of bounded curves.</returns>
+        public IEnumerator<BoundedCurve> GetEnumerator()
+        {
+            foreach (var curveIndexSet in this.CurveIndices)
+            {
+                // Construct a curve
+                if (curveIndexSet.Count == 2)
+                {
+                    yield return new Line(Vertices[curveIndexSet[0]], Vertices[curveIndexSet[1]]);
+                }
+                else if (curveIndexSet.Count == 3)
+                {
+                    yield return Arc.ByThreePoints(this.Vertices[curveIndexSet[0]], this.Vertices[curveIndexSet[1]], this.Vertices[curveIndexSet[2]]);
+                }
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
     }
 }

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -271,13 +271,10 @@ namespace Elements.Geometry
             return new BBox3(Vertices);
         }
 
-        /// <summary>
-        /// Get parameters to be used to find points along the curve for visualization.
-        /// </summary>
-        /// <param name="startSetbackDistance">An optional setback from the start of the curve.</param>
-        /// <param name="endSetbackDistance">An optional setback from the end of the curve.</param>
-        /// <returns>A collection of parameter values.</returns>
-        public override double[] GetSubdivisionParameters(double startSetbackDistance = 0, double endSetbackDistance = 0)
+        /// <inheritdoc/>
+        public override double[] GetSubdivisionParameters(double startSetbackDistance = 0,
+                                                          double endSetbackDistance = 0,
+                                                          double minimumChordLength = 0.01)
         {
             var parameters = new List<double>();
             for (var i = 0; i < _curves.Count; i++)

--- a/Elements/src/Geometry/InfiniteLine.cs
+++ b/Elements/src/Geometry/InfiniteLine.cs
@@ -26,10 +26,7 @@ namespace Elements.Geometry
             this.Direction = direction.Unitized();
         }
 
-        /// <summary>
-        /// Construct a transformed copy of this Curve.
-        /// </summary>
-        /// <param name="transform">The transform to apply.</param>
+        /// <inheritdoc/>
         public override Curve Transformed(Transform transform)
         {
             if (transform == null)

--- a/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
+++ b/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
@@ -64,5 +64,12 @@ namespace Elements.Geometry.Interfaces
         /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
         /// <returns>The transform of the curve at parameter u, with the transform's Z axis tangent to the curve.</returns>
         Transform TransformAtNormalized(double u);
+
+        /// <summary>
+        /// Get a point along the curve at parameter u.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>The point on the curve.</returns>
+        Vector3 PointAtNormalized(double u);
     }
 }

--- a/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
+++ b/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
@@ -57,5 +57,12 @@ namespace Elements.Geometry.Interfaces
         /// <param name="endSetbackDistance">An optional setback from the end of the curve.</param>
         /// <returns>A collection of parameter values.</returns>
         double[] GetSubdivisionParameters(double startSetbackDistance = 0, double endSetbackDistance = 0);
+
+        /// <summary>
+        /// Get the frame from the curve at parameter u.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>The transform of the curve at parameter u, with the transform's Z axis tangent to the curve.</returns>
+        Transform TransformAtNormalized(double u);
     }
 }

--- a/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
+++ b/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
@@ -29,7 +29,7 @@ namespace Elements.Geometry.Interfaces
         /// <summary>
         /// Calculate the length of the curve between two parameters.
         /// </summary>
-        double Length(double start, double end);
+        double ArcLength(double start, double end);
 
         /// <summary>
         /// Get the bounding box of this curve.

--- a/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
+++ b/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
@@ -42,8 +42,12 @@ namespace Elements.Geometry.Interfaces
         /// <param name="startSetbackDistance">The offset from the start of the ICurve.</param>
         /// <param name="endSetbackDistance">The offset from the end of the ICurve.</param>
         /// <param name="additionalRotation">An additional rotation of the frame at each point.</param>
+        /// <param name="minimumChordLength">The minimum chord length allowed for subdivision of the curve. A smaller MinimumChordLength results in smoother curves. For polylines and polygons this parameter will have no effect.</param>
         /// <returns>A collection of Transforms.</returns>
-        Transform[] Frames(double startSetbackDistance = 0.0, double endSetbackDistance = 0.0, double additionalRotation = 0.0);
+        Transform[] Frames(double startSetbackDistance = 0.0,
+                           double endSetbackDistance = 0.0,
+                           double additionalRotation = 0.0,
+                           double minimumChordLength = 0.01);
 
         /// <summary>
         /// The domain of the curve.
@@ -55,8 +59,11 @@ namespace Elements.Geometry.Interfaces
         /// </summary>
         /// <param name="startSetbackDistance">An optional setback from the start of the curve.</param>
         /// <param name="endSetbackDistance">An optional setback from the end of the curve.</param>
+        /// <param name="minimumChordLength">The minimum chord length allowed for subdivision of the curve. A smaller MinimumChordLength results in smoother curves.</param>
         /// <returns>A collection of parameter values.</returns>
-        double[] GetSubdivisionParameters(double startSetbackDistance = 0, double endSetbackDistance = 0);
+        double[] GetSubdivisionParameters(double startSetbackDistance = 0,
+                                          double endSetbackDistance = 0,
+                                          double minimumChordLength = 0.01);
 
         /// <summary>
         /// Get a point along the curve at parameter u.

--- a/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
+++ b/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
@@ -42,12 +42,10 @@ namespace Elements.Geometry.Interfaces
         /// <param name="startSetbackDistance">The offset from the start of the ICurve.</param>
         /// <param name="endSetbackDistance">The offset from the end of the ICurve.</param>
         /// <param name="additionalRotation">An additional rotation of the frame at each point.</param>
-        /// <param name="minimumChordLength">The minimum chord length allowed for subdivision of the curve. A smaller MinimumChordLength results in smoother curves. For polylines and polygons this parameter will have no effect.</param>
         /// <returns>A collection of Transforms.</returns>
         Transform[] Frames(double startSetbackDistance = 0.0,
                            double endSetbackDistance = 0.0,
-                           double additionalRotation = 0.0,
-                           double minimumChordLength = 0.01);
+                           double additionalRotation = 0.0);
 
         /// <summary>
         /// The domain of the curve.
@@ -59,11 +57,9 @@ namespace Elements.Geometry.Interfaces
         /// </summary>
         /// <param name="startSetbackDistance">An optional setback from the start of the curve.</param>
         /// <param name="endSetbackDistance">An optional setback from the end of the curve.</param>
-        /// <param name="minimumChordLength">The minimum chord length allowed for subdivision of the curve. A smaller MinimumChordLength results in smoother curves.</param>
         /// <returns>A collection of parameter values.</returns>
         double[] GetSubdivisionParameters(double startSetbackDistance = 0,
-                                          double endSetbackDistance = 0,
-                                          double minimumChordLength = 0.01);
+                                          double endSetbackDistance = 0);
 
         /// <summary>
         /// Get a point along the curve at parameter u.

--- a/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
+++ b/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
@@ -27,6 +27,11 @@ namespace Elements.Geometry.Interfaces
         double Length();
 
         /// <summary>
+        /// Calculate the length of the curve between two parameters.
+        /// </summary>
+        double Length(double start, double end);
+
+        /// <summary>
         /// Get the bounding box of this curve.
         /// </summary>
         BBox3 Bounds();

--- a/Elements/src/Geometry/Interfaces/ICurve.cs
+++ b/Elements/src/Geometry/Interfaces/ICurve.cs
@@ -8,9 +8,16 @@ namespace Elements.Geometry.Interfaces
         /// <summary>
         /// Get a point along the curve at parameter u.
         /// </summary>
-        /// <param name="u">A parameter on the curve.</param>
+        /// <param name="u">A parameter on the curve between domain.min and domain.max.</param>
         /// <returns>The point on the curve.</returns>
         Vector3 PointAt(double u);
+
+        /// <summary>
+        /// Get a point along the curve at parameter u.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>The point on the curve.</returns>
+        Vector3 PointAtNormalized(double u);
 
         /// <summary>
         /// Get the frame from the curve at parameter u.

--- a/Elements/src/Geometry/Interfaces/ICurve.cs
+++ b/Elements/src/Geometry/Interfaces/ICurve.cs
@@ -27,6 +27,13 @@ namespace Elements.Geometry.Interfaces
         Transform TransformAt(double u);
 
         /// <summary>
+        /// Get the frame from the curve at parameter u.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>The transform of the curve at parameter u, with the transform's Z axis tangent to the curve.</returns>
+        Transform TransformAtNormalized(double u);
+
+        /// <summary>
         /// Get the parameter at a distance from the specified parameter along the curve.
         /// </summary>
         /// <param name="distance">The distance from the start parameter.</param>

--- a/Elements/src/Geometry/Interfaces/ICurve.cs
+++ b/Elements/src/Geometry/Interfaces/ICurve.cs
@@ -27,13 +27,6 @@ namespace Elements.Geometry.Interfaces
         Transform TransformAt(double u);
 
         /// <summary>
-        /// Get the frame from the curve at parameter u.
-        /// </summary>
-        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
-        /// <returns>The transform of the curve at parameter u, with the transform's Z axis tangent to the curve.</returns>
-        Transform TransformAtNormalized(double u);
-
-        /// <summary>
         /// Get the parameter at a distance from the specified parameter along the curve.
         /// </summary>
         /// <param name="distance">The distance from the start parameter.</param>

--- a/Elements/src/Geometry/Interfaces/ICurve.cs
+++ b/Elements/src/Geometry/Interfaces/ICurve.cs
@@ -13,13 +13,6 @@ namespace Elements.Geometry.Interfaces
         Vector3 PointAt(double u);
 
         /// <summary>
-        /// Get a point along the curve at parameter u.
-        /// </summary>
-        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
-        /// <returns>The point on the curve.</returns>
-        Vector3 PointAtNormalized(double u);
-
-        /// <summary>
         /// Get the frame from the curve at parameter u.
         /// </summary>
         /// <param name="u">A parameter on the curve.</param>

--- a/Elements/src/Geometry/Interfaces/ICurve.cs
+++ b/Elements/src/Geometry/Interfaces/ICurve.cs
@@ -8,7 +8,7 @@ namespace Elements.Geometry.Interfaces
         /// <summary>
         /// Get a point along the curve at parameter u.
         /// </summary>
-        /// <param name="u">A parameter on the curve between domain.min and domain.max.</param>
+        /// <param name="u">A parameter on the curve.</param>
         /// <returns>The point on the curve.</returns>
         Vector3 PointAt(double u);
 

--- a/Elements/src/Geometry/Kernel.cs
+++ b/Elements/src/Geometry/Kernel.cs
@@ -29,7 +29,7 @@ namespace Elements.Geometry
         /// Create a sweep along a curve.
         /// </summary>
         /// <returns>A solid.</returns>
-        public Solid CreateSweepAlongCurve(Profile profile, BoundedCurve curve, double startSetback, double endSetback, double profileRotation)
+        public Solid CreateSweepAlongCurve(Profile profile, BoundedCurve curve, double startSetback, double endSetback, double profileRotation, double minimumChordLength = 0.01)
         {
             return Solid.SweepFaceAlongCurve(profile.Perimeter, profile.Voids != null && profile.Voids.Count > 0 ? profile.Voids : null, curve, startSetback, endSetback, profileRotation);
         }

--- a/Elements/src/Geometry/Kernel.cs
+++ b/Elements/src/Geometry/Kernel.cs
@@ -29,9 +29,20 @@ namespace Elements.Geometry
         /// Create a sweep along a curve.
         /// </summary>
         /// <returns>A solid.</returns>
-        public Solid CreateSweepAlongCurve(Profile profile, BoundedCurve curve, double startSetback, double endSetback, double profileRotation, double minimumChordLength = 0.01)
+        public Solid CreateSweepAlongCurve(Profile profile,
+                                           BoundedCurve curve,
+                                           double startSetback,
+                                           double endSetback,
+                                           double profileRotation,
+                                           double minimumChordLength = 0.01)
         {
-            return Solid.SweepFaceAlongCurve(profile.Perimeter, profile.Voids != null && profile.Voids.Count > 0 ? profile.Voids : null, curve, startSetback, endSetback, profileRotation);
+            return Solid.SweepFaceAlongCurve(profile.Perimeter,
+                                             profile.Voids != null && profile.Voids.Count > 0 ? profile.Voids : null,
+                                             curve,
+                                             startSetback,
+                                             endSetback,
+                                             profileRotation,
+                                             minimumChordLength);
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Kernel.cs
+++ b/Elements/src/Geometry/Kernel.cs
@@ -33,16 +33,14 @@ namespace Elements.Geometry
                                            BoundedCurve curve,
                                            double startSetback,
                                            double endSetback,
-                                           double profileRotation,
-                                           double minimumChordLength = 0.01)
+                                           double profileRotation)
         {
             return Solid.SweepFaceAlongCurve(profile.Perimeter,
                                              profile.Voids != null && profile.Voids.Count > 0 ? profile.Voids : null,
                                              curve,
                                              startSetback,
                                              endSetback,
-                                             profileRotation,
-                                             minimumChordLength);
+                                             profileRotation);
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -18,13 +18,18 @@ namespace Elements.Geometry
     public class Line : TrimmedCurve<InfiniteLine>, IEquatable<Line>
     {
         /// <summary>
+        /// The domain of the curve.
+        /// </summary>
+        [JsonIgnore]
+        public override Domain1d Domain => new Domain1d(this.Start.DistanceTo(BasisCurve.Origin), this.End.DistanceTo(BasisCurve.Origin));
+
+        /// <summary>
         /// Create a line of one unit length along the X axis.
         /// </summary>
         public Line()
         {
             this.Start = Vector3.Origin;
             this.End = new Vector3(1, 0, 0);
-            this.Domain = new Domain1d(0, 1);
             this.BasisCurve = new InfiniteLine(this.Start, (this.End - this.Start).Unitized());
         }
 
@@ -46,7 +51,6 @@ namespace Elements.Geometry
 
             this.Start = @start;
             this.End = @end;
-            this.Domain = new Domain1d(0, this.Start.DistanceTo(this.End));
             this.BasisCurve = new InfiniteLine(this.Start, (this.End - this.Start).Unitized());
         }
 
@@ -60,7 +64,6 @@ namespace Elements.Geometry
         {
             this.Start = start;
             this.End = start + direction.Unitized() * length;
-            this.Domain = new Domain1d(0, length);
             this.BasisCurve = new InfiniteLine(this.Start, direction);
         }
 
@@ -73,7 +76,6 @@ namespace Elements.Geometry
         public Line(InfiniteLine line, double startParameter, double endParameter)
         {
             this.BasisCurve = line;
-            this.Domain = new Domain1d(startParameter, endParameter);
             this.Start = this.BasisCurve.Origin + this.Domain.Min * this.BasisCurve.Direction;
             this.End = this.BasisCurve.Origin + this.Domain.Max * this.BasisCurve.Direction;
         }

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -91,7 +91,7 @@ namespace Elements.Geometry
         /// </summary>
         public override double ArcLength(double start, double end)
         {
-            return end - start;
+            return Math.Abs(end - start);
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -71,9 +71,7 @@ namespace Elements.Geometry
         /// Create a line from a trimmed segment of an infinite line.
         /// </summary>
         /// <param name="line">The infinite line from which this segment is trimmed.</param>
-        /// <param name="startParameter">The start parameter of the line segment.</param>
-        /// <param name="endParameter">The end parameter of the line segment.</param>
-        public Line(InfiniteLine line, double startParameter, double endParameter)
+        public Line(InfiniteLine line)
         {
             this.BasisCurve = line;
             this.Start = this.BasisCurve.Origin + this.Domain.Min * this.BasisCurve.Direction;

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -9,7 +9,7 @@ namespace Elements.Geometry
 {
     /// <summary>
     /// A line segment.
-    /// Parameterization of the line is  0(start)->length(end)
+    /// Parameterization of the line is  0 (start) -> length (end)
     /// </summary>
     /// <example>
     /// [!code-csharp[Main](../../Elements/test/LineTests.cs?name=example)]
@@ -107,16 +107,6 @@ namespace Elements.Geometry
                 throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve.");
             }
             return this.BasisCurve.TransformAt(u);
-        }
-
-        /// <summary>
-        /// Get the frame from the curve at parameter u.
-        /// </summary>
-        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
-        /// <returns>The transform of the curve at parameter u, with the transform's Z axis tangent to the curve.</returns>
-        public override Transform TransformAtNormalized(double u)
-        {
-            return TransformAt(u * Length());
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1343,12 +1343,10 @@ namespace Elements.Geometry
             return start + distance;
         }
 
-        /// <summary>
-        /// Get parameters to be used to find points along the curve for visualization.
-        /// </summary>
-        /// <param name="startSetbackDistance">An optional setback from the start of the curve.</param>
-        /// <param name="endSetbackDistance">An optional setback from the end of the curve.</param>
-        public override double[] GetSubdivisionParameters(double startSetbackDistance = 0, double endSetbackDistance = 0)
+        /// <inheritdoc/>
+        public override double[] GetSubdivisionParameters(double startSetbackDistance = 0,
+                                                          double endSetbackDistance = 0,
+                                                          double minimumChordLength = 0.01)
         {
             return new[] { ParameterAtDistanceFromParameter(startSetbackDistance, this.Domain.Min), ParameterAtDistanceFromParameter(this.Length() - endSetbackDistance, this.Domain.Min) };
         }

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1345,8 +1345,7 @@ namespace Elements.Geometry
 
         /// <inheritdoc/>
         public override double[] GetSubdivisionParameters(double startSetbackDistance = 0,
-                                                          double endSetbackDistance = 0,
-                                                          double minimumChordLength = 0.01)
+                                                          double endSetbackDistance = 0)
         {
             return new[] { ParameterAtDistanceFromParameter(startSetbackDistance, this.Domain.Min), ParameterAtDistanceFromParameter(this.Length() - endSetbackDistance, this.Domain.Min) };
         }

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -91,7 +91,7 @@ namespace Elements.Geometry
         /// <summary>
         /// Calculate the length of the line between two parameters.
         /// </summary>
-        public override double Length(double start, double end)
+        public override double ArcLength(double start, double end)
         {
             return end - start;
         }

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -124,20 +124,6 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Get a point along the line at parameter u.
-        /// </summary>
-        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
-        /// <returns>A point on the curve at parameter u.</returns>
-        public override Vector3 PointAtNormalized(double u)
-        {
-            if (u < 0 || u > 1)
-            {
-                throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between 0.0 and 1.0.");
-            }
-            return this.BasisCurve.PointAt(this.Domain.Min + u * Length());
-        }
-
-        /// <summary>
         /// Create new line transformed by transform.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -104,7 +104,7 @@ namespace Elements.Geometry
         /// <summary>
         /// Get a point along the line at parameter u.
         /// </summary>
-        /// <param name="u"></param>
+        /// <param name="u">A parameter on the curve between 0.0 and length.</param>
         /// <returns>A point on the curve at parameter u.</returns>
         public override Vector3 PointAt(double u)
         {
@@ -113,6 +113,20 @@ namespace Elements.Geometry
                 throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between {Domain.Min} and {Domain.Max}.");
             }
             return this.BasisCurve.PointAt(u);
+        }
+
+        /// <summary>
+        /// Get a point along the line at parameter u.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>A point on the curve at parameter u.</returns>
+        public override Vector3 PointAtNormalized(double u)
+        {
+            if (u < 0 || u > 1)
+            {
+                throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between 0.0 and 1.0.");
+            }
+            return this.BasisCurve.PointAt(this.Domain.Min + u * Length());
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -123,10 +123,7 @@ namespace Elements.Geometry
             return this.BasisCurve.PointAt(u);
         }
 
-        /// <summary>
-        /// Create new line transformed by transform.
-        /// </summary>
-        /// <param name="transform">The transform to apply.</param>
+        /// <inheritdoc/>
         public override Curve Transformed(Transform transform)
         {
             if (transform == null)

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -9,7 +9,7 @@ namespace Elements.Geometry
 {
     /// <summary>
     /// A line segment.
-    /// Parameterization of the line is  0 (start) -> length (end)
+    /// Parameterization of the line is  0(start)->length(end)
     /// </summary>
     /// <example>
     /// [!code-csharp[Main](../../Elements/test/LineTests.cs?name=example)]
@@ -87,6 +87,14 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Calculate the length of the line between two parameters.
+        /// </summary>
+        public override double Length(double start, double end)
+        {
+            return end - start;
+        }
+
+        /// <summary>
         /// Get a transform whose XY plane is perpendicular to the curve, and whose
         /// positive Z axis points along the curve.
         /// </summary>
@@ -99,6 +107,16 @@ namespace Elements.Geometry
                 throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve.");
             }
             return this.BasisCurve.TransformAt(u);
+        }
+
+        /// <summary>
+        /// Get the frame from the curve at parameter u.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>The transform of the curve at parameter u, with the transform's Z axis tangent to the curve.</returns>
+        public override Transform TransformAtNormalized(double u)
+        {
+            return TransformAt(u * Length());
         }
 
         /// <summary>

--- a/Elements/src/Geometry/NormalizationType.cs
+++ b/Elements/src/Geometry/NormalizationType.cs
@@ -1,0 +1,21 @@
+namespace Elements.Geometry
+{
+    /// <summary>
+    /// Normalization type.
+    /// </summary>
+    public enum NormalizationType
+    {
+        /// <summary>
+        /// During normalization move start points of segments.
+        /// </summary>
+        Start,
+        /// <summary>
+        /// During normalization move end points of segments.
+        /// </summary>
+        End,
+        /// <summary>
+        /// During normalization move both start and end vertices in approximately equivalent proportions.
+        /// </summary>
+        Middle
+    }
+}

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -1735,10 +1735,7 @@ namespace Elements.Geometry
         }
 
 
-        /// <summary>
-        /// Get a collection a lines representing each segment of this polyline.
-        /// </summary>
-        /// <returns>A collection of Lines.</returns>
+        /// <inheritdoc/>
         public override Line[] Segments()
         {
             return SegmentsInternal(this.Vertices);
@@ -2218,7 +2215,7 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="radius">The fillet radius.</param>
         /// <returns>A contour containing trimmed edge segments and fillets.</returns>
-        public IndexedPolycurve Fillet(double radius)
+        public new IndexedPolycurve Fillet(double radius)
         {
             var curves = new List<BoundedCurve>();
             var segments = this.Segments();

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -1,7 +1,6 @@
 using ClipperLib;
 using Elements.Search;
 using Elements.Spatial;
-using LibTessDotNet.Double;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -2408,127 +2407,6 @@ namespace Elements.Geometry
                 }
             }
             return polygons;
-        }
-    }
-
-    /// <summary>
-    /// Mode to apply a boolean operation
-    /// </summary>
-    public enum BooleanMode
-    {
-        /// <summary>
-        /// A and not B
-        /// </summary>
-        Difference,
-        /// <summary>
-        /// A or B
-        /// </summary>
-        Union,
-        /// <summary>
-        /// A and B
-        /// </summary>
-        Intersection,
-        /// <summary>
-        /// Exclusive or — either A or B but not both.
-        /// </summary>
-        XOr
-    }
-
-
-    /// <summary>
-    /// Controls the handling of internal regions in a polygon boolean operation.
-    /// </summary>
-    public enum VoidTreatment
-    {
-        /// <summary>
-        /// Use an Even/Odd fill pattern to decide whether internal polygons are solid or void.
-        /// This corresponds to Clipper's "EvenOdd" PolyFillType.
-        /// </summary>
-        PreserveInternalVoids = 0,
-        /// <summary>
-        /// Treat all contained or overlapping polygons as solid.
-        /// This corresponds to Clipper's "Positive" PolyFillType.
-        /// </summary>
-        IgnoreInternalVoids = 1
-    }
-
-    /// <summary>
-    /// Polygon extension methods.
-    /// </summary>
-    internal static class PolygonExtensions
-    {
-        /// <summary>
-        /// Construct a clipper path from a Polygon.
-        /// </summary>
-        /// <param name="p"></param>
-        /// <param name="tolerance">Optional tolerance value. If converting back to a polygon after the operation, be sure to use the same tolerance value.</param>
-        /// <returns></returns>
-        internal static List<IntPoint> ToClipperPath(this Polygon p, double tolerance = Vector3.EPSILON)
-        {
-            var scale = Math.Round(1.0 / tolerance);
-            var path = new List<IntPoint>();
-            foreach (var v in p.Vertices)
-            {
-                path.Add(new IntPoint(Math.Round(v.X * scale), Math.Round(v.Y * scale)));
-            }
-            return path;
-        }
-
-        /// <summary>
-        /// Construct a Polygon from a clipper path
-        /// </summary>
-        /// <param name="p"></param>
-        /// <param name="tolerance">Optional tolerance value. Be sure to use the same tolerance value as you used when converting to Clipper path.</param>
-        /// <returns></returns>
-        internal static Polygon ToPolygon(this List<IntPoint> p, double tolerance = Vector3.EPSILON)
-        {
-            var scale = Math.Round(1.0 / tolerance);
-            var converted = new Vector3[p.Count];
-            for (var i = 0; i < converted.Length; i++)
-            {
-                var v = p[i];
-                converted[i] = new Vector3(v.X / scale, v.Y / scale);
-            }
-            try
-            {
-                return new Polygon(converted);
-            }
-            catch
-            {
-                // Often, the polygons coming back from clipper will have self-intersections, in the form of lines that go out and back.
-                // here we make a last-ditch attempt to fix this and construct a new polygon.
-                var cleanedVertices = Vector3.AttemptPostClipperCleanup(converted);
-                if (cleanedVertices.Count < 3)
-                {
-                    return null;
-                }
-                try
-                {
-                    return new Polygon(cleanedVertices);
-                }
-                catch
-                {
-                    throw new Exception("Unable to clean up bad polygon resulting from a polygon boolean operation.");
-                }
-            }
-        }
-
-        public static IList<Polygon> Reversed(this IList<Polygon> polygons)
-        {
-            return polygons.Select(p => p.Reversed()).ToArray();
-        }
-
-        internal static ContourVertex[] ToContourVertexArray(this Polyline poly)
-        {
-            var contour = new ContourVertex[poly.Vertices.Count];
-            for (var i = 0; i < poly.Vertices.Count; i++)
-            {
-                var vert = poly.Vertices[i];
-                var cv = new ContourVertex();
-                cv.Position = new Vec3 { X = vert.X, Y = vert.Y, Z = vert.Z };
-                contour[i] = cv;
-            }
-            return contour;
         }
     }
 }

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -2171,29 +2171,25 @@ namespace Elements.Geometry
         /// </summary>
         /// <param name="radius">The fillet radius.</param>
         /// <returns>A contour containing trimmed edge segments and fillets.</returns>
-        public Contour Fillet(double radius)
+        public IndexedPolycurve Fillet(double radius)
         {
             var curves = new List<BoundedCurve>();
             var segments = this.Segments();
-            var arcs = new List<Arc>();
 
             for (var i = 0; i < segments.Length; i++)
             {
                 var a = segments[i];
                 var b = segments[i == segments.Length - 1 ? 0 : i + 1];
-                var arc = a.Fillet(b, 0.5);
-                arcs.Add(arc);
+                var arc = b.Fillet(a, 0.5);
+                if (i > 0)
+                {
+                    curves.Add(new Line(curves[curves.Count - 1].End, arc.Start));
+                }
+                curves.Add(arc);
             }
+            curves.Add(new Line(curves[curves.Count - 1].End, curves[0].Start));
 
-            for (var i = 0; i < arcs.Count; i++)
-            {
-                var a = arcs[i];
-                var b = arcs[i == arcs.Count - 1 ? 0 : i + 1];
-                curves.Add(new Line(a.Start, b.End));
-                curves.Add(b);
-            }
-
-            return new Contour(curves);
+            return new IndexedPolycurve(curves);
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -2075,8 +2075,7 @@ namespace Elements.Geometry
         /// <inheritdoc/>
         public override Transform[] Frames(double startSetback = 0.0,
                                            double endSetback = 0.0,
-                                           double additionalRotation = 0.0,
-                                           double minimumChordLength = 0.01)
+                                           double additionalRotation = 0.0)
         {
             // Create an array of transforms with the same
             // number of items as the vertices.

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -2235,7 +2235,7 @@ namespace Elements.Geometry
             {
                 var a = segments[i];
                 var b = segments[i == segments.Length - 1 ? 0 : i + 1];
-                var arc = b.Fillet(a, 0.5);
+                var arc = b.Fillet(a, radius);
                 if (i > 0)
                 {
                     curves.Add(new Line(curves[curves.Count - 1].End, arc.Start));

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -2072,15 +2072,11 @@ namespace Elements.Geometry
             return new Polygon(unique);
         }
 
-        /// <summary>
-        /// Get the transforms used to transform a Profile extruded along this Polyline.
-        /// </summary>
-        /// <param name="startSetback"></param>
-        /// <param name="endSetback"></param>
-        /// <param name="additionalRotation"></param>
+        /// <inheritdoc/>
         public override Transform[] Frames(double startSetback = 0.0,
                                            double endSetback = 0.0,
-                                           double additionalRotation = 0.0)
+                                           double additionalRotation = 0.0,
+                                           double minimumChordLength = 0.01)
         {
             // Create an array of transforms with the same
             // number of items as the vertices.

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -146,10 +146,7 @@ namespace Elements.Geometry
             return p;
         }
 
-        /// <summary>
-        /// Construct a transformed copy of this Curve.
-        /// </summary>
-        /// <param name="transform">The transform to apply.</param>
+        /// <inheritdoc/>
         public override Curve Transformed(Transform transform)
         {
             if (transform == null)

--- a/Elements/src/Geometry/PolygonExtensions.cs
+++ b/Elements/src/Geometry/PolygonExtensions.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using ClipperLib;
+using LibTessDotNet.Double;
+using System.Linq;
+
+namespace Elements.Geometry
+{
+    /// <summary>
+    /// Polygon extension methods.
+    /// </summary>
+    internal static class PolygonExtensions
+    {
+        /// <summary>
+        /// Construct a clipper path from a Polygon.
+        /// </summary>
+        /// <param name="p"></param>
+        /// <param name="tolerance">Optional tolerance value. If converting back to a polygon after the operation, be sure to use the same tolerance value.</param>
+        /// <returns></returns>
+        internal static List<IntPoint> ToClipperPath(this Polygon p, double tolerance = Vector3.EPSILON)
+        {
+            var scale = Math.Round(1.0 / tolerance);
+            var path = new List<IntPoint>();
+            foreach (var v in p.Vertices)
+            {
+                path.Add(new IntPoint(Math.Round(v.X * scale), Math.Round(v.Y * scale)));
+            }
+            return path;
+        }
+
+        /// <summary>
+        /// Construct a Polygon from a clipper path
+        /// </summary>
+        /// <param name="p"></param>
+        /// <param name="tolerance">Optional tolerance value. Be sure to use the same tolerance value as you used when converting to Clipper path.</param>
+        /// <returns></returns>
+        internal static Polygon ToPolygon(this List<IntPoint> p, double tolerance = Vector3.EPSILON)
+        {
+            var scale = Math.Round(1.0 / tolerance);
+            var converted = new Vector3[p.Count];
+            for (var i = 0; i < converted.Length; i++)
+            {
+                var v = p[i];
+                converted[i] = new Vector3(v.X / scale, v.Y / scale);
+            }
+            try
+            {
+                return new Polygon(converted);
+            }
+            catch
+            {
+                // Often, the polygons coming back from clipper will have self-intersections, in the form of lines that go out and back.
+                // here we make a last-ditch attempt to fix this and construct a new polygon.
+                var cleanedVertices = Vector3.AttemptPostClipperCleanup(converted);
+                if (cleanedVertices.Count < 3)
+                {
+                    return null;
+                }
+                try
+                {
+                    return new Polygon(cleanedVertices);
+                }
+                catch
+                {
+                    throw new Exception("Unable to clean up bad polygon resulting from a polygon boolean operation.");
+                }
+            }
+        }
+
+        public static IList<Polygon> Reversed(this IList<Polygon> polygons)
+        {
+            return polygons.Select(p => p.Reversed()).ToArray();
+        }
+
+        internal static ContourVertex[] ToContourVertexArray(this Polyline poly)
+        {
+            var contour = new ContourVertex[poly.Vertices.Count];
+            for (var i = 0; i < poly.Vertices.Count; i++)
+            {
+                var vert = poly.Vertices[i];
+                var cv = new ContourVertex();
+                cv.Position = new Vec3 { X = vert.X, Y = vert.Y, Z = vert.Z };
+                contour[i] = cv;
+            }
+            return contour;
+        }
+    }
+}

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -9,7 +9,7 @@ namespace Elements.Geometry
 {
     /// <summary>
     /// A continuous set of lines.
-    /// Parameterization of the curve is 0 -> length.
+    /// Parameterization of the curve is 0->length.
     /// </summary>
     /// <example>
     /// [!code-csharp[Main](../../Elements/test/PolylineTests.cs?name=example)]
@@ -144,6 +144,16 @@ namespace Elements.Geometry
                 totalLength += currLength;
             }
             return new Transform(o, x, normal, x.Cross(normal));
+        }
+
+        /// <summary>
+        /// Get the frame from the curve at parameter u.
+        /// </summary>
+        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
+        /// <returns>The transform of the curve at parameter u, with the transform's Z axis tangent to the curve.</returns>
+        public override Transform TransformAtNormalized(double u)
+        {
+            return TransformAt(u * this.Length());
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -76,10 +76,9 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Get a collection a lines representing each segment of this polyline.
+        /// Get a collection a line segments which connect the vertices of this polyline.
         /// </summary>
         /// <returns>A collection of Lines.</returns>
-        [Obsolete("Please use for each to get sub curves.")]
         public virtual Line[] Segments()
         {
             return SegmentsInternal(this.Vertices);

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -284,15 +284,11 @@ namespace Elements.Geometry
             return result;
         }
 
-        /// <summary>
-        /// Get the transforms used to transform a Profile extruded along this Polyline.
-        /// </summary>
-        /// <param name="startSetbackDistance"></param>
-        /// <param name="endSetbackDistance"></param>
-        /// <param name="additionalRotation"></param>
+        /// <inheritdoc/>
         public override Transform[] Frames(double startSetbackDistance = 0.0,
                                            double endSetbackDistance = 0.0,
-                                           double additionalRotation = 0.0)
+                                           double additionalRotation = 0.0,
+                                           double minimumChordLength = 0.01)
         {
             var normals = this.NormalsAtVertices();
 

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -147,16 +147,6 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Get the frame from the curve at parameter u.
-        /// </summary>
-        /// <param name="u">A parameter on the curve between 0.0 and 1.0.</param>
-        /// <returns>The transform of the curve at parameter u, with the transform's Z axis tangent to the curve.</returns>
-        public override Transform TransformAtNormalized(double u)
-        {
-            return TransformAt(u * this.Length());
-        }
-
-        /// <summary>
         /// Construct a transformed copy of this Polyline.
         /// </summary>
         /// <param name="transform">The transform to apply.</param>

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -15,20 +15,8 @@ namespace Elements.Geometry
     /// <example>
     /// [!code-csharp[Main](../../Elements/test/PolylineTests.cs?name=example)]
     /// </example>
-    public class Polyline : BoundedCurve, IEquatable<Polyline>
+    public class Polyline : IndexedPolycurve, IEquatable<Polyline>
     {
-        /// <summary>
-        /// A bounding box created once during the polyline's construction.
-        /// This will not be updated when a polyline's vertices are changed.
-        /// </summary>
-        internal BBox3 _bounds;
-
-        /// <summary>The vertices of the polygon.</summary>
-        [JsonProperty("Vertices", Required = Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
-        [System.ComponentModel.DataAnnotations.MinLength(2)]
-        public IList<Vector3> Vertices { get; set; } = new List<Vector3>();
-
         /// <summary>
         /// Construct a polyline.
         /// </summary>
@@ -1468,73 +1456,5 @@ namespace Elements.Geometry
 
             return parameters;
         }
-    }
-
-    /// <summary>
-    /// Polyline extension methods.
-    /// </summary>
-    internal static class PolylineExtensions
-    {
-        /// <summary>
-        /// Construct a clipper path from a Polygon.
-        /// </summary>
-        /// <param name="p"></param>
-        /// <param name="tolerance">An optional tolerance. If converting back to a Polyline, be sure to use the same tolerance.</param>
-        /// <returns></returns>
-        internal static List<IntPoint> ToClipperPath(this Polyline p, double tolerance = Vector3.EPSILON)
-        {
-            var clipperScale = Math.Round(1.0 / tolerance);
-            var path = new List<IntPoint>();
-            foreach (var v in p.Vertices)
-            {
-                path.Add(new IntPoint(Math.Round(v.X * clipperScale), Math.Round(v.Y * clipperScale)));
-            }
-            return path;
-        }
-
-        /// <summary>
-        /// Convert a line to a polyline
-        /// </summary>
-        /// <param name="l">The line to convert.</param>
-        public static Polyline ToPolyline(this Line l) => new Polyline(new[] { l.Start, l.End });
-
-    }
-
-    /// <summary>
-    /// Offset end types
-    /// </summary>
-    public enum EndType
-    {
-        /// <summary>
-        /// Open ends are extended by the offset distance and squared off
-        /// </summary>
-        Square,
-        /// <summary>
-        /// Ends are squared off with no extension
-        /// </summary>
-        Butt,
-        /// <summary>
-        /// If open, ends are joined and treated as a closed polygon
-        /// </summary>
-        ClosedPolygon,
-    }
-
-    /// <summary>
-    /// Normalization type.
-    /// </summary>
-    public enum NormalizationType
-    {
-        /// <summary>
-        /// During normalization move start points of segments.
-        /// </summary>
-        Start,
-        /// <summary>
-        /// During normalization move end points of segments.
-        /// </summary>
-        End,
-        /// <summary>
-        /// During normalization move both start and end vertices in approximately equivalent proportions.
-        /// </summary>
-        Middle
     }
 }

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -395,11 +395,6 @@ namespace Elements.Geometry
         /// <returns>Returns a Vector3 indicating a point along the Polygon length from its start vertex.</returns>
         protected override Vector3 PointAtInternal(double u, out int curveIndex)
         {
-            if (!Domain.Includes(u, true))
-            {
-                throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between {Domain.Min} and {Domain.Max}.");
-            }
-
             var totalLength = 0.0;
             for (var i = 0; i < this.Vertices.Count - 1; i++)
             {

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -303,7 +303,7 @@ namespace Elements.Geometry
                 {
                     a = PointAt(ParameterAtDistanceFromParameter(startSetbackDistance, this.Domain.Min));
                 }
-                else if (i == Vertices.Count)
+                else if (i == Vertices.Count - 1)
                 {
                     a = PointAt(ParameterAtDistanceFromParameter(l - endSetbackDistance, this.Domain.Min));
                 }

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -17,6 +17,12 @@ namespace Elements.Geometry
     public class Polyline : IndexedPolycurve
     {
         /// <summary>
+        /// The domain of the curve.
+        /// </summary>
+        [JsonIgnore]
+        public override Domain1d Domain => new Domain1d(0, Vertices.Count - 1);
+
+        /// <summary>
         /// Construct a polyline.
         /// </summary>
         /// <param name="vertices">A collection of vertex locations.</param>

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -1206,5 +1206,35 @@ namespace Elements.Geometry
                 return null;
             }
         }
+
+        /// <summary>
+        /// Fillet all corners on this polygon.
+        /// </summary>
+        /// <param name="radius">The fillet radius.</param>
+        /// <returns>A contour containing trimmed edge segments and fillets.</returns>
+        public IndexedPolycurve Fillet(double radius)
+        {
+            var curves = new List<BoundedCurve>();
+            var segments = this.Segments();
+
+            for (var i = 0; i < segments.Length - 1; i++)
+            {
+                var a = segments[i];
+                var b = segments[i + 1];
+                var arc = b.Fillet(a, radius);
+                if (i == 0)
+                {
+                    curves.Add(new Line(Start, arc.Start));
+                }
+                else
+                {
+                    curves.Add(new Line(curves[curves.Count - 1].End, arc.Start));
+                }
+                curves.Add(arc);
+            }
+            curves.Add(new Line(curves[curves.Count - 1].End, End));
+
+            return new IndexedPolycurve(curves);
+        }
     }
 }

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -73,17 +73,16 @@ namespace Elements.Geometry
         /// Get a collection a lines representing each segment of this polyline.
         /// </summary>
         /// <returns>A collection of Lines.</returns>
-        [Obsolete("Use the enumerator to get curves instead.")]
         public virtual Line[] Segments()
         {
             return SegmentsInternal(this.Vertices);
         }
 
         /// <summary>
-        /// Get the Transform at the specified parameter along the Polygon.
+        /// Get the transform at the specified parameter along the polyline.
         /// </summary>
-        /// <param name="u">The parameter on the Polygon between 0.0 and 1.0.</param>
-        /// <returns>A Transform with its Z axis aligned trangent to the Polygon.</returns>
+        /// <param name="u">The parameter on the polygon between 0.0 and length.</param>
+        /// <returns>A transform with its Z axis aligned trangent to the polyline.</returns>
         public override Transform TransformAt(double u)
         {
             if (!Domain.Includes(u, true))

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -287,8 +287,7 @@ namespace Elements.Geometry
         /// <inheritdoc/>
         public override Transform[] Frames(double startSetbackDistance = 0.0,
                                            double endSetbackDistance = 0.0,
-                                           double additionalRotation = 0.0,
-                                           double minimumChordLength = 0.01)
+                                           double additionalRotation = 0.0)
         {
             var normals = this.NormalsAtVertices();
 

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -173,10 +173,7 @@ namespace Elements.Geometry
             return p;
         }
 
-        /// <summary>
-        /// Construct a transformed copy of this Curve.
-        /// </summary>
-        /// <param name="transform">The transform to apply.</param>
+        /// <inheritdoc/>
         public override Curve Transformed(Transform transform)
         {
             if (transform == null)

--- a/Elements/src/Geometry/PolylineExtensions.cs
+++ b/Elements/src/Geometry/PolylineExtensions.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using ClipperLib;
+
+namespace Elements.Geometry
+{
+    /// <summary>
+    /// Polyline extension methods.
+    /// </summary>
+    internal static class PolylineExtensions
+    {
+        /// <summary>
+        /// Construct a clipper path from a Polygon.
+        /// </summary>
+        /// <param name="p"></param>
+        /// <param name="tolerance">An optional tolerance. If converting back to a Polyline, be sure to use the same tolerance.</param>
+        /// <returns></returns>
+        internal static List<IntPoint> ToClipperPath(this Polyline p, double tolerance = Vector3.EPSILON)
+        {
+            var clipperScale = Math.Round(1.0 / tolerance);
+            var path = new List<IntPoint>();
+            foreach (var v in p.Vertices)
+            {
+                path.Add(new IntPoint(Math.Round(v.X * clipperScale), Math.Round(v.Y * clipperScale)));
+            }
+            return path;
+        }
+
+        /// <summary>
+        /// Convert a line to a polyline
+        /// </summary>
+        /// <param name="l">The line to convert.</param>
+        public static Polyline ToPolyline(this Line l) => new Polyline(new[] { l.Start, l.End });
+
+    }
+}

--- a/Elements/src/Geometry/Solids/Solid.cs
+++ b/Elements/src/Geometry/Solids/Solid.cs
@@ -107,13 +107,15 @@ namespace Elements.Geometry.Solids
         /// <param name="startSetback">The setback distance of the sweep from the start of the curve.</param>
         /// <param name="endSetback">The setback distance of the sweep from the end of the curve.</param>
         /// <param name="profileRotation">The rotation of the profile.</param>
+        /// <param name="minimumChordLength">The minimum chord length allowed for subdivision of the curve. A smaller MinimumChordLength results in smoother curves.</param>
         /// <returns>A solid.</returns>
         public static Solid SweepFaceAlongCurve(Polygon perimeter,
                                                 IList<Polygon> holes,
                                                 IBoundedCurve curve,
                                                 double startSetback = 0,
                                                 double endSetback = 0,
-                                                double profileRotation = 0)
+                                                double profileRotation = 0,
+                                                double minimumChordLength = 0.01)
         {
             var solid = new Solid();
 

--- a/Elements/src/Geometry/Solids/Solid.cs
+++ b/Elements/src/Geometry/Solids/Solid.cs
@@ -107,15 +107,13 @@ namespace Elements.Geometry.Solids
         /// <param name="startSetback">The setback distance of the sweep from the start of the curve.</param>
         /// <param name="endSetback">The setback distance of the sweep from the end of the curve.</param>
         /// <param name="profileRotation">The rotation of the profile.</param>
-        /// <param name="minimumChordLength">The minimum chord length allowed for subdivision of the curve. A smaller MinimumChordLength results in smoother curves.</param>
         /// <returns>A solid.</returns>
         public static Solid SweepFaceAlongCurve(Polygon perimeter,
                                                 IList<Polygon> holes,
                                                 IBoundedCurve curve,
                                                 double startSetback = 0,
                                                 double endSetback = 0,
-                                                double profileRotation = 0,
-                                                double minimumChordLength = 0.01)
+                                                double profileRotation = 0)
         {
             var solid = new Solid();
 

--- a/Elements/src/Geometry/VoidTreatment.cs
+++ b/Elements/src/Geometry/VoidTreatment.cs
@@ -1,0 +1,19 @@
+namespace Elements.Geometry
+{
+    /// <summary>
+    /// Controls the handling of internal regions in a polygon boolean operation.
+    /// </summary>
+    public enum VoidTreatment
+    {
+        /// <summary>
+        /// Use an Even/Odd fill pattern to decide whether internal polygons are solid or void.
+        /// This corresponds to Clipper's "EvenOdd" PolyFillType.
+        /// </summary>
+        PreserveInternalVoids = 0,
+        /// <summary>
+        /// Treat all contained or overlapping polygons as solid.
+        /// This corresponds to Clipper's "Positive" PolyFillType.
+        /// </summary>
+        IgnoreInternalVoids = 1
+    }
+}

--- a/Elements/src/Spatial/Grid1d.cs
+++ b/Elements/src/Spatial/Grid1d.cs
@@ -67,7 +67,6 @@ namespace Elements.Spatial
             }
         }
 
-
         /// <summary>
         /// Returns true if this 1D Grid has no subdivisions / sub-grids.
         /// </summary>
@@ -188,7 +187,7 @@ namespace Elements.Spatial
         public Grid1d(BoundedCurve curve)
         {
             this.curve = curve;
-            Domain = new Domain1d(0, curve.Length());
+            Domain = curve.Domain;
             curveDomain = Domain;
         }
 
@@ -400,29 +399,28 @@ namespace Elements.Spatial
             {
                 point = parent.toGrid.OfPoint(point);
             }
-            if (Curve is Polyline pl && pl.Segments().Count() > 1)
+            if (Curve is Polyline pl)
             {
-                var minDist = Double.MaxValue;
-                Line[] segments = pl.Segments();
-                int closestSegment = -1;
-                for (int i = 0; i < segments.Length; i++)
+                var segments = pl.Segments();
+                if (segments.Count() > 1)
                 {
-                    Line seg = segments[i];
-                    var cp = point.ClosestPointOn(seg);
-                    var dist = cp.DistanceTo(point);
-                    if (dist < minDist)
+                    var minDist = Double.MaxValue;
+                    var localParam = 0.0;
+                    int closestSegment = -1;
+                    for (int i = 0; i < segments.Length; i++)
                     {
-                        minDist = dist;
-                        closestSegment = i;
+                        Line seg = segments[i];
+                        var cp = point.ClosestPointOn(seg);
+                        var dist = cp.DistanceTo(point);
+                        if (dist < minDist)
+                        {
+                            minDist = dist;
+                            closestSegment = i;
+                            localParam = cp.DistanceTo(seg.Start) / seg.Length();
+                        }
                     }
+                    return closestSegment + localParam;
                 }
-                double curvePosition = 0.0;
-                for (int i = 0; i < closestSegment; i++)
-                {
-                    curvePosition += segments[i].Length();
-                }
-                curvePosition += segments[closestSegment].Start.DistanceTo(point);
-                return curvePosition;
             }
             var A = Curve.Start;
             var B = Curve.End;
@@ -483,7 +481,9 @@ namespace Elements.Spatial
             {
                 throw new ArgumentException($"Unable to divide. Target Length {targetLength} is too small.");
             }
-            var numDivisions = Math.Max(1, Domain.Length / targetLength);
+
+            var arcLength = Curve.Length(Domain.Min, Domain.Max);
+            var numDivisions = Math.Max(1, arcLength / targetLength);
             int roundedDivisions;
             switch (divisionMode)
             {

--- a/Elements/src/Spatial/Grid1d.cs
+++ b/Elements/src/Spatial/Grid1d.cs
@@ -482,7 +482,7 @@ namespace Elements.Spatial
                 throw new ArgumentException($"Unable to divide. Target Length {targetLength} is too small.");
             }
 
-            var arcLength = Curve.Length(Domain.Min, Domain.Max);
+            var arcLength = Curve.ArcLength(Domain.Min, Domain.Max);
             var numDivisions = Math.Max(1, arcLength / targetLength);
             int roundedDivisions;
             switch (divisionMode)

--- a/Elements/src/StructuralFraming.cs
+++ b/Elements/src/StructuralFraming.cs
@@ -121,9 +121,8 @@ namespace Elements
         {
             if (this.Representation.SolidOperations.Count == 0)
             {
-                if (this.Curve.GetType() == typeof(IndexedPolycurve))
+                if (this.Curve is IndexedPolycurve pc)
                 {
-                    var pc = this.Curve as IndexedPolycurve;
                     foreach (var curve in pc)
                     {
                         this.Representation.SolidOperations.Add(new Sweep(this.Profile,

--- a/Elements/src/StructuralFraming.cs
+++ b/Elements/src/StructuralFraming.cs
@@ -121,12 +121,28 @@ namespace Elements
         {
             if (this.Representation.SolidOperations.Count == 0)
             {
-                this.Representation.SolidOperations.Add(new Sweep(this.Profile,
-                                                            this.Curve,
-                                                            this.StartSetback,
-                                                            this.EndSetback,
-                                                            this.Rotation,
-                                                            false));
+                if (this.Curve.GetType() == typeof(IndexedPolycurve))
+                {
+                    var pc = this.Curve as IndexedPolycurve;
+                    foreach (var curve in pc)
+                    {
+                        this.Representation.SolidOperations.Add(new Sweep(this.Profile,
+                                                                curve,
+                                                                this.StartSetback,
+                                                                this.EndSetback,
+                                                                this.Rotation,
+                                                                false));
+                    }
+                }
+                else
+                {
+                    this.Representation.SolidOperations.Add(new Sweep(this.Profile,
+                                                                this.Curve,
+                                                                this.StartSetback,
+                                                                this.EndSetback,
+                                                                this.Rotation,
+                                                                false));
+                }
             }
         }
     }

--- a/Elements/test/ArcTests.cs
+++ b/Elements/test/ArcTests.cs
@@ -304,11 +304,11 @@ namespace Hypar.Tests
             var testParam = 0.24;
             var equivalentTestParam = 0.0;
 
-            if (curve is Line || curve is Polyline)
+            if (curve is Line)
             {
                 equivalentTestParam = curve.Length() * testParam;
             }
-            else if (curve is Arc || curve is EllipticalArc)
+            else
             {
                 equivalentTestParam = curve.Domain.Min + curve.Domain.Length * testParam;
             }

--- a/Elements/test/CsgTests.cs
+++ b/Elements/test/CsgTests.cs
@@ -63,7 +63,7 @@ namespace Elements.Tests
         public void Difference()
         {
             this.Name = "CSG_Difference";
-            var profile = _profileFactory.GetProfileByType(HSSPipeProfileType.HSS10_000x0_188);
+            var profile = Polygon.Rectangle(0.5, 0.5);
 
             var path = new Arc(Vector3.Origin, 5, 0, 270);
             var beam = new Beam(path, profile);
@@ -71,7 +71,7 @@ namespace Elements.Tests
             var s2 = new Extrude(new Circle(Vector3.Origin, 6).ToPolygon(20), 1, Vector3.ZAxis, true);
             beam.Representation.SolidOperations.Add(s2);
 
-            for (var i = path.Domain.Min; i < path.Domain.Max; i += 0.05)
+            for (var i = path.Domain.Min; i < path.Domain.Max; i += 0.1)
             {
                 var pt = path.PointAt(i);
                 var hole = new Extrude(new Circle(Vector3.Origin, 0.05).ToPolygon(), 3, Vector3.ZAxis, true)

--- a/Elements/test/IndexedPolyCurveTests.cs
+++ b/Elements/test/IndexedPolyCurveTests.cs
@@ -26,6 +26,9 @@ namespace Elements.Tests
             };
             var pc = new IndexedPolycurve(vertices, indices);
             Model.AddElement(new ModelCurve(pc));
+
+            var t = pc.TransformAt(1.5);
+            Model.AddElements(t.ToModelCurves());
         }
     }
 }

--- a/Elements/test/IndexedPolyCurveTests.cs
+++ b/Elements/test/IndexedPolyCurveTests.cs
@@ -1,0 +1,31 @@
+using Elements.Geometry;
+using Xunit;
+
+namespace Elements.Tests
+{
+    public class IndexedPolycurveTests : ModelTest
+    {
+        [Fact]
+        public void IndexedPolycurve()
+        {
+            Name = nameof(IndexedPolycurve);
+
+            var line = new Line(Vector3.Origin, new Vector3(0, 5, 0));
+            var line1 = new Line(new Vector3(5, 5, 0), new Vector3(5, 0, 0));
+            var arc = new Arc(new Vector3(2.5, 5), 2.5, 0, 180);
+            var a = new Vector3(5, 0, 0);
+            var b = new Vector3(5, 5, 0);
+            var c = arc.Mid();
+            var d = new Vector3(0, 5, 0);
+            var e = Vector3.Origin;
+            var vertices = new[] { a, b, c, d, e };
+            var indices = new[]{
+                new[]{0,1},
+                new[]{1,2,3},
+                new[]{3,4}
+            };
+            var pc = new IndexedPolycurve(vertices, indices);
+            Model.AddElement(new ModelCurve(pc));
+        }
+    }
+}

--- a/Elements/test/IndexedPolyCurveTests.cs
+++ b/Elements/test/IndexedPolyCurveTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Elements.Geometry;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Elements.Tests
@@ -130,6 +131,18 @@ namespace Elements.Tests
             var plineRVerts = pline.RenderVertices();
             Assert.Equal(6, pgonRVerts.Count);
             Assert.Equal(5, plineRVerts.Count);
+        }
+
+        [Fact]
+        public void Serialization()
+        {
+            var pc = CreateTestPolycurve();
+            var json = JsonConvert.SerializeObject(pc);
+            var pc2 = JsonConvert.DeserializeObject<IndexedPolycurve>(json);
+            var mc1 = new ModelCurve(pc, BuiltInMaterials.XAxis);
+            var mc2 = new ModelCurve(pc2, BuiltInMaterials.YAxis);
+            Assert.Equal(pc.Vertices, pc2.Vertices);
+            Assert.Equal(pc._bounds, pc2._bounds);
         }
     }
 }

--- a/Elements/test/IndexedPolyCurveTests.cs
+++ b/Elements/test/IndexedPolyCurveTests.cs
@@ -31,7 +31,11 @@ namespace Elements.Tests
             Model.AddElements(t.ToModelCurves());
 
             var t1 = new Transform(Vector3.Origin, Vector3.XAxis);
-            Model.AddElement(new ModelCurve(pc.TransformedPolycurve(t1)));
+            var pc1 = pc.TransformedPolycurve(t1);
+            Model.AddElement(new ModelCurve(pc1));
+
+            var t2 = pc1.TransformAt(1.5);
+            Model.AddElements(t2.ToModelCurves());
         }
 
         [Fact]

--- a/Elements/test/IndexedPolyCurveTests.cs
+++ b/Elements/test/IndexedPolyCurveTests.cs
@@ -10,6 +10,7 @@ namespace Elements.Tests
         {
             Name = nameof(IndexedPolycurve);
 
+            // <example>
             var arc = new Arc(new Vector3(2.5, 5), 2.5, 0, 180);
 
             var a = new Vector3(5, 0, 0);
@@ -25,6 +26,8 @@ namespace Elements.Tests
             };
 
             var pc = new IndexedPolycurve(vertices, indices);
+            // </example>
+
             Model.AddElement(new ModelCurve(pc));
 
             var t = pc.TransformAt(1.5);
@@ -55,6 +58,37 @@ namespace Elements.Tests
                     Model.AddElements(arc.BasisCurve.Transform.ToModelCurves());
                 }
             }
+        }
+
+        private IndexedPolycurve CreateTestPolycurve()
+        {
+            var arc = new Arc(new Vector3(2.5, 5), 2.5, 0, 180);
+            var a = new Vector3(5, 0, 0);
+            var b = new Vector3(5, 5, 0);
+            var c = arc.Mid();
+            var d = new Vector3(0, 5, 0);
+            var e = Vector3.Origin;
+            var vertices = new[] { a, b, c, d, e };
+            var indices = new[]{
+                new[]{0,1},
+                new[]{1,2,3},
+                new[]{3,4}
+            };
+
+            return new IndexedPolycurve(vertices, indices);
+        }
+
+        [Fact]
+        public void ArcLength()
+        {
+            // An arc that looks like the middle of the test polycurve.
+            var middleArc = new Arc(new Vector3(2.5, 5), 2.5, 0, 180);
+
+            // Measure the arc length half way along one
+            // leg, around the arc, and half way down the
+            // other leg.
+            var pc = CreateTestPolycurve();
+            Assert.Equal(5 + middleArc.Length(), pc.ArcLength(0.5, 2.5));
         }
     }
 }

--- a/Elements/test/IndexedPolyCurveTests.cs
+++ b/Elements/test/IndexedPolyCurveTests.cs
@@ -10,9 +10,8 @@ namespace Elements.Tests
         {
             Name = nameof(IndexedPolycurve);
 
-            var line = new Line(Vector3.Origin, new Vector3(0, 5, 0));
-            var line1 = new Line(new Vector3(5, 5, 0), new Vector3(5, 0, 0));
             var arc = new Arc(new Vector3(2.5, 5), 2.5, 0, 180);
+
             var a = new Vector3(5, 0, 0);
             var b = new Vector3(5, 5, 0);
             var c = arc.Mid();
@@ -24,11 +23,31 @@ namespace Elements.Tests
                 new[]{1,2,3},
                 new[]{3,4}
             };
+
             var pc = new IndexedPolycurve(vertices, indices);
             Model.AddElement(new ModelCurve(pc));
 
             var t = pc.TransformAt(1.5);
             Model.AddElements(t.ToModelCurves());
+        }
+
+        [Fact]
+        public void PolyCurveFromFillet()
+        {
+            Name = nameof(PolyCurveFromFillet);
+
+            var shape3 = Polygon.Star(5, 3, 5);
+            var contour3 = shape3.Fillet(0.5);
+            Model.AddElement(new ModelCurve(contour3));
+
+            foreach (var curve in contour3.Curves)
+            {
+                if (curve is Arc)
+                {
+                    var arc = (Arc)curve;
+                    Model.AddElements(arc.BasisCurve.Transform.ToModelCurves());
+                }
+            }
         }
     }
 }

--- a/Elements/test/IndexedPolyCurveTests.cs
+++ b/Elements/test/IndexedPolyCurveTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Elements.Geometry;
 using Xunit;
 
@@ -89,6 +90,46 @@ namespace Elements.Tests
             // other leg.
             var pc = CreateTestPolycurve();
             Assert.Equal(5 + middleArc.Length(), pc.ArcLength(0.5, 2.5));
+        }
+
+        [Fact]
+        public void CurveCounts()
+        {
+            var pc = CreateTestPolycurve();
+            Assert.Equal(3, pc.Count());
+
+            var pline = new Polyline(pc.Vertices);
+            Assert.Equal(pline.Vertices.Count - 1, pline.Count());
+
+            var pgon = new Polygon(pc.Vertices);
+            Assert.Equal(pgon.Vertices.Count, pgon.Count());
+        }
+
+        [Fact]
+        public void EndPoints()
+        {
+            // Polycurve is not closed
+            var pc = CreateTestPolycurve();
+            Assert.NotEqual(pc.End, pc.Start);
+
+            // Polyline is not closed
+            var pline = new Polyline(pc.Vertices);
+            Assert.NotEqual(pline.Last().End, pline.First().Start);
+
+            // Polygon is closed
+            var pgon = new Polygon(pc.Vertices);
+            Assert.Equal(pgon.Last().End, pgon.First().Start);
+        }
+
+        [Fact]
+        public void RenderVertices()
+        {
+            var pgon = Polygon.Ngon(5);
+            var pline = new Polyline(pgon.Vertices);
+            var pgonRVerts = pgon.RenderVertices();
+            var plineRVerts = pline.RenderVertices();
+            Assert.Equal(6, pgonRVerts.Count);
+            Assert.Equal(5, plineRVerts.Count);
         }
     }
 }

--- a/Elements/test/IndexedPolyCurveTests.cs
+++ b/Elements/test/IndexedPolyCurveTests.cs
@@ -47,7 +47,7 @@ namespace Elements.Tests
             var contour3 = shape3.Fillet(0.5);
             Model.AddElement(new ModelCurve(contour3));
 
-            foreach (var curve in contour3.Curves)
+            foreach (var curve in contour3)
             {
                 if (curve is Arc)
                 {

--- a/Elements/test/IndexedPolyCurveTests.cs
+++ b/Elements/test/IndexedPolyCurveTests.cs
@@ -29,6 +29,9 @@ namespace Elements.Tests
 
             var t = pc.TransformAt(1.5);
             Model.AddElements(t.ToModelCurves());
+
+            var t1 = new Transform(Vector3.Origin, Vector3.XAxis);
+            Model.AddElement(new ModelCurve(pc.TransformedPolycurve(t1)));
         }
 
         [Fact]

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -827,9 +827,7 @@ namespace Elements.Geometry.Tests
             var pointInternal = extremelyConcavePolygon.PointInternal();
             Assert.True(extremelyConcavePolygon.Contains(pointInternal));
             Model.AddElement(extremelyConcavePolygon);
-            Curve.MinimumChordLength = 0.001;
             Model.AddElement(new Circle(pointInternal, 0.02));
-            Curve.MinimumChordLength = 0.1;
         }
 
         [Fact]

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -48,13 +48,10 @@ namespace Elements.Geometry.Tests
             // Square in Quadrant I
             var polygon = new Polygon
             (
-                new[]
-                {
-                    Vector3.Origin,
-                    new Vector3(6.0, 0.0),
-                    new Vector3(6.0, 6.0),
-                    new Vector3(0.0, 6.0),
-                }
+                Vector3.Origin,
+                new Vector3(6.0, 0.0),
+                new Vector3(6.0, 6.0),
+                new Vector3(0.0, 6.0)
             );
             var centroid = polygon.Centroid();
             Assert.Equal(3.0, centroid.X);
@@ -63,13 +60,10 @@ namespace Elements.Geometry.Tests
             // Square in Quadrant II
             polygon = new Polygon
             (
-                new[]
-                {
-                    Vector3.Origin,
-                    new Vector3(-6.0, 0.0),
-                    new Vector3(-6.0, 6.0),
-                    new Vector3(0.0, 6.0),
-                }
+                Vector3.Origin,
+                new Vector3(-6.0, 0.0),
+                new Vector3(-6.0, 6.0),
+                new Vector3(0.0, 6.0)
             );
             centroid = polygon.Centroid();
             Assert.Equal(-3.0, centroid.X);
@@ -78,13 +72,10 @@ namespace Elements.Geometry.Tests
             // Square in Quadrant III
             polygon = new Polygon
             (
-                new[]
-                {
-                    Vector3.Origin,
-                    new Vector3(-6.0, 0.0),
-                    new Vector3(-6.0, -6.0),
-                    new Vector3(0.0, -6.0),
-                }
+                Vector3.Origin,
+                new Vector3(-6.0, 0.0),
+                new Vector3(-6.0, -6.0),
+                new Vector3(0.0, -6.0)
             );
             centroid = polygon.Centroid();
             Assert.Equal(-3.0, centroid.X);
@@ -93,13 +84,10 @@ namespace Elements.Geometry.Tests
             // Square in Quadrant IV
             polygon = new Polygon
             (
-                new[]
-                {
                 Vector3.Origin,
                 new Vector3(6.0, 0.0),
                 new Vector3(6.0, -6.0),
-                    new Vector3(0.0, -6.0),
-                }
+                new Vector3(0.0, -6.0)
             );
             centroid = polygon.Centroid();
             Assert.Equal(3.0, centroid.X);
@@ -108,15 +96,12 @@ namespace Elements.Geometry.Tests
             // Bow Tie in Quadrant I
             polygon = new Polygon
             (
-                new[]
-                {
                 new Vector3(1.0, 1.0),
                 new Vector3(4.0, 4.0),
                 new Vector3(7.0, 1.0),
                 new Vector3(7.0, 9.0),
                 new Vector3(4.0, 6.0),
                 new Vector3(1.0, 9.0)
-                }
             );
             centroid = polygon.Centroid();
             Assert.Equal(4.0, centroid.X);
@@ -125,15 +110,12 @@ namespace Elements.Geometry.Tests
             // Bow Tie in Quadrant III
             polygon = new Polygon
             (
-                new[]
-                {
                 new Vector3(-1.0, -1.0),
                 new Vector3(-4.0, -4.0),
                 new Vector3(-7.0, -1.0),
                 new Vector3(-7.0, -9.0),
                 new Vector3(-4.0, -6.0),
                 new Vector3(-1.0, -9.0)
-                }
             );
             centroid = polygon.Centroid();
             Assert.Equal(-4.0, centroid.X);
@@ -155,33 +137,24 @@ namespace Elements.Geometry.Tests
             var v2 = new Vector3(7.5, 7.5);
             var p1 = new Polygon
             (
-                new[]
-                {
-                    new Vector3(0.0, 0.0),
-                    new Vector3(20.0, 0.0),
-                    new Vector3(20.0, 20.0),
-                    new Vector3(0.0, 20.0)
-                }
+                new Vector3(0.0, 0.0),
+                new Vector3(20.0, 0.0),
+                new Vector3(20.0, 20.0),
+                new Vector3(0.0, 20.0)
             );
             var p2 = new Polygon
             (
-                new[]
-                {
-                    new Vector3(0.0, 0.0),
-                    new Vector3(10.0, 5.0),
-                    new Vector3(10.0, 10.0),
-                    new Vector3(5.0, 10.0)
-                }
+                new Vector3(0.0, 0.0),
+                new Vector3(10.0, 5.0),
+                new Vector3(10.0, 10.0),
+                new Vector3(5.0, 10.0)
             );
             var p3 = new Polygon
             (
-                new[]
-                {
-                    new Vector3(5.0, 5.0),
-                    new Vector3(10.0, 5.0),
-                    new Vector3(10.0, 10.0),
-                    new Vector3(5.0, 10.0)
-                }
+                new Vector3(5.0, 5.0),
+                new Vector3(10.0, 5.0),
+                new Vector3(10.0, 10.0),
+                new Vector3(5.0, 10.0)
             );
 
             Assert.False(p1.Contains(v1));

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -95,9 +95,9 @@ namespace Elements.Geometry.Tests
             (
                 new[]
                 {
-                    Vector3.Origin,
-                    new Vector3(6.0, 0.0),
-                    new Vector3(6.0, -6.0),
+                Vector3.Origin,
+                new Vector3(6.0, 0.0),
+                new Vector3(6.0, -6.0),
                     new Vector3(0.0, -6.0),
                 }
             );
@@ -110,12 +110,12 @@ namespace Elements.Geometry.Tests
             (
                 new[]
                 {
-                    new Vector3(1.0, 1.0),
-                    new Vector3(4.0, 4.0),
-                    new Vector3(7.0, 1.0),
-                    new Vector3(7.0, 9.0),
-                    new Vector3(4.0, 6.0),
-                    new Vector3(1.0, 9.0)
+                new Vector3(1.0, 1.0),
+                new Vector3(4.0, 4.0),
+                new Vector3(7.0, 1.0),
+                new Vector3(7.0, 9.0),
+                new Vector3(4.0, 6.0),
+                new Vector3(1.0, 9.0)
                 }
             );
             centroid = polygon.Centroid();
@@ -127,12 +127,12 @@ namespace Elements.Geometry.Tests
             (
                 new[]
                 {
-                    new Vector3(-1.0, -1.0),
-                    new Vector3(-4.0, -4.0),
-                    new Vector3(-7.0, -1.0),
-                    new Vector3(-7.0, -9.0),
-                    new Vector3(-4.0, -6.0),
-                    new Vector3(-1.0, -9.0)
+                new Vector3(-1.0, -1.0),
+                new Vector3(-4.0, -4.0),
+                new Vector3(-7.0, -1.0),
+                new Vector3(-7.0, -9.0),
+                new Vector3(-4.0, -6.0),
+                new Vector3(-1.0, -9.0)
                 }
             );
             centroid = polygon.Centroid();
@@ -1055,11 +1055,6 @@ namespace Elements.Geometry.Tests
             var poly3 = contour3.ToPolygon();
             var mass3 = new Mass(poly3, transform: t);
             Assert.Equal(shape3.Segments().Count() * 2, contour3.Count());
-
-            for (var u = contour3.Domain.Min; u <= contour3.Domain.Max; u += contour3.Domain.Length / 10)
-            {
-                var pt = contour3.TransformAt(u);
-            }
         }
 
         [Fact]

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -42,162 +42,103 @@ namespace Elements.Geometry.Tests
             this.Model.AddElement(new ModelCurve(star));
         }
 
-        public static IEnumerable<object[]> GetCenterTestPolygons()
+        [Fact]
+        public void Centroid()
         {
+            // Square in Quadrant I
+            var polygon = new Polygon
+            (
+                new[]
+                {
+                    Vector3.Origin,
+                    new Vector3(6.0, 0.0),
+                    new Vector3(6.0, 6.0),
+                    new Vector3(0.0, 6.0),
+                }
+            );
+            var centroid = polygon.Centroid();
+            Assert.Equal(3.0, centroid.X);
+            Assert.Equal(3.0, centroid.Y);
+
             // Square in Quadrant II
-            var polygon = new Polygon(Vector3.Origin,
-                                      (-6.0, 0.0),
-                                      (-6.0, 6.0),
-                                      (0.0, 6.0));
-            yield return new object[] { polygon, new Vector3(-3.0, 3.0), new Vector3(-3.0, 3.0) };
+            polygon = new Polygon
+            (
+                new[]
+                {
+                    Vector3.Origin,
+                    new Vector3(-6.0, 0.0),
+                    new Vector3(-6.0, 6.0),
+                    new Vector3(0.0, 6.0),
+                }
+            );
+            centroid = polygon.Centroid();
+            Assert.Equal(-3.0, centroid.X);
+            Assert.Equal(3.0, centroid.Y);
+
+            // Square in Quadrant III
+            polygon = new Polygon
+            (
+                new[]
+                {
+                    Vector3.Origin,
+                    new Vector3(-6.0, 0.0),
+                    new Vector3(-6.0, -6.0),
+                    new Vector3(0.0, -6.0),
+                }
+            );
+            centroid = polygon.Centroid();
+            Assert.Equal(-3.0, centroid.X);
+            Assert.Equal(-3.0, centroid.Y);
 
             // Square in Quadrant IV
-            polygon = new Polygon(Vector3.Origin,
-                                  (6.0, 0.0),
-                                  (6.0, -6.0),
-                                  (0.0, -6.0));
-            yield return new object[] { polygon, new Vector3(3.0, -3.0), new Vector3(3.0, -3.0) };
+            polygon = new Polygon
+            (
+                new[]
+                {
+                    Vector3.Origin,
+                    new Vector3(6.0, 0.0),
+                    new Vector3(6.0, -6.0),
+                    new Vector3(0.0, -6.0),
+                }
+            );
+            centroid = polygon.Centroid();
+            Assert.Equal(3.0, centroid.X);
+            Assert.Equal(-3.0, centroid.Y);
 
             // Bow Tie in Quadrant I
-            polygon = new Polygon((1.0, 1.0),
-                                  (4.0, 4.0),
-                                  (7.0, 1.0),
-                                  (7.0, 9.0),
-                                  (4.0, 6.0),
-                                  (1.0, 9.0));
-            yield return new object[] { polygon, new Vector3(4.0, 5.0), new Vector3(4.0, 5.0) };
+            polygon = new Polygon
+            (
+                new[]
+                {
+                    new Vector3(1.0, 1.0),
+                    new Vector3(4.0, 4.0),
+                    new Vector3(7.0, 1.0),
+                    new Vector3(7.0, 9.0),
+                    new Vector3(4.0, 6.0),
+                    new Vector3(1.0, 9.0)
+                }
+            );
+            centroid = polygon.Centroid();
+            Assert.Equal(4.0, centroid.X);
+            Assert.Equal(5.0, centroid.Y);
 
             // Bow Tie in Quadrant III
-            polygon = new Polygon((-1.0, -1.0),
-                                  (-4.0, -4.0),
-                                  (-7.0, -1.0),
-                                  (-7.0, -9.0),
-                                  (-4.0, -6.0),
-                                  (-1.0, -9.0));
-            yield return new object[] { polygon, new Vector3(-4.0, -5.0), new Vector3(-4.0, -5.0) };
-
-            polygon = new Polygon((20.710443, 4.926839, 0),
-                                  (16.247129, 18.703601, 0),
-                                  (20.769954, 26.440012, 0),
-                                  (28.179055, 23.52398, 0),
-                                  (25.571221, 16.897954, 0),
-                                  (30.202424, 13.37738, 0),
-                                  (28.565876, 9.003332, 0),
-                                  (20.710443, 4.926839, 0));
-            yield return new object[] { polygon, new Vector3(24.320872, 16.124728, 0), new Vector3(22.862188, 15.809823, 0) };
-
-            polygon = Polygon.Rectangle(6, 4);
-            polygon.Vertices.Insert(2, new Vector3(3.0, 1.0));
-
-            yield return new object[] { polygon, new Vector3(0.6, 0.2), new Vector3(0, 0) };
+            polygon = new Polygon
+            (
+                new[]
+                {
+                    new Vector3(-1.0, -1.0),
+                    new Vector3(-4.0, -4.0),
+                    new Vector3(-7.0, -1.0),
+                    new Vector3(-7.0, -9.0),
+                    new Vector3(-4.0, -6.0),
+                    new Vector3(-1.0, -9.0)
+                }
+            );
+            centroid = polygon.Centroid();
+            Assert.Equal(-4.0, centroid.X);
+            Assert.Equal(-5.0, centroid.Y);
         }
-
-        [Theory]
-        [MemberData(nameof(GetCenterTestPolygons))]
-        public void CentersAndCentroids(Polygon polygon, Vector3 center, Vector3 centroid)
-        {
-            var foundCentroid = polygon.Centroid();
-            var foundCenter = polygon.Center();
-            Assert.True(center.IsAlmostEqualTo(foundCenter));
-            Assert.True(centroid.IsAlmostEqualTo(foundCentroid));
-        }
-
-        [Fact]
-        public void ThreeDCentroids()
-        {
-            var pgon = new Polygon((-4.800147, -9.701137, 0),
-                                   (-4.800147, 6.574991, 0),
-                                   (9.600293, 3.126146, 0),
-                                   (-4.800147, -9.701137, 0));
-            Assert.Equal((0, 0), pgon.Centroid());
-            var pgon2 = new Polygon((-14.525461, -9.276887, 1),
-                                    (-15.433052, -2.863245, 1),
-                                    (-7.022711, 1.19066, 1),
-                                    (-2.121721, 8.269868, 1),
-                                    (4.654957, 22.428284, 1),
-                                    (15.48554, 14.804521, 1),
-                                    (3.807872, 0.948636, 1),
-                                    (-3.694878, 0.948636, 1),
-                                    (15.122504, -3.226282, 1),
-                                    (9.011393, -13.088768, 1),
-                                    (-0.894814, -6.950567, 1),
-                                    (-0.894814, -13.572816, 1),
-                                    (-8.958905, -13.572816, 1),
-                                    (-14.525461, -9.276887, 1));
-            Assert.Equal((1, 1, 1), pgon2.Centroid());
-            var pgon3 = new Polygon((7.110806, -11.726081, -2.15209),
-                                    (-11.130781, 9.469516, -2.833149),
-                                    (-4.657744, 18.325267, 6.541436),
-                                    (0.998623, 7.638583, 4.458195),
-                                    (-4.011031, 5.850639, 0.027956),
-                                    (13.805502, 3.394647, 10.868168),
-                                    (6.806682, -2.3006, 2.895764),
-                                    (17.41365, -4.20029, 9.105426),
-                                    (12.630537, -8.092519, 3.656948),
-                                    (7.110806, -11.726081, -2.15209));
-            Assert.Equal((2, 2, 2), pgon3.Centroid());
-
-            var pgon4 = new Polygon((38.337892, 0.04147, 27.352492),
-                                    (55.553043, 1.557339, 17.913199),
-                                    (70.414095, 0.745786, 15.341362),
-                                    (60.364178, 10.513956, -7.169442),
-                                    (47.355624, 13.559341, -11.060032),
-                                    (18.808653, 18.030108, -13.77884),
-                                    (17.047729, 13.175249, -0.451222),
-                                    (13.719433, 9.651443, 9.871657),
-                                    (23.803571, 1.111343, 29.141383),
-                                    (38.337892, 0.04147, 27.352492));
-            Assert.True(pgon4.Centroid().IsAlmostEqualTo(new Vector3(38.944684, 7.812381, 6.720177)));
-
-            var pgon5 = new Polygon((13.367577, 37.637427, 19.913696),
-                                    (-14.19544, 24.029118, 25.91016),
-                                    (7.030176, -2.096658, 26.66828),
-                                    (28.726802, -10.894791, 24.813338),
-                                    (27.499415, 9.222174, 22.036983),
-                                    (13.367577, 37.637427, 19.913696));
-            Assert.True(pgon5.Centroid().IsAlmostEqualTo(new Vector3(10.523549, 14.044947, 23.791014)));
-
-            var pgon6 = new Polygon((15.164654, 33.292556, 13.183789),
-                                    (7.462208, 35.568885, 20.632929),
-                                    (8.147323, 22.539536, 33.843797),
-                                    (23.718464, 18.112903, 18.595288),
-                                    (26.914692, 20.349983, 12.062899),
-                                    (24.18474, 34.732703, 0.01945),
-                                    (7.483351, 40.774657, 14.975199),
-                                    (15.164654, 33.292556, 13.183789));
-            Assert.True(pgon6.Centroid().IsAlmostEqualTo(new Vector3(16.95831, 28.253992, 16.325457)));
-
-            var pgon7 = new Polygon((54.53824, 29.174668, -13.957174),
-                                    (49.089342, 38.630962, -15.007422),
-                                    (41.692673, 43.190619, -12.301108),
-                                    (34.52574, 41.779419, -6.768785),
-                                    (22.997622, 56.878945, -6.541126),
-                                    (9.979076, 54.67304, 3.329722),
-                                    (12.144266, 41.168415, 8.612961),
-                                    (14.906397, 25.693682, 14.477601),
-                                    (12.021633, 15.32467, 21.597258),
-                                    (8.605531, 7.350425, 27.879325),
-                                    (15.977353, 7.52054, 22.828556),
-                                    (30.190687, -3.299195, 18.655516),
-                                    (38.126281, 1.246412, 11.040648),
-                                    (40.766884, -4.078799, 11.920318),
-                                    (50.549067, -2.199374, 4.39255),
-                                    (57.429011, 2.955815, -2.815521),
-                                    (54.53824, 29.174668, -13.957174));
-            Assert.True(pgon7.Centroid().IsAlmostEqualTo(new Vector3(32.623945, 23.645959, 3.564879)));
-
-            var pgon8 = new Polygon((10.072801, 0.604668, 31.063089),
-                                    (36.455088, 10.00387, 9.599957),
-                                    (31.815341, 12.467897, 6.809542),
-                                    (33.728473, 12.916257, 5.625037),
-                                    (9.678915, 22.398682, -3.593184),
-                                    (0.954908, 18.588346, 4.623971),
-                                    (-12.930914, 18.147159, 8.735526),
-                                    (5.138936, 2.18134, 29.759844),
-                                    (10.072801, 0.604668, 31.063089));
-            Assert.True(pgon8.Centroid().IsAlmostEqualTo(new Vector3(11.681926, 11.801531, 12.813532)));
-        }
-
 
         [Fact]
         public void DoesNotContainPointNotInPlane()
@@ -214,24 +155,33 @@ namespace Elements.Geometry.Tests
             var v2 = new Vector3(7.5, 7.5);
             var p1 = new Polygon
             (
+                new[]
+                {
                     new Vector3(0.0, 0.0),
                     new Vector3(20.0, 0.0),
                     new Vector3(20.0, 20.0),
                     new Vector3(0.0, 20.0)
+                }
             );
             var p2 = new Polygon
             (
+                new[]
+                {
                     new Vector3(0.0, 0.0),
                     new Vector3(10.0, 5.0),
                     new Vector3(10.0, 10.0),
                     new Vector3(5.0, 10.0)
+                }
             );
             var p3 = new Polygon
             (
+                new[]
+                {
                     new Vector3(5.0, 5.0),
                     new Vector3(10.0, 5.0),
                     new Vector3(10.0, 10.0),
                     new Vector3(5.0, 10.0)
+                }
             );
 
             Assert.False(p1.Contains(v1));
@@ -1173,7 +1123,7 @@ namespace Elements.Geometry.Tests
             this.Name = "PolygonPointsAtToTheEnd";
 
             var polyCircle = new Circle(Vector3.Origin, 5).ToPolygon(7);
-            var polyline = new Polyline(polyCircle.Vertices.Take(polyCircle.Vertices.Count - 1).ToList());
+            var polyline = new Polyline(polyCircle.Vertices);
 
             // Ensure that the PointAt function for u=1.0 is at the
             // end of the polygon AND at the end of the polyline.
@@ -1181,7 +1131,7 @@ namespace Elements.Geometry.Tests
             Assert.True(polyline.PointAt(polyline.Domain.Max).IsAlmostEqualTo(polyline.Vertices[polyline.Vertices.Count - 1]));
             // Test value close to u=0.0 within tolerance
             Assert.True(polyCircle.PointAt(-1e-15).IsAlmostEqualTo(polyCircle.End));
-            Assert.True(polyline.PointAt(-1e-15).IsAlmostEqualTo(polyline.Vertices[polyline.Vertices.Count - 1]));
+            Assert.True(polyline.PointAt(-1e-15).IsAlmostEqualTo(polyline.Vertices[0]));
 
             this.Model.AddElement(new ModelCurve(polyCircle));
 

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -1055,6 +1055,11 @@ namespace Elements.Geometry.Tests
             var poly3 = contour3.ToPolygon();
             var mass3 = new Mass(poly3, transform: t);
             Assert.Equal(shape3.Segments().Count() * 2, contour3.Count());
+
+            for (var u = contour3.Domain.Min; u <= contour3.Domain.Max; u += contour3.Domain.Length / 10)
+            {
+                var pt = contour3.TransformAt(u);
+            }
         }
 
         [Fact]
@@ -1136,10 +1141,10 @@ namespace Elements.Geometry.Tests
             this.Model.AddElement(new ModelCurve(polyCircle));
 
             var circle = new Circle(Vector3.Origin, 0.1).ToPolygon();
-            for (var u = 0.0; u <= 1.0; u += 0.05)
+            for (var u = 0.0; u <= polyCircle.Domain.Max; u += 0.05)
             {
                 var pt = polyCircle.PointAt(u);
-                this.Model.AddElement(new ModelCurve(circle, BuiltInMaterials.XAxis));
+                this.Model.AddElement(new ModelCurve(circle, BuiltInMaterials.XAxis, new Transform(pt)));
             }
         }
 

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -249,13 +249,12 @@ namespace Elements.Geometry.Tests
             var polyline = new Polyline(new[] { start, new Vector3(1, 4), end });
 
             Assert.Equal(0, polyline.GetParameterAt(start));
-            Assert.Equal(polyline.Length(), polyline.GetParameterAt(end));
+            Assert.Equal(2, polyline.GetParameterAt(end));
             Assert.Equal(-1, polyline.GetParameterAt(Vector3.Origin));
 
             var point = new Vector3(2, 4);
             var resultParameter = polyline.GetParameterAt(point);
-            var expectedResult = 0.75 * polyline.Length();
-            Assert.True(resultParameter.ApproximatelyEquals(expectedResult));
+            Assert.Equal(1.5, resultParameter);
             var testPoint = polyline.PointAt(resultParameter);
             Assert.True(point.IsAlmostEqualTo(testPoint));
         }

--- a/Elements/test/StructuralFramingTests.cs
+++ b/Elements/test/StructuralFramingTests.cs
@@ -241,6 +241,7 @@ namespace Elements.Tests
         public void Setbacks()
         {
             this.Name = "BeamSetbacks";
+
             var line = new Line(Vector3.Origin, new Vector3(3, 3, 0));
             var mc = new ModelCurve(line, BuiltInMaterials.XAxis);
             this.Model.AddElement(mc);
@@ -270,7 +271,7 @@ namespace Elements.Tests
             var pl = new Polyline(new[] { new Vector3(0, 0), new Vector3(0, 2), new Vector3(0, 3, 1) });
             var mc3 = new ModelCurve(pl, BuiltInMaterials.Black);
             this.Model.AddElement(mc3);
-            var plBeam = new Beam(pl, this._testProfile, 1, 2, 0, material: BuiltInMaterials.Steel);
+            var plBeam = new Beam(pl, this._testProfile, 1, 1, 0, material: BuiltInMaterials.Steel);
             this.Model.AddElement(plBeam);
 
             // Ellipse setbacks


### PR DESCRIPTION
BACKGROUND:
We previously built a class called `Contour` that was `IEnumerable<Curve>`. This class was meant to support planar compositions of any curve type. It was not thoroughly designed. After completing work on trimmed curves in #957 #961 #959, we decided to rebuild a composite curve type capable of representing networks of lines and arcs.

DESCRIPTION:
This PR implements a new class `IndexedPolycurve` which is a composite curve of line and arc segments. The external representation of the curve is a set of vertices and a set of sets of of indices which implicitly describe the constructing curves. In this way it is similar to [IFCIndexedPolycurve](https://standards.buildingsmart.org/IFC/RELEASE/IFC4/ADD1/HTML/schema/ifcgeometryresource/lexical/ifcindexedpolycurve.htm). In addition to being `IEnumerable<BoundedCurve>`, allowing the user to do `foreach(var curve in polycurve)`, it is also a `BoundedCurve`, allowing the user to find the start, end, point at at parameter, and transforms along the curve.
The `Contour` class is deprecated, and locations that used the `Contour` class, such as the creation of a filleted polycurve from a polygon, now return an `IndexedPolycurve`.

TESTING:
- How should a reviewer observe the behavior desired by this pull request?
  
FUTURE WORK:
- We need to take a position on whether this curve is strictly planar. We do not check and we do not enforce planarity. As such, you can make a polycurve that represents, for example, a duct run, with arc sections and lines running in 3D. This seems useful.
- This implementation sacrifices memory for inheritance. The indexed polycurve has a set of curves that are derived from its vertices. We don't want to have to recreate these whenever someone uses the iterator, so we cache them. This is an improvement over what we used to do with polygons, allowing people to call `Segments()`, but it creates curves even for the polygon case where they might not ever be used.
- This is a mutable class, which is problematic because of the curves that we cache. If the caller adds or removes vertices to the polygon, the index sets and the internal curve sets need to be rebuilt. We can handle this by making the vertex collection read only and adding modifier methods, or we can make the iterator construct the curves. 

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

An indexed polycurve created by filleting a polygon.
![image](https://user-images.githubusercontent.com/1139788/235269986-1ba01d3e-679b-4eed-9710-7249e2f92baa.png)

An indexed polycurve created by filleting a polyline.
![image](https://user-images.githubusercontent.com/1139788/235270007-e668839e-ba68-4c4d-ae1f-7f4ee57c94ea.png)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/976)
<!-- Reviewable:end -->
