### PR TITLE
Emissive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `AdaptiveGrid`: removed obsolete `TryGetVertexIndex` with `tolerance` parameter.
 - `EdgeInfo`: obsolete attribute is removed from `HasVerticalChange` property.
 - `RoutingConfiguration`: removed obsolete `MainLayer` and `LayerPenalty` properties.
+- `Material.EmissiveFactor` is now 0.0 by default.
 
 ### Fixed
 

--- a/Elements/src/Material.cs
+++ b/Elements/src/Material.cs
@@ -203,7 +203,7 @@ namespace Elements
                         string normalTexture = null,
                         bool interpolateTexture = true,
                         string emissiveTexture = null,
-                        double emissiveFactor = 1.0,
+                        double emissiveFactor = 0.0,
                         bool drawInFront = false,
                         Guid id = default) :
             this(color,

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -360,8 +360,9 @@ namespace Elements.Serialization.glTF
                         samplerId++;
                     }
 
-                    gltfMaterial.EmissiveFactor = new float[] { (float)material.EmissiveFactor, (float)material.EmissiveFactor, (float)material.EmissiveFactor };
                 }
+
+                gltfMaterial.EmissiveFactor = new float[] { (float)material.EmissiveFactor, (float)material.EmissiveFactor, (float)material.EmissiveFactor };
 
                 if (material.Color.Alpha < 1.0 || textureHasTransparency)
                 {


### PR DESCRIPTION
BACKGROUND:
While debugging materials for Hypar's Unreal integration, we noticed that emissive factor was only being applied if the emissive texture was used as well. You should be able to use one without the other.

DESCRIPTION:
This PR applies the emissive factor whether there is an emissive texture or not, and it sets the emissive factor to 0 by default, as opposed to 1.0. An emissive factor of 1 would cause all materials to appear to emit light.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

Materials with increasing emissive factors.
![image](https://github.com/hypar-io/Elements/assets/1139788/ab472b7f-e8e9-400c-ad45-4e2c9e78458c)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/979)
<!-- Reviewable:end -->
