### PR TITLE
Topography.Trimmed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `Message.Warning`
 - `Topography.Trimmed`
 - `new Topography(Topography other)`
+- `Topography.TopMesh()`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - `Message.Info`
 - `Message.Error`
 - `Message.Warning`
+- `Topography.Trimmed`
+- `new Topography(Topography other)`
 
 ### Changed
 
@@ -49,6 +51,7 @@
 - Fix the polygon centroid calculation to remove collinear vertices.
 - Fix the tests for 3dCentroid testing.
 - `Message` created from `Message.FromPoint` now has `Transform.Origin` set exactly on original point.
+- Certain `Triangle` constructors would not correctly update `Vertex.Triangles`, this is fixed.
 
 ## 1.6.0
 

--- a/Elements/src/Geometry/Mesh.cs
+++ b/Elements/src/Geometry/Mesh.cs
@@ -253,6 +253,18 @@ Triangles:{Triangles.Count}";
         }
 
         /// <summary>
+        /// Removes the specified triangle from the mesh and updates the vertex-triangle relationships.
+        /// </summary>
+        /// <param name="face">The triangle to remove.</param>
+        public void RemoveTriangle(Triangle face)
+        {
+            this.Triangles.Remove(face);
+            foreach(var vert in face.Vertices) {
+                vert.Triangles.Remove(face);
+            }
+        }
+
+        /// <summary>
         /// Add a vertex to the mesh.
         /// </summary>
         /// <param name="position">The position of the vertex.</param>

--- a/Elements/src/Geometry/Triangle.cs
+++ b/Elements/src/Geometry/Triangle.cs
@@ -46,20 +46,9 @@ namespace Elements.Geometry
         {
             this.Vertices = new[] { a, b, c };
 
-            if (!a.Triangles.Contains(this))
-            {
-                a.Triangles.Add(this);
-            }
-
-            if (!b.Triangles.Contains(this))
-            {
-                b.Triangles.Add(this);
-            }
-
-            if (!c.Triangles.Contains(this))
-            {
-                c.Triangles.Add(this);
-            }
+            a.Triangles.Add(this);
+            b.Triangles.Add(this);
+            c.Triangles.Add(this);
 
             var ab = (b.Position - a.Position).Unitized();
             var bc = (c.Position - a.Position).Unitized();

--- a/Elements/src/Geometry/Triangle.cs
+++ b/Elements/src/Geometry/Triangle.cs
@@ -26,9 +26,16 @@ namespace Elements.Geometry
         /// <param name="vertices">The vertices of the triangle.</param>
         /// <param name="normal">The normal of the triangle.</param>
         [JsonConstructor]
-        public Triangle(IList<Vertex> @vertices, Vector3 @normal)
+        public Triangle(IList<Vertex> vertices, Vector3 @normal)
         {
-            this.Vertices = @vertices;
+            this.Vertices = vertices;
+            foreach (var vert in vertices)
+            {
+                if (!vert.Triangles.Contains(this))
+                {
+                    vert.Triangles.Add(this);
+                }
+            }
             this.Normal = @normal;
         }
 

--- a/Elements/src/Geometry/Triangle.cs
+++ b/Elements/src/Geometry/Triangle.cs
@@ -26,17 +26,14 @@ namespace Elements.Geometry
         /// <param name="vertices">The vertices of the triangle.</param>
         /// <param name="normal">The normal of the triangle.</param>
         [JsonConstructor]
-        public Triangle(IList<Vertex> vertices, Vector3 @normal)
+        public Triangle(IList<Vertex> vertices, Vector3 normal)
         {
             this.Vertices = vertices;
             foreach (var vert in vertices)
             {
-                if (!vert.Triangles.Contains(this))
-                {
-                    vert.Triangles.Add(this);
-                }
+                vert.Triangles.Add(this);
             }
-            this.Normal = @normal;
+            this.Normal = normal;
         }
 
         /// <summary>

--- a/Elements/test/TopographyTests.cs
+++ b/Elements/test/TopographyTests.cs
@@ -380,6 +380,34 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void TrimTopoWithRegion()
+        {
+            Name = nameof(TrimTopoWithRegion);
+            var count = 10;
+            var elevations = new List<double>();
+            for (int i = 0; i < count; i++)
+            {
+                for (int j = 0; j < count; j++)
+                {
+                    elevations.Add(Math.Sin(i) + Math.Sin(j));
+                }
+            }
+            var topo = new Topography(Vector3.Origin, count, elevations.ToArray())
+            {
+                DepthBelowMinimumElevation = 3,
+            };
+            var polygonToProject = new Profile(new Circle((5, 5), 3).ToPolygon(50), new Circle((5, 5), 1).ToPolygon(6));
+            var trimmed = topo.Trimmed(polygonToProject);
+            trimmed.Material = BuiltInMaterials.XAxis;
+            trimmed.Transform.Move(0, 0, 0.001);
+            var topSurface = trimmed.TopMesh();
+            var me = new MeshElement(topSurface, new Transform(0, 0, 1), BuiltInMaterials.ZAxis);
+            Model.AddElement(topo);
+            Model.AddElement(trimmed);
+            Model.AddElement(me);
+        }
+
+        [Fact]
         public void CreateTopoFromMesh()
         {
             Name = nameof(CreateTopoFromMesh);


### PR DESCRIPTION
BACKGROUND:
- There was a request from some customers to support trimming a topography with a profile. The existing Trim method wasn't exactly what was needed, because it:
  - left behind a solid rather than just the top surface
  - didn't support voids within the projected shape
  - mutated the existing topography instead of creating a new mesh
DESCRIPTION:
- adds `Topography.Trimmed`, which returns a new Topopgraphy trimmed by a Profile
- adds `Topography.TopMesh` which returns just the upwards facing portion of the topo without the sides
- Updates `Topography.Trim` to support Profile instead of Polygon 
- Fixes an issue where cloning a mesh would result in incorrect vertex-triangle relationships, due to an oversight in one Triangle constructor

TESTING:
- Added a test which tests all new methods:
<img width="1289" alt="image" src="https://github.com/hypar-io/Elements/assets/31935763/40aede89-aca0-4707-b4fa-03933dad7ac0">

  
FUTURE WORK:
- calling `GetNakedBoundaries` results in some really funky shapes with these meshes... there's still something weird about the mesh topology after a CSG operation.

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/990)
<!-- Reviewable:end -->
