### PR TITLE
Add short-hand methods for Info, Warning, and Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - `Ellipse`
 - `EllipticalArc`
 - `Grid1d.GetCellDomains`
+- `Message.Info`
+- `Message.Error`
+- `Message.Warning`
 
 ### Changed
 

--- a/Elements/src/Annotations/Message.cs
+++ b/Elements/src/Annotations/Message.cs
@@ -13,6 +13,7 @@ namespace Elements.Annotations
         /// Default json constructor for a message that may have geometry.
         /// </summary>
         /// <param name="message"></param>
+        /// <param name="shortMessage"></param>
         /// <param name="stackTrace"></param>
         /// <param name="severity"></param>
         /// <param name="transform"></param>
@@ -22,9 +23,10 @@ namespace Elements.Annotations
         /// <param name="id"></param>
         /// <param name="name"></param>
         [JsonConstructor]
-        public Message(string @message, string @stackTrace, MessageSeverity @severity, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public Message(string @message, string @shortMessage, string @stackTrace, MessageSeverity @severity, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
+            this.ShortMessage = @shortMessage;
             this.MessageText = @message;
             this.StackTrace = @stackTrace;
             this.Severity = @severity;
@@ -37,6 +39,10 @@ namespace Elements.Annotations
             : base()
         {
         }
+
+        /// <summary>A short message for the user. For a more detailed message, use MessageText.</summary>
+        [JsonProperty("ShortMessage", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string ShortMessage { get; set; }
 
         /// <summary>A warning message for the user.</summary>
         [JsonProperty("Message", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]

--- a/Elements/src/Annotations/Messages.cs
+++ b/Elements/src/Annotations/Messages.cs
@@ -202,7 +202,7 @@ namespace Elements.Annotations
         /// </summary>
         public static Message Error(Vector3? point, string message = null)
         {
-            return Message.FromPoint(message, point, MessageSeverity.Warning, shortMessage: "🛑");
+            return Message.FromPoint(message, point, MessageSeverity.Error, shortMessage: "🛑");
         }
 
         /// <summary>

--- a/Elements/src/Annotations/Messages.cs
+++ b/Elements/src/Annotations/Messages.cs
@@ -1,5 +1,4 @@
-﻿using Elements;
-using Elements.Geometry;
+﻿using Elements.Geometry;
 using Elements.Geometry.Solids;
 using System;
 using System.Collections.Generic;
@@ -38,36 +37,39 @@ namespace Elements.Annotations
         /// <param name="name">The name given to the message.</param>
         /// <param name="severity">The severity of the message.</param>
         /// <param name="stackTrace">Any stack trace associated with the message.</param>
-        /// <returns></returns>
+        /// <param name="shortMessage">A short message.</param>
         public static Message FromText(string message,
                                        string name = null,
                                        MessageSeverity severity = MessageSeverity.Warning,
-                                       string stackTrace = null)
+                                       string stackTrace = null,
+                                       string shortMessage = null)
         {
-            return new Message(message, stackTrace, severity, name: name ?? DefaultName);
+            return new Message(message, shortMessage, stackTrace, severity, name: name ?? DefaultName);
         }
 
         /// <summary>
         /// Create a simple message at a point.
         /// </summary>
         /// <param name="messageText">The message to the user.</param>
+        /// <param name="shortMessage">A short message.</param>
         /// <param name="point"></param>
         /// <param name="severity">The severity of the message.</param>
         /// <param name="sideLength"></param>
         /// <param name="name">The name given to the message.</param>
         /// <param name="stackTrace">Any stack trace associated with the message.</param>
-        /// <returns></returns>
         public static Message FromPoint(string messageText,
-                                             Vector3? point,
-                                             MessageSeverity severity = MessageSeverity.Warning,
-                                             double sideLength = DefaultSideLength,
-                                             string name = null,
-                                             string stackTrace = null)
+                                        Vector3? point,
+                                        MessageSeverity severity = MessageSeverity.Warning,
+                                        double sideLength = DefaultSideLength,
+                                        string name = null,
+                                        string stackTrace = null,
+                                        string shortMessage = null)
         {
             var transform = point.HasValue
                 ? new Transform(point.Value).Moved(z: -sideLength / 2)
                 : new Transform();
             var message = new Message(messageText,
+                                      shortMessage,
                                       stackTrace,
                                       severity,
                                       transform,
@@ -91,22 +93,24 @@ namespace Elements.Annotations
         /// Create a simple message along a curve.
         /// </summary>
         /// <param name="messageText">The message to the user.</param>
+        /// <param name="shortMessage">A short message.</param>
         /// <param name="curve"></param>
         /// <param name="severity">The severity of the message.</param>
         /// <param name="sideLength"></param>
         /// <param name="name">The name given to the message.</param>
         /// <param name="stackTrace">Any stack trace associated with the message.</param>
-        /// <returns></returns>
         public static Message FromCurve(string messageText,
-                                           BoundedCurve curve,
-                                           MessageSeverity severity = MessageSeverity.Warning,
-                                           double sideLength = DefaultSideLength,
-                                           string name = null,
-                                           string stackTrace = null)
+                                        BoundedCurve curve,
+                                        MessageSeverity severity = MessageSeverity.Warning,
+                                        double sideLength = DefaultSideLength,
+                                        string name = null,
+                                        string stackTrace = null,
+                                        string shortMessage = null)
         {
             var profile = Polygon.Rectangle(sideLength, sideLength);
             var sweep = new Sweep(profile, curve, 0, 0, 0, false);
             var message = new Message(messageText,
+                                      shortMessage,
                                       stackTrace,
                                       severity,
                                       null,
@@ -121,22 +125,24 @@ namespace Elements.Annotations
         /// Create a simple message from a polygon.
         /// </summary>
         /// <param name="messageText">The message to the user.</param>
+        /// <param name="shortMessage">A short message.</param>
         /// <param name="polygon"></param>
         /// <param name="severity">The severity of the message.</param>
         /// <param name="height"></param>
         /// <param name="name">The name given to the message.</param>
         /// <param name="stackTrace">Any stack trace associated with the message.</param>
-        /// <returns></returns>
         public static Message FromPolygon(string messageText,
                                           Polygon polygon,
                                           MessageSeverity severity = MessageSeverity.Warning,
                                           double height = 0,
                                           string name = null,
-                                          string stackTrace = null)
+                                          string stackTrace = null,
+                                          string shortMessage = null)
         {
             const double messageHeightSubtleLift = 0.02;
             SolidOperation solid = height > 0 ? new Extrude(polygon, height, Vector3.ZAxis, false) : new Lamina(polygon, false) as SolidOperation;
             var message = new Message(messageText,
+                                      shortMessage,
                                       stackTrace,
                                       severity,
                                       new Transform().Moved(z: messageHeightSubtleLift),
@@ -152,26 +158,51 @@ namespace Elements.Annotations
         /// Create a simple message from polygons.
         /// </summary>
         /// <param name="messageText">The message to the user.</param>
+        /// <param name="shortMessage">A short message.</param>
         /// <param name="polygons"></param>
         /// <param name="severity">The severity of the message.</param>
         /// <param name="height"></param>
         /// <param name="name">The name given to the message.</param>
         /// <param name="stackTrace">Any stack trace associated with the message.</param>
-        /// <returns></returns>
         public static Message[] FromPolygons(string messageText,
                                              IEnumerable<Polygon> polygons,
                                              MessageSeverity severity = MessageSeverity.Warning,
                                              double height = 0,
                                              string name = null,
-                                             string stackTrace = null)
+                                             string stackTrace = null,
+                                             string shortMessage = null)
         {
             var messages = new List<Message>();
             foreach (var polygon in polygons)
             {
-                var message = FromPolygon(messageText, polygon, severity, height, name);
+                var message = FromPolygon(messageText, polygon, severity, height, name, shortMessage);
                 messages.Add(message);
             }
             return messages.ToArray();
+        }
+
+        /// <summary>
+        /// Create an informational message.
+        /// </summary>
+        public static Message Info(Vector3? point, string message = null)
+        {
+            return Message.FromPoint(message, point, MessageSeverity.Info, shortMessage: "💡");
+        }
+
+        /// <summary>
+        /// Create a warning message.
+        /// </summary>
+        public static Message Warning(Vector3? point, string message = null)
+        {
+            return Message.FromPoint(message, point, MessageSeverity.Warning, shortMessage: "⚠️");
+        }
+
+        /// <summary>
+        /// Create an error message.
+        /// </summary>
+        public static Message Error(Vector3? point, string message = null)
+        {
+            return Message.FromPoint(message, point, MessageSeverity.Warning, shortMessage: "🛑");
         }
 
         /// <summary>


### PR DESCRIPTION
BACKGROUND:
In a conversation about how to show messages in Hypar, we decided to create a `ShortMessage` property on `Message` to allow developers to represent an error with a short message, even a single character like an emoji.

DESCRIPTION:
This PR adds a `ShortMessage` property to `Message`, and adds three static constructors to `Message` which set the short message for various message types to emojis representing information, warning, and error.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/984)
<!-- Reviewable:end -->
