### PR TITLE
`Message` created from `Message.FromPoint` now has `Transform.Origin`…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - `Vector3.AreCoplanar` would sometimes return false negatives.
 - Fix the polygon centroid calculation to remove collinear vertices.
 - Fix the tests for 3dCentroid testing.
+- `Message` created from `Message.FromPoint` now has `Transform.Origin` set exactly on original point.
 
 ## 1.6.0
 

--- a/Elements/src/Annotations/Messages.cs
+++ b/Elements/src/Annotations/Messages.cs
@@ -64,9 +64,7 @@ namespace Elements.Annotations
                                              string name = null,
                                              string stackTrace = null)
         {
-            var transform = point.HasValue
-                ? new Transform(point.Value).Moved(z: -sideLength / 2)
-                : new Transform();
+            var transform = point.HasValue ? new Transform(point.Value) : new Transform();
             var message = new Message(messageText,
                                       stackTrace,
                                       severity,
@@ -78,8 +76,9 @@ namespace Elements.Annotations
                                       name ?? DefaultName);
             if (point.HasValue)
             {
-                var extrude = new Extrude(Polygon.Rectangle(
-                    sideLength, sideLength), sideLength, Vector3.ZAxis, false);
+                var rectangle = Polygon.Rectangle(sideLength, sideLength).TransformedPolygon(
+                    new Transform(0, 0, -sideLength / 2));
+                var extrude = new Extrude(rectangle, sideLength, Vector3.ZAxis, false);
 
                 message.Representation = new Representation(new[] { extrude });
             }

--- a/Elements/test/MessageTests.cs
+++ b/Elements/test/MessageTests.cs
@@ -1,0 +1,18 @@
+﻿using Elements;
+using Elements.Geometry;
+using Elements.Annotations;
+using Xunit;
+
+namespace Elements.Tests
+{
+    public class MessageTests
+    {
+        [Fact]
+        public void MessageFromPointHasCorrectTransform()
+        {
+            var line = new Line((2.1, 4.2, 2), (3.3, 5, 3));
+            var message = Message.FromPoint("Test", line.Start);
+            Assert.Equal(line.Start, message.Transform.Origin);
+        }
+    }
+}

--- a/Elements/test/MessageTests.cs
+++ b/Elements/test/MessageTests.cs
@@ -10,9 +10,9 @@ namespace Elements.Tests
         [Fact]
         public void MessageFromPointHasCorrectTransform()
         {
-            var line = new Line((2.1, 4.2, 2), (3.3, 5, 3));
-            var message = Message.FromPoint("Test", line.Start);
-            Assert.Equal(line.Start, message.Transform.Origin);
+            var point = new Vector3(2.1, 4.2, 2);
+            var message = Message.FromPoint("Test", point);
+            Assert.Equal(point, message.Transform.Origin);
         }
     }
 }


### PR DESCRIPTION
… set exactly on original point.

BACKGROUND:
- While working on the function I needed to find line end that is closest to warning box. I found that Transfrom.Origin for Message object, originated from Point are not set to this point but rather to the center of box bottom side. 

DESCRIPTION:
- Instead of lowering transform - representation is lowered. 

TESTING:
- Added a MessageFromPointHasCorrectTransform test.
  
FUTURE WORK:
- Inside Message.FromCurve and Message.FromPolygon tranform is set without meaning. This also can be changed, so Message.FromCurve Transform.Origin is set to start point and Message.FromPolygon - to centroid, for example.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/982)
<!-- Reviewable:end -->
