### PR TITLE
allow custom prefix exclusion

### DIFF
--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -97,7 +97,7 @@ namespace Elements.Serialization.JSON
                 {
                     types = assembly.GetTypes();
                 }
-                catch (Exception)
+                catch (ReflectionTypeLoadException)
                 {
                     failedAssemblyErrors.Add($"Failed to load assembly: {assembly.FullName}");
                     continue;

--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -60,6 +60,18 @@ namespace Elements.Serialization.JSON
             _discriminator = discriminator;
         }
 
+        private static readonly List<string> TypePrefixesExcludedFromTypeCache = new List<string> { "System", "SixLabors", "Newtonsoft" };
+
+        /// <summary>
+        /// When we build up the element type cache, we iterate over all types in the app domain.
+        /// Excluding other types can speed up the process and reduce deserialization issues.
+        /// </summary>
+        /// <param name="prefixes"></param>
+        public static void ExcludeTypePrefixesFromTypeCache(params string[] prefixes)
+        {
+            TypePrefixesExcludedFromTypeCache.AddRange(prefixes);
+        }
+
         /// <summary>
         /// The type cache needs to contains all types that will have a discriminator.
         /// This includes base types, like elements, and all derived types like Wall.
@@ -74,11 +86,10 @@ namespace Elements.Serialization.JSON
 
             failedAssemblyErrors = new List<string>();
 
-            var skipAssembliesPrefices = new[] { "System", "SixLabors", "Newtonsoft" };
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().Where(a =>
             {
                 var name = a.GetName().Name;
-                return !skipAssembliesPrefices.Any(p => name.StartsWith(p));
+                return !TypePrefixesExcludedFromTypeCache.Any(p => name.StartsWith(p));
             }))
             {
                 var types = Array.Empty<Type>();
@@ -86,7 +97,7 @@ namespace Elements.Serialization.JSON
                 {
                     types = assembly.GetTypes();
                 }
-                catch (ReflectionTypeLoadException)
+                catch (Exception)
                 {
                     failedAssemblyErrors.Add($"Failed to load assembly: {assembly.FullName}");
                     continue;


### PR DESCRIPTION
BACKGROUND:
- Revit conversion was failing weirdly because we were searching through `Autodesk.*` types in the app domain for element types. 

DESCRIPTION:
- Allows custom exclusions for the `JsonInheritanceConverter`. 

TESTING:
- I called `JsonInheritanceConverter.ExcludeTypePrefixesFromTypeCache("Autodesk")` and conversion worked again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/978)
<!-- Reviewable:end -->
