### PR TITLE
Real mid and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - `Bezier` now inherits from `BoundedCurve`.
 - `Polyline` is now parameterized 0->length.
 - `Circle` is now parameterized 0->2Pi.
-- `Line` is now parameterized 0->length.
+- `Circle` now implements the `IHasArcLength` interface
 - `Vector3.DistanceTo(Ray ray)` now returns positive infinity instead of throwing.
 - `Message`: removed obsolete `FromLine` method.
 - `AdaptiveGrid`: removed obsolete `TryGetVertexIndex` with `tolerance` parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,21 +23,31 @@
 - `Topography.Trimmed`
 - `new Topography(Topography other)`
 - `Topography.TopMesh()`
+- `Bezier.PointAtLength()`
+- `Bezier.PointAtNormalizedLength()`
+- `Bezier.ParameterAt()`
+- `Bezier.DivideByLength()`
+- `Bezier.Split()`
+- `Bezier.SplitAt()`
+- `Bezier.SplitByLength()`
+- `Bezier.ConstructPiecewiseCubicBezier()`
 
 ### Changed
 
 - `Polyline` now inherits from `BoundedCurve`.
 - `Polyline` is now parameterized 0->length.
-- `Polyline` now implements the `IHasArcLength` interface
+- `Polyline` now implements the `IHasArcLength` interface.
 - `Arc` now inherits from `TrimmedCurve<Circle>`.
-- `Arc` is now parameterized 0->2Pi
+- `Arc` is now parameterized 0->2Pi.
 - `Line` now inherits from `TrimmedCurve<InfiniteLine>`.
 - `Line` is now parameterized 0->length.
-- `Line` now implements the `IHasArcLength` interface
+- `Line` now implements the `IHasArcLength` interface.
 - `Bezier` now inherits from `BoundedCurve`.
+- `Bezier` now implements the `IHasArcLength` interface.
+- `Bezier.ArcLength()` now uses Gauss quadrature approximation vs linear sampling.
 - `Polyline` is now parameterized 0->length.
 - `Circle` is now parameterized 0->2Pi.
-- `Circle` now implements the `IHasArcLength` interface
+- `Circle` now implements the `IHasArcLength` interface.
 - `Vector3.DistanceTo(Ray ray)` now returns positive infinity instead of throwing.
 - `Message`: removed obsolete `FromLine` method.
 - `AdaptiveGrid`: removed obsolete `TryGetVertexIndex` with `tolerance` parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `Ellipse`
 - `EllipticalArc`
 - `IndexedPolycurve`
+- `IHasArcLength`
 - `Grid1d.GetCellDomains`
 - `Message.Info`
 - `Message.Error`
@@ -27,6 +28,7 @@
 
 - `Polyline` now inherits from `BoundedCurve`.
 - `Polyline` is now parameterized 0->length.
+- `Polyline` now implements the `IHasArcLength` interface
 - `Arc` now inherits from `TrimmedCurve<Circle>`.
 - `Arc` is now parameterized 0->2Pi
 - `Line` now inherits from `TrimmedCurve<InfiniteLine>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `Arc` is now parameterized 0->2Pi
 - `Line` now inherits from `TrimmedCurve<InfiniteLine>`.
 - `Line` is now parameterized 0->length.
+- `Line` now implements the `IHasArcLength` interface
 - `Bezier` now inherits from `BoundedCurve`.
 - `Polyline` is now parameterized 0->length.
 - `Circle` is now parameterized 0->2Pi.

--- a/Elements/src/Elements.csproj
+++ b/Elements/src/Elements.csproj
@@ -10,7 +10,7 @@
     <Summary>The Elements library provides object types for generating the built environment.</Summary>
     <PackageProjectUrl>https://github.com/hypar-io/elements</PackageProjectUrl>
     <RepositoryUrl>https://github.com/hypar-io/elements</RepositoryUrl>
-    <Version>$(Version)</Version>
+    <Version>21.21.21</Version>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>
   <ItemGroup>

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using Elements.Geometry.Interfaces;
 using Newtonsoft.Json;
+using System.Linq;
 
 namespace Elements.Geometry
 {
@@ -9,7 +11,7 @@ namespace Elements.Geometry
     // http://webhome.cs.uvic.ca/~blob/courses/305/notes/pdf/ref-frames.pdf
 
     /// <summary>
-    /// The frame type to be used for operations requiring 
+    /// The frame type to be used for operations requiring
     /// a moving frame around the curve.
     /// </summary>
     public enum FrameType
@@ -31,7 +33,7 @@ namespace Elements.Geometry
     /// <example>
     /// [!code-csharp[Main](../../Elements/test/BezierTests.cs?name=example)]
     /// </example>
-    public class Bezier : BoundedCurve
+    public class Bezier : BoundedCurve, IHasArcLength
     {
         private readonly int _lengthSamples = 500;
 
@@ -103,23 +105,156 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Calculate the length of the bezier between start and end parameters.
+        /// Constants for Gauss quadrature points and weights (n = 24)
+        /// https://pomax.github.io/bezierinfo/legendre-gauss.html
         /// </summary>
-        /// <returns>The length of the bezier between start and end.</returns>
+        private static readonly double[] T = new double[]
+        {
+        -0.0640568928626056260850430826247450385909,
+        0.0640568928626056260850430826247450385909,
+        -0.1911188674736163091586398207570696318404,
+        0.1911188674736163091586398207570696318404,
+        -0.3150426796961633743867932913198102407864,
+        0.3150426796961633743867932913198102407864,
+        -0.4337935076260451384870842319133497124524,
+        0.4337935076260451384870842319133497124524,
+        -0.5454214713888395356583756172183723700107,
+        0.5454214713888395356583756172183723700107,
+        -0.6480936519369755692524957869107476266696,
+        0.6480936519369755692524957869107476266696,
+        -0.7401241915785543642438281030999784255232,
+        0.7401241915785543642438281030999784255232,
+        -0.8200019859739029219539498726697452080761,
+        0.8200019859739029219539498726697452080761,
+        -0.8864155270044010342131543419821967550873,
+        0.8864155270044010342131543419821967550873,
+        -0.9382745520027327585236490017087214496548,
+        0.9382745520027327585236490017087214496548,
+        -0.9747285559713094981983919930081690617411,
+        0.9747285559713094981983919930081690617411,
+        -0.9951872199970213601799974097007368118745,
+        0.9951872199970213601799974097007368118745
+        };
+
+        /// <summary>
+        /// Constants for Gauss quadrature weights corresponding to the points (n = 24)
+        /// https://pomax.github.io/bezierinfo/legendre-gauss.html
+        /// </summary>
+        private static readonly double[] C = new double[]
+        {
+        0.1279381953467521569740561652246953718517,
+        0.1279381953467521569740561652246953718517,
+        0.1258374563468282961213753825111836887264,
+        0.1258374563468282961213753825111836887264,
+        0.121670472927803391204463153476262425607,
+        0.121670472927803391204463153476262425607,
+        0.1155056680537256013533444839067835598622,
+        0.1155056680537256013533444839067835598622,
+        0.1074442701159656347825773424466062227946,
+        0.1074442701159656347825773424466062227946,
+        0.0976186521041138882698806644642471544279,
+        0.0976186521041138882698806644642471544279,
+        0.086190161531953275917185202983742667185,
+        0.086190161531953275917185202983742667185,
+        0.0733464814110803057340336152531165181193,
+        0.0733464814110803057340336152531165181193,
+        0.0592985849154367807463677585001085845412,
+        0.0592985849154367807463677585001085845412,
+        0.0442774388174198061686027482113382288593,
+        0.0442774388174198061686027482113382288593,
+        0.0285313886289336631813078159518782864491,
+        0.0285313886289336631813078159518782864491,
+        0.0123412297999871995468056670700372915759,
+        0.0123412297999871995468056670700372915759
+                };
+
+        /// <summary>
+        /// Computes the arc length of the Bézier curve between the given parameter values start and end.
+        /// https://pomax.github.io/bezierinfo/#arclength
+        /// </summary>
+        /// <param name="start">The starting parameter value of the Bézier curve.</param>
+        /// <param name="end">The ending parameter value of the Bézier curve.</param>
+        /// <returns>The arc length between the specified parameter values.</returns>
         public override double ArcLength(double start, double end)
         {
-            if (!Domain.Includes(start, true))
+            double z = 0.5; // Scaling factor for the Legendre-Gauss quadrature
+            int len = T.Length; // Number of points in the Legendre-Gauss quadrature
+
+            double sum = 0; // Accumulated sum for the arc length calculation
+
+            // Iterating through the Legendre-Gauss quadrature points and weights
+            for (int i = 0; i < len; i++)
             {
-                throw new ArgumentOutOfRangeException("start", $"The start parameter {start} must be between {Domain.Min} and {Domain.Max}.");
-            }
-            if (!Domain.Includes(end, true))
-            {
-                throw new ArgumentOutOfRangeException("end", $"The end parameter {end} must be between {Domain.Min} and {Domain.Max}.");
+                double t = z * T[i] + z; // Mapping the quadrature point to the Bézier parameter range [0, 1]
+                Vector3 derivative = Derivative(t); // Calculating the derivative of the Bézier curve at parameter t
+                sum += C[i] * ArcFn(t, derivative); // Adding the weighted arc length contribution to the sum
             }
 
-            // TODO: We use max value here so that the calculation will continue
-            // until at least the end of the curve. This is not a nice solution.
-            return ArcLengthUntil(start, double.MaxValue, out end);
+            // Scaling the sum by the scaling factor and the parameter interval (end - start) to get the arc length between start and end.
+            return z * sum * (end - start);
+        }
+
+        /// <summary>
+        /// Calculates the arc length contribution at parameter t based on the derivative of the Bézier curve.
+        /// </summary>
+        /// <param name="t">The parameter value of the Bézier curve.</param>
+        /// <param name="d">The derivative of the Bézier curve at parameter t as a Vector3.</param>
+        /// <returns>The arc length contribution at parameter t.</returns>
+        private double ArcFn(double t, Vector3 d)
+        {
+            // Compute the Euclidean distance of the derivative vector (d) at parameter t
+            return Math.Sqrt(d.X * d.X + d.Y * d.Y);
+        }
+
+        /// <summary>
+        /// Computes the derivative of the Bézier curve at parameter t.
+        /// https://pomax.github.io/bezierinfo/#derivatives
+        /// </summary>
+        /// <param name="t">The parameter value of the Bézier curve.</param>
+        /// <returns>The derivative of the Bézier curve as a Vector3.</returns>
+        private Vector3 Derivative(double t)
+        {
+            int n = ControlPoints.Count - 1; // Degree of the Bézier curve
+            Vector3[] derivatives = new Vector3[n]; // Array to store the derivative control points
+
+            // Calculating the derivative control points using the given formula
+            for (int i = 0; i < n; i++)
+            {
+                derivatives[i] = n * (ControlPoints[i + 1] - ControlPoints[i]);
+            }
+
+            // Using the derivative control points to construct an (n-1)th degree Bézier curve at parameter t.
+            return BezierCurveValue(t, derivatives);
+        }
+
+        /// <summary>
+        /// Evaluates the value of an (n-1)th degree Bézier curve at parameter t using the given control points.
+        /// </summary>
+        /// <param name="t">The parameter value of the Bézier curve.</param>
+        /// <param name="controlPoints">The control points for the Bézier curve.</param>
+        /// <returns>The value of the Bézier curve at parameter t as a Vector3.</returns>
+        private Vector3 BezierCurveValue(double t, Vector3[] controlPoints)
+        {
+            int n = controlPoints.Length - 1; // Degree of the Bézier curve
+            Vector3[] points = new Vector3[n + 1];
+
+            // Initialize the points array with the provided control points
+            for (int i = 0; i <= n; i++)
+            {
+                points[i] = controlPoints[i];
+            }
+
+            // De Casteljau's algorithm to evaluate the value of the Bézier curve at parameter t
+            for (int r = 1; r <= n; r++)
+            {
+                for (int i = 0; i <= n - r; i++)
+                {
+                    points[i] = (1 - t) * points[i] + t * points[i + 1];
+                }
+            }
+
+            // The first element of the points array contains the value of the Bézier curve at parameter t.
+            return points[0];
         }
 
         private double ArcLengthUntil(double start, double distance, out double end)
@@ -150,6 +285,15 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// The mid point of the curve.
+        /// </summary>
+        /// <returns>The length based midpoint.</returns>
+        public virtual Vector3 MidPoint()
+        {
+            return PointAtNormalizedLength(0.5);
+        }
+
+        /// <summary>
         /// Get the point on the curve at parameter u.
         /// </summary>
         /// <param name="u">The parameter between 0.0 and 1.0.</param>
@@ -166,6 +310,157 @@ namespace Elements.Geometry
                 p += BerensteinBasisPolynomial(n, i, t) * ControlPoints[i];
             }
             return p;
+        }
+
+        /// <summary>
+        /// Returns the point on the bezier corresponding to the specified length value.
+        /// </summary>
+        /// <param name="length">The length value along the bezier.</param>
+        /// <returns>The point on the bezier corresponding to the specified length value.</returns>
+        /// <exception cref="ArgumentException">Thrown when the specified length is out of range.</exception>
+        public virtual Vector3 PointAtLength(double length)
+        {
+            double totalLength = ArcLength(this.Domain.Min, this.Domain.Max); // Calculate the total length of the Bezier
+            if (length < 0 || length > totalLength)
+            {
+                throw new ArgumentException("The specified length is out of range.");
+            }
+            return PointAt(ParameterAtDistanceFromParameter(length, Domain.Min));
+        }
+
+        /// <summary>
+        /// Returns the point on the bezier corresponding to the specified normalized length-based parameter value.
+        /// </summary>
+        /// <param name="parameter">The normalized length-based parameter value, ranging from 0 to 1.</param>
+        /// <returns>The point on the bezier corresponding to the specified normalized length-based parameter value.</returns>
+        /// <exception cref="ArgumentException">Thrown when the specified parameter is out of range.</exception>
+        public virtual Vector3 PointAtNormalizedLength(double parameter)
+        {
+            if (parameter < 0 || parameter > 1)
+            {
+                throw new ArgumentException("The specified parameter is out of range.");
+            }
+            return PointAtLength(parameter * this.ArcLength(this.Domain.Min, this.Domain.Max));
+        }
+
+        /// <summary>
+        /// Finds the parameter value on the Bezier curve that corresponds to the given 3D point within a specified threshold.
+        /// </summary>
+        /// <param name="point">The 3D point to find the corresponding parameter for.</param>
+        /// <param name="threshold">The maximum distance threshold to consider a match between the projected point and the original point.</param>
+        /// <returns>The parameter value on the Bezier curve if the distance between the projected point and the original point is within the threshold, otherwise returns null.</returns>
+        public double? ParameterAt(Vector3 point, double threshold = 0.0001)
+        {
+            // Find the parameter corresponding to the projected point on the Bezier curve
+            var parameter = ProjectedPoint(point, threshold);
+
+            if (parameter == null)
+            {
+                // If the projected point does not return a relevant parameter return null
+                return null;
+            }
+            // Find the 3D point on the Bezier curve at the obtained parameter value
+            var projection = PointAt((double)parameter);
+
+            // Check if the distance between the projected point and the original point is within
+            // a tolerence of the threshold
+            if (projection.DistanceTo(point) < (threshold * 10) - threshold)
+            {
+                // If the distance is within the threshold, return the parameter value
+                return parameter;
+            }
+            else
+            {
+                // If the distance exceeds the threshold, consider the point as not on the Bezier curve and return null
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Projects a 3D point onto the Bezier curve to find the parameter value of the closest point on the curve.
+        /// </summary>
+        /// <param name="point">The 3D point to project onto the Bezier curve.</param>
+        /// <param name="threshold">The maximum threshold to refine the projection and find the closest point.</param>
+        /// <returns>The parameter value on the Bezier curve corresponding to the projected point, or null if the projection is not within the specified threshold.</returns>
+        public double? ProjectedPoint(Vector3 point, double threshold = 0.001)
+        {
+            // https://pomax.github.io/bezierinfo/#projections
+            // Generate a lookup table (LUT) of points and their corresponding parameter values on the Bezier curve
+            List<(Vector3 point, double t)> lut = GenerateLookupTable();
+
+            // Initialize variables to store the closest distance (d) and the index (index) of the closest point in the lookup table
+            double d = double.MaxValue;
+            int index = 0;
+
+            // Find the closest point to the input point in the lookup table (LUT) using Euclidean distance
+            for (int i = 0; i < lut.Count; i++)
+            {
+                double q = Math.Sqrt(Math.Pow((point - lut[i].point).X, 2) + Math.Pow((point - lut[i].point).Y, 2) + Math.Pow((point - lut[i].point).Z, 2));
+                if (q < d)
+                {
+                    d = q;
+                    index = i;
+                }
+            }
+
+            // Obtain the parameter values of the neighboring points in the LUT for further refinement
+            double t1 = lut[Math.Max(index - 1, 0)].t;
+            double t2 = lut[Math.Min(index + 1, lut.Count - 1)].t;
+            double v = t2 - t1;
+
+            // Refine the projection by iteratively narrowing down the parameter range to find the closest point
+            while (v > threshold)
+            {
+                // Calculate intermediate parameter values
+                double t0 = t1 + v / 4;
+                double t3 = t2 - v / 4;
+
+                // Calculate corresponding points on the Bezier curve using the intermediate parameter values
+                Vector3 p0 = PointAt(t0);
+                Vector3 p3 = PointAt(t3);
+
+                // Calculate the distances between the input point and the points on the Bezier curve
+                double d0 = Math.Sqrt(Math.Pow((point - p0).X, 2) + Math.Pow((point - p0).Y, 2) + Math.Pow((point - p0).Z, 2));
+                double d3 = Math.Sqrt(Math.Pow((point - p3).X, 2) + Math.Pow((point - p3).Y, 2) + Math.Pow((point - p3).Z, 2));
+
+                // Choose the sub-range that is closer to the input point and update the range
+                if (d0 < d3)
+                {
+                    t2 = t3;
+                }
+                else
+                {
+                    t1 = t0;
+                }
+
+                // Update the range difference for the next iteration
+                v = t2 - t1;
+            }
+
+            // Return the average of the refined parameter values as the projection of the input point on the Bezier curve
+            return (t1 + t2) / 2;
+        }
+
+        /// <summary>
+        /// Generates a lookup table of points and their corresponding parameter values on the Bezier curve.
+        /// </summary>
+        /// <param name="numSamples">Number of samples to take along the curve.</param>
+        /// <returns>A list of tuples containing the sampled points and their corresponding parameter values on the Bezier curve.</returns>
+        private List<(Vector3 point, double t)> GenerateLookupTable(int numSamples = 100)
+        {
+            // Initialize an empty list to store the lookup table (LUT)
+            List<(Vector3 point, double t)> lut = new List<(Vector3 point, double t)>();
+
+            // Generate lookup table by sampling points on the Bezier curve
+            for (int i = 0; i <= numSamples; i++)
+            {
+                double t = (double)i / numSamples; // Calculate the parameter value based on the current sample index
+                Vector3 point = PointAt(t); // Get the 3D point on the Bezier curve corresponding to the current parameter value
+                lut.Add((point, t)); // Add the sampled point and its corresponding parameter value to the lookup table (LUT)
+            }
+
+            // Return the completed lookup table (LUT)
+            return lut;
         }
 
         private double BinomialCoefficient(int n, int i)
@@ -340,6 +635,275 @@ namespace Elements.Geometry
         {
             ArcLengthUntil(start, distance, out var end);
             return end;
+        }
+
+        /// <summary>
+        /// Divides the bezier into segments of the specified length.
+        /// </summary>
+        /// <param name="divisionLength">The desired length of each segment.</param>
+        /// <returns>A list of points representing the segment divisions.</returns>
+        public Vector3[] DivideByLength(double divisionLength)
+        {
+            var totalLength = this.ArcLength(Domain.Min, Domain.Max);
+            if (totalLength <= 0)
+            {
+                // Handle invalid bezier with insufficient length
+                return new Vector3[0];
+            }
+            var parameter = ParameterAtDistanceFromParameter(divisionLength, Domain.Min);
+            var segments = new List<Vector3> { this.Start };
+
+            while (parameter < Domain.Max)
+            {
+                segments.Add(PointAt(parameter));
+                var newParameter = ParameterAtDistanceFromParameter(divisionLength, parameter);
+                parameter = newParameter != parameter ? newParameter : Domain.Max;
+            }
+
+            // Add the last vertex of the bezier as the endpoint of the last segment if it
+            // is not already part of the list
+            if (!segments[segments.Count - 1].IsAlmostEqualTo(this.End))
+            {
+                segments.Add(this.End);
+            }
+
+            return segments.ToArray();
+        }
+
+        /// <summary>
+        /// Divides the bezier into segments of the specified length.
+        /// </summary>
+        /// <param name="divisionLength">The desired length of each segment.</param>
+        /// <returns>A list of beziers representing the segments.</returns>
+        public List<Bezier> SplitByLength(double divisionLength)
+        {
+            var totalLength = this.ArcLength(Domain.Min, Domain.Max);
+            if (totalLength <= 0)
+            {
+                // Handle invalid bezier with insufficient length
+                return null;
+            }
+            var currentParameter = ParameterAtDistanceFromParameter(divisionLength, Domain.Min);
+            var parameters = new List<double> { this.Domain.Min };
+
+            while (currentParameter < Domain.Max)
+            {
+                parameters.Add(currentParameter);
+                var newParameter = ParameterAtDistanceFromParameter(divisionLength, currentParameter);
+                currentParameter = newParameter != currentParameter ? newParameter : Domain.Max;
+            }
+
+            // Add the last vertex of the bezier as the endpoint of the last segment if it
+            // is not already part of the list
+            if (!parameters[parameters.Count - 1].ApproximatelyEquals(this.Domain.Max))
+            {
+                parameters.Add(this.Domain.Max);
+            }
+
+            return Split(parameters);
+        }
+
+        /// <summary>
+        /// Splits the Bezier curve into segments at specified parameter values.
+        /// </summary>
+        /// <param name="parameters">The list of parameter values to split the curve at.</param>
+        /// <param name="normalize">If true the parameters will be length normalized.</param>
+        /// <returns>A list of Bezier segments obtained after splitting.</returns>
+        public List<Bezier> Split(List<double> parameters, bool normalize = false)
+        {
+            // Calculate the total length of the Bezier curve
+            var totalLength = this.ArcLength(Domain.Min, Domain.Max);
+
+            // Check for invalid curve with insufficient length
+            if (totalLength <= 0)
+            {
+                throw new InvalidOperationException($"Invalid bezier with insufficient length. Total Length = {totalLength}");
+            }
+
+            // Check if the list of parameters is empty or null
+            if (parameters == null || parameters.Count == 0)
+            {
+                throw new ArgumentException("No split points provided.");
+            }
+
+            // Initialize a list to store the resulting Bezier segments
+            var segments = new List<Bezier>();
+            var bezier = this; // Create a reference to the original Bezier curve
+
+            if (normalize)
+            {
+                parameters = parameters.Select(parameter => ParameterAtDistanceFromParameter(parameter * this.ArcLength(this.Domain.Min, this.Domain.Max), Domain.Min)).ToList();
+            }
+            parameters.Sort(); // Sort the parameters in ascending order
+
+            // Iterate through each parameter to split the curve
+            for (int i = 0; i < parameters.Count; i++)
+            {
+                double t = (Domain.Min <= parameters[i] && parameters[i] <= Domain.Max)
+                    ? parameters[i] // Ensure the parameter is within the domain
+                    : throw new ArgumentException($"Parameter {parameters[i]} is not within the domain ({Domain.Min}->{Domain.Max}) of the Bezier curve.");
+
+                // Check if the parameter is within the valid range [0, 1]
+                if (t >= 0 && t <= 1)
+                {
+                    // Split the curve at the given parameter and obtain the two resulting Bezier segments
+                    var tuple = bezier.SplitAt(t);
+
+                    // Store the first split Bezier in the list
+                    segments.Add(tuple.Item1);
+
+                    // Update bezier to the second split Bezier to continue splitting
+                    bezier = tuple.Item2;
+
+                    // Remap subsequent parameters to the new Bezier curve's parameter space
+                    for (int j = i + 1; j < parameters.Count; j++)
+                    {
+                        parameters[j] = (parameters[j] - t) / (1 - t);
+                    }
+                }
+            }
+
+            segments.Add(bezier);
+
+            // Return the list of Bezier segments obtained after splitting
+            return segments;
+        }
+
+        /// <summary>
+        /// Splits the bezier curve at the given parameter value.
+        /// </summary>
+        /// <param name="t">The parameter value at which to split the curve.</param>
+        /// <returns>A tuple containing two split bezier curves.</returns>
+        public Tuple<Bezier, Bezier> SplitAt(double t)
+        {
+            // Extract the control points from the input bezier
+            var startPoint = ControlPoints[0];
+            var controlPoint1 = ControlPoints[1];
+            var controlPoint2 = ControlPoints[2];
+            var endPoint = ControlPoints[3];
+
+            // Compute the intermediate points using de Casteljau's algorithm
+            var q0 = (1 - t) * startPoint + t * controlPoint1;
+            var q1 = (1 - t) * controlPoint1 + t * controlPoint2;
+            var q2 = (1 - t) * controlPoint2 + t * endPoint;
+
+            var r0 = (1 - t) * q0 + t * q1;
+            var r1 = (1 - t) * q1 + t * q2;
+
+            // Compute the split point on the bezier curve
+            var splitPoint = (1 - t) * r0 + t * r1;
+
+            // Construct the first split bezier curve
+            var subBezier1 = new Bezier(new List<Vector3>() { startPoint, q0, r0, splitPoint });
+
+            // Construct the second split bezier curve
+            var subBezier2 = new Bezier(new List<Vector3>() { splitPoint, r1, q2, endPoint });
+
+            // Return a tuple containing the split bezier curves
+            return new Tuple<Bezier, Bezier>(subBezier1, subBezier2);
+        }
+
+        /// <summary>
+        /// Constructs piecewise cubic Bézier curves from a list of points using control points calculated with the specified looseness.
+        /// </summary>
+        /// <param name="points">The list of points defining the path.</param>
+        /// <param name="looseness">The looseness factor used to calculate control points. A higher value results in smoother curves.</param>
+        /// <param name="close">If true, the path will be closed, connecting the last point with the first one.</param>
+        /// <returns>A list of piecewise cubic Bézier curves approximating the path defined by the input points.</returns>
+        public static List<Bezier> ConstructPiecewiseCubicBezier(List<Vector3> points, double looseness = 6.0, bool close = false)
+        {
+            List<Bezier> beziers = new List<Bezier>();
+
+            // Calculate the control points.
+            List<Vector3[]> controlPoints = CalculateControlPoints(points, looseness);
+
+            // Create the start Bezier curve.
+            Bezier startBezier = new Bezier(
+                new List<Vector3>
+                {
+                    points[0],
+                    controlPoints[0][1],
+                    points[1]
+                }
+            );
+
+            // Add the start Bezier curve to the list.
+            beziers.Add(startBezier);
+
+            // Iterate through pairs of points.
+            for (int i = 1; i < points.Count - 2; i++)
+            {
+                // Create the control points.
+                List<Vector3> bezierControlPoints = new List<Vector3>
+                {
+                    points[i],
+                    controlPoints[i - 1][0],
+                    controlPoints[i][1],
+                    points[i + 1]
+                };
+
+                // Create the Bezier curve.
+                Bezier bezier = new Bezier(bezierControlPoints);
+
+                // Add the Bezier curve to the list.
+                beziers.Add(bezier);
+            }
+
+            // Create the end Bezier curve.
+            Bezier endBezier = new Bezier(
+                new List<Vector3>
+                {
+                    points[points.Count() - 1],
+                    controlPoints[controlPoints.Count() - 1][0],
+                    points[points.Count() - 2]
+                }
+            );
+
+            // Add the end Bezier curve to the list.
+            beziers.Add(endBezier);
+
+            // Return the list of Bezier curves.
+            return beziers;
+        }
+
+        /// <summary>
+        /// Calculates the control points for constructing piecewise cubic Bézier curves from the given list of points and looseness factor.
+        /// </summary>
+        /// <param name="points">The list of points defining the path.</param>
+        /// <param name="looseness">The looseness factor used to calculate control points. A higher value results in smoother curves.</param>
+        /// <returns>A list of control points (pairs of Vector3) for the piecewise cubic Bézier curves.</returns>
+        private static List<Vector3[]> CalculateControlPoints(List<Vector3> points, double looseness)
+        {
+            List<Vector3[]> controlPoints = new List<Vector3[]>();
+
+            for (int i = 1; i < points.Count - 1; i++)
+            {
+                // Calculate the differences in x and y coordinates.
+                var dx = points[i - 1].X - points[i + 1].X;
+                var dy = points[i - 1].Y - points[i + 1].Y;
+
+                // Calculate the control point coordinates.
+                var controlPointX1 = points[i].X - dx * (1 / looseness);
+                var controlPointY1 = points[i].Y - dy * (1 / looseness);
+                var controlPoint1 = new Vector3(controlPointX1, controlPointY1, 0);
+
+                var controlPointX2 = points[i].X + dx * (1 / looseness);
+                var controlPointY2 = points[i].Y + dy * (1 / looseness);
+                var controlPoint2 = new Vector3(controlPointX2, controlPointY2, 0);
+
+                // Create an array to store the control points.
+                Vector3[] controlPointArray = new Vector3[]
+                {
+            controlPoint1,
+            controlPoint2
+                };
+
+                // Add the control points to the list.
+                controlPoints.Add(controlPointArray);
+            }
+
+            // Return the list of control points.
+            return controlPoints;
         }
     }
 }

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -881,21 +881,24 @@ namespace Elements.Geometry
                 // Calculate the differences in x and y coordinates.
                 var dx = points[i - 1].X - points[i + 1].X;
                 var dy = points[i - 1].Y - points[i + 1].Y;
+                var dz = points[i - 1].Z - points[i + 1].Z;
 
                 // Calculate the control point coordinates.
                 var controlPointX1 = points[i].X - dx * (1 / looseness);
                 var controlPointY1 = points[i].Y - dy * (1 / looseness);
-                var controlPoint1 = new Vector3(controlPointX1, controlPointY1, 0);
+                var controlPointZ1 = points[i].Z - dz * (1 / looseness);
+                var controlPoint1 = new Vector3(controlPointX1, controlPointY1, controlPointZ1);
 
                 var controlPointX2 = points[i].X + dx * (1 / looseness);
                 var controlPointY2 = points[i].Y + dy * (1 / looseness);
-                var controlPoint2 = new Vector3(controlPointX2, controlPointY2, 0);
+                var controlPointZ2 = points[i].Z + dz * (1 / looseness);
+                var controlPoint2 = new Vector3(controlPointX2, controlPointY2, controlPointZ2);
 
                 // Create an array to store the control points.
                 Vector3[] controlPointArray = new Vector3[]
                 {
-            controlPoint1,
-            controlPoint2
+                    controlPoint1,
+                    controlPoint2
                 };
 
                 // Add the control points to the list.

--- a/Elements/src/Geometry/Interfaces/IHasArcLength.cs
+++ b/Elements/src/Geometry/Interfaces/IHasArcLength.cs
@@ -1,0 +1,38 @@
+namespace Elements.Geometry.Interfaces
+{
+    /// <summary>
+    /// Represents a curve with arc length-based operations.
+    /// Implementing classes define methods for computing points and performing operations based on arc length.
+    /// </summary>
+    public interface IHasArcLength
+    {
+        /// <summary>
+        /// Returns the point on the curve at the specified arc length.
+        /// </summary>
+        /// <param name="length">The arc length along the curve.</param>
+        /// <returns>The point on the curve at the specified arc length.</returns>
+        Vector3 PointAtLength(double length);
+
+        /// <summary>
+        /// Returns the point on the curve at the specified normalized length.
+        /// The normalized length is a value between 0 and 1 representing the relative position along the curve.
+        /// </summary>
+        /// <param name="normalizedLength">The normalized length along the curve.</param>
+        /// <returns>The point on the curve at the specified normalized length.</returns>
+        Vector3 PointAtNormalizedLength(double normalizedLength);
+
+        /// <summary>
+        /// Returns the midpoint of the curve.
+        /// </summary>
+        /// <returns>The midpoint of the curve.</returns>
+        Vector3 MidPoint();
+
+        /// <summary>
+        /// Divides the curve into segments of the specified length and returns the points along the curve at those intervals.
+        /// </summary>
+        /// <param name="length">The desired length for dividing the curve.</param>
+        /// <returns>A list of points representing the divisions along the curve.</returns>
+        Vector3[] DivideByLength(double length);
+    }
+
+}

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Elements.Spatial;
+using Elements.Geometry.Interfaces;
 
 namespace Elements.Geometry
 {
@@ -15,7 +16,7 @@ namespace Elements.Geometry
     /// [!code-csharp[Main](../../Elements/test/LineTests.cs?name=example)]
     /// </example>
     /// TODO: Rename this class to LineSegment
-    public class Line : TrimmedCurve<InfiniteLine>, IEquatable<Line>
+    public class Line : TrimmedCurve<InfiniteLine>, IEquatable<Line>, IHasArcLength
     {
         /// <summary>
         /// The domain of the curve.
@@ -121,6 +122,48 @@ namespace Elements.Geometry
                 throw new Exception($"The parameter {u} is not on the trimmed portion of the basis curve. The parameter must be between {Domain.Min} and {Domain.Max}.");
             }
             return this.BasisCurve.PointAt(u);
+        }
+
+        /// <summary>
+        /// The mid point of the curve.
+        /// </summary>
+        /// <returns>The length based midpoint.</returns>
+        public virtual Vector3 MidPoint()
+        {
+            return PointAtNormalizedLength(0.5);
+        }
+
+        /// <summary>
+        /// Returns the point on the line corresponding to the specified length value.
+        /// </summary>
+        /// <param name="length">The length value along the line.</param>
+        /// <returns>The point on the line corresponding to the specified length value.</returns>
+        /// <exception cref="ArgumentException">Thrown when the specified length is out of range.</exception>
+        public virtual Vector3 PointAtLength(double length)
+        {
+            double totalLength = ArcLength(this.Domain.Min, this.Domain.Max); // Calculate the total length of the Line
+
+            if (length < 0 || length > totalLength)
+            {
+                throw new ArgumentException("The specified length is out of range.");
+            }
+            var lengthParameter = length / totalLength;
+            return this.PointAtNormalized(lengthParameter);
+        }
+
+        /// <summary>
+        /// Returns the point on the line corresponding to the specified normalized length-based parameter value.
+        /// </summary>
+        /// <param name="parameter">The normalized length-based parameter value, ranging from 0 to 1.</param>
+        /// <returns>The point on the line corresponding to the specified normalized length-based parameter value.</returns>
+        /// <exception cref="ArgumentException">Thrown when the specified parameter is out of range.</exception>
+        public virtual Vector3 PointAtNormalizedLength(double parameter)
+        {
+            if (parameter < 0 || parameter > 1)
+            {
+                throw new ArgumentException("The specified parameter is out of range.");
+            }
+            return PointAtLength(parameter * this.ArcLength(this.Domain.Min, this.Domain.Max));
         }
 
         /// <inheritdoc/>
@@ -541,38 +584,79 @@ namespace Elements.Geometry
             return false;
         }
 
+        // /// <summary>
+        // /// Divide the line into as many segments of the provided length as possible.
+        // /// </summary>
+        // /// <param name="l">The length.</param>
+        // /// <param name="removeShortSegments">A flag indicating whether segments shorter than l should be removed.</param>
+        // public List<Line> DivideByLength(double l, bool removeShortSegments = false)
+        // {
+        //     var len = this.Length();
+        //     if (l > len)
+        //     {
+        //         return new List<Line>() { new Line(this.Start, this.End) };
+        //     }
+
+        //     var total = 0.0;
+        //     var d = this.Direction();
+        //     var lines = new List<Line>();
+        //     while (total + l <= len)
+        //     {
+        //         var a = this.Start + d * total;
+        //         var b = a + d * l;
+        //         lines.Add(new Line(a, b));
+        //         total += l;
+        //     }
+        //     if (total < len && !removeShortSegments)
+        //     {
+        //         var a = this.Start + d * total;
+        //         if (!a.IsAlmostEqualTo(End))
+        //         {
+        //             lines.Add(new Line(a, End));
+        //         }
+        //     }
+        //     return lines;
+        // }
+
         /// <summary>
-        /// Divide the line into as many segments of the provided length as possible.
+        /// Divides the line into segments of the specified length.
         /// </summary>
-        /// <param name="l">The length.</param>
-        /// <param name="removeShortSegments">A flag indicating whether segments shorter than l should be removed.</param>
-        public List<Line> DivideByLength(double l, bool removeShortSegments = false)
+        /// <param name="divisionLength">The desired length of each segment.</param>
+        /// <returns>A list of points representing the segments.</returns>
+        public Vector3[] DivideByLength(double divisionLength)
         {
-            var len = this.Length();
-            if (l > len)
+            var segments = new List<Vector3>();
+
+            if (this.ArcLength(this.Domain.Min, this.Domain.Max) < double.Epsilon)
             {
-                return new List<Line>() { new Line(this.Start, this.End) };
+                // Handle invalid line with insufficient length
+                return new Vector3[0];
             }
 
-            var total = 0.0;
-            var d = this.Direction();
-            var lines = new List<Line>();
-            while (total + l <= len)
+            var currentProgression = 0.0;
+            segments = new List<Vector3> { this.Start };
+
+            // currentProgression from last segment before hitting end
+            if (currentProgression != 0.0)
             {
-                var a = this.Start + d * total;
-                var b = a + d * l;
-                lines.Add(new Line(a, b));
-                total += l;
+                currentProgression -= divisionLength;
             }
-            if (total < len && !removeShortSegments)
+            while (this.ArcLength(this.Domain.Min, this.Domain.Max) >= currentProgression + divisionLength)
             {
-                var a = this.Start + d * total;
-                if (!a.IsAlmostEqualTo(End))
-                {
-                    lines.Add(new Line(a, End));
-                }
+                segments.Add(this.PointAt(currentProgression + divisionLength));
+                currentProgression += divisionLength;
             }
-            return lines;
+            // Set currentProgression from divisionLength less distance from last segment point
+            currentProgression = divisionLength - segments.LastOrDefault().DistanceTo(this.End);
+
+            // Add the last vertex of the polyline as the endpoint of the last segment if it
+            // is not already part of the list
+            if (!segments.LastOrDefault().IsAlmostEqualTo(this.End))
+            {
+                segments.Add(this.End);
+            }
+
+            return segments.ToArray();
         }
 
         /// <summary>
@@ -925,7 +1009,7 @@ namespace Elements.Geometry
             // line vectors are not collinear, their directions share the common plane.
             else
             {
-                // dStartStart length is distance to the common plane. 
+                // dStartStart length is distance to the common plane.
                 dStartStart = dStartStart.ProjectOnto(cross);
                 Vector3 vStartStart = other.Start + dStartStart - this.Start;
                 Vector3 vStartEnd = other.Start + dStartStart - this.End;
@@ -1028,8 +1112,8 @@ namespace Elements.Geometry
                 var B = intersectionsOrdered[i + 1];
                 if (A.IsAlmostEqualTo(B)) // skip duplicate points
                 {
-                    // it's possible that A is outside, but B is at an edge, even 
-                    // if they are within tolerance of each other. 
+                    // it's possible that A is outside, but B is at an edge, even
+                    // if they are within tolerance of each other.
                     // This can happen due to floating point error when the point is almost exactly
                     // epsilon distance from the edge.
                     // so if we have duplicate points, we have to update the containment value.

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -85,8 +85,6 @@ namespace Elements.Geometry
             return SegmentsInternal(this.Vertices);
         }
 
-
-
         /// <summary>
         /// The mid point of the curve.
         /// </summary>

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -452,8 +452,6 @@ namespace Elements.Geometry
         /// <returns>A list of points representing the segments.</returns>
         public Vector3[] DivideByLength(double divisionLength)
         {
-            var segments = new List<Vector3>();
-
             if (this.Vertices.Count < 2)
             {
                 // Handle invalid polyline with insufficient vertices
@@ -461,7 +459,7 @@ namespace Elements.Geometry
             }
 
             var currentProgression = 0.0;
-            segments = new List<Vector3> { this.Vertices.FirstOrDefault() };
+            var segments = new List<Vector3> { this.Vertices.FirstOrDefault() };
 
             foreach (var currentSegment in this.Segments())
             {

--- a/Elements/test/BezierTests.cs
+++ b/Elements/test/BezierTests.cs
@@ -67,5 +67,166 @@ namespace Hypar.Tests
             var polylineLength = bezier.ToPolyline(divisions).Length();
             Assert.Equal(polylineLength, bezier.Length());
         }
+
+        [Fact]
+        public void Bezier_ArcLength()
+        {
+            var a = new Vector3(50, 150, 0);
+            var b = new Vector3(105, 66, 0);
+            var c = new Vector3(170, 230, 0);
+            var d = new Vector3(200, 150, 0);
+            var ctrlPts = new List<Vector3> { a, b, c, d };
+            var bezier = new Bezier(ctrlPts);
+
+            var expectedLength = 184.38886379602502;  // approximation as the integral function used for calculating length is not 100% accurate
+            Assert.Equal(expectedLength, bezier.ArcLength(0.0, 1.0), 2);
+        }
+
+        [Fact]
+        public void GetParameterAt()
+        {
+            var tolerance = 0.00001;
+
+            var a = new Vector3(1, 5, 0);
+            var b = new Vector3(5, 20, 0);
+            var c = new Vector3(5, -10, 0);
+            var d = new Vector3(9, 5, 0);
+            var ctrlPts = new List<Vector3> { a, b, c, d };
+            var bezier = new Bezier(ctrlPts);
+
+            var samplePt = new Vector3(0, 0, 0);
+            Assert.Null(bezier.ParameterAt(samplePt, tolerance));
+
+            samplePt = new Vector3(6.625, 0.7812, 0.0);
+            Assert.True((double)bezier.ParameterAt(samplePt, tolerance) - 0.75 <= tolerance * 10);
+        }
+
+        [Fact]
+        public void GetPointAt()
+        {
+            var a = new Vector3(1, 5, 0);
+            var b = new Vector3(5, 20, 0);
+            var c = new Vector3(5, -10, 0);
+            var d = new Vector3(9, 5, 0);
+            var ctrlPts = new List<Vector3> { a, b, c, d };
+            var bezier = new Bezier(ctrlPts);
+
+            var testPt = new Vector3(3.3750, 9.21875, 0.0000);
+            Assert.True(testPt.Equals(bezier.PointAt(0.25)));
+
+            testPt = new Vector3(4.699, 6.11375, 0.0000);
+            Assert.True(testPt.Equals(bezier.PointAtNormalized(0.45)));
+
+            testPt = new Vector3(4.515904, 6.75392, 0.0000);
+            Assert.True(testPt.Equals(bezier.PointAtLength(8.0)));
+
+            testPt = new Vector3(3.048823, 9.329262, 0.0000);
+            Assert.True(testPt.Equals(bezier.PointAtNormalizedLength(0.25)));
+        }
+
+        [Fact]
+        public void DivideByLength()
+        {
+            var a = new Vector3(50, 150, 0);
+            var b = new Vector3(105, 66, 0);
+            var c = new Vector3(170, 230, 0);
+            var d = new Vector3(200, 150, 0);
+            var ctrlPts = new List<Vector3> { a, b, c, d };
+            var bezier = new Bezier(ctrlPts);
+
+            var testPts = new List<Vector3>(){
+                new Vector3(50.00, 150.00, 0.00),
+                new Vector3(90.705919, 125.572992, 0.00),
+                new Vector3(134.607122, 148.677130, 0.00),
+                new Vector3(177.600231, 172.675064, 0.00),
+                new Vector3(200.00, 150.00, 0.00),
+            };
+
+            var ptsFromBezier = bezier.DivideByLength(50.0);
+
+            for (int i = 0; i < ptsFromBezier.Length; i++)
+            {
+                Assert.True(ptsFromBezier[i].Equals(testPts[i]));
+            }
+        }
+
+        [Fact]
+        public void Split()
+        {
+            var a = new Vector3(50, 150, 0);
+            var b = new Vector3(105, 66, 0);
+            var c = new Vector3(170, 230, 0);
+            var d = new Vector3(200, 150, 0);
+            var ctrlPts = new List<Vector3> { a, b, c, d };
+            var bezier = new Bezier(ctrlPts);
+
+            var testBeziers = new List<Bezier>(){
+                new Bezier(new List<Vector3>() {
+                    new Vector3(50.00, 150.00, 0.00),
+                    new Vector3(63.75, 129.00, 0.00),
+                    new Vector3(78.1250, 123.50, 0.00),
+                    new Vector3(92.421875, 125.8125, 0.00)
+                    }
+                ),
+                new Bezier(new List<Vector3>() {
+                    new Vector3(92.421875, 125.8125, 0.00),
+                    new Vector3(121.015625, 130.4375, 0.00),
+                    new Vector3(149.296875, 166.3125, 0.00),
+                    new Vector3(171.640625, 171.9375, 0.00)
+                    }
+                ),
+                new Bezier(new List<Vector3>() {
+                    new Vector3(171.640625, 171.9375, 0.00),
+                    new Vector3(182.8125, 174.7500, 0.00),
+                    new Vector3(192.50, 170.00, 0.00),
+                    new Vector3(200.00, 150.00, 0.00)
+                    }
+                ),
+            };
+
+            var beziers = bezier.Split(new List<double>() { 0.25, 0.75 });
+
+            for (int i = 0; i < beziers.Count; i++)
+            {
+                Assert.True(beziers[i].ControlPoints[0].Equals(testBeziers[i].ControlPoints[0]));
+                Assert.True(beziers[i].ControlPoints[1].Equals(testBeziers[i].ControlPoints[1]));
+                Assert.True(beziers[i].ControlPoints[2].Equals(testBeziers[i].ControlPoints[2]));
+                Assert.True(beziers[i].ControlPoints[3].Equals(testBeziers[i].ControlPoints[3]));
+            }
+
+            testBeziers = new List<Bezier>(){
+                new Bezier(new List<Vector3>() {
+                    new Vector3(50.00, 150.00, 0.00),
+                    new Vector3(61.88, 131.856, 0.00),
+                    new Vector3(74.22656, 125.282688, 0.00),
+                    new Vector3(86.586183, 125.321837, 0.00)
+                    }
+                ),
+                new Bezier(new List<Vector3>() {
+                    new Vector3(86.586183, 125.321837, 0.00),
+                    new Vector3(114.738659, 125.411011, 0.00),
+                    new Vector3(142.958913, 159.807432, 0.00),
+                    new Vector3(165.887648, 169.916119, 0.00)
+                    }
+                ),
+                new Bezier(new List<Vector3>() {
+                    new Vector3(165.887648, 169.916119, 0.00),
+                    new Vector3(179.49576, 175.915584, 0.00),
+                    new Vector3(191.24, 173.36, 0.00),
+                    new Vector3(200.00, 150.00, 0.00)
+                    }
+                ),
+            };
+
+            var normalizedBeziers = bezier.Split(new List<double>() { 0.25, 0.75 }, true);
+
+            for (int i = 0; i < normalizedBeziers.Count; i++)
+            {
+                Assert.True(normalizedBeziers[i].ControlPoints[0].Equals(testBeziers[i].ControlPoints[0]));
+                Assert.True(normalizedBeziers[i].ControlPoints[1].Equals(testBeziers[i].ControlPoints[1]));
+                Assert.True(normalizedBeziers[i].ControlPoints[2].Equals(testBeziers[i].ControlPoints[2]));
+                Assert.True(normalizedBeziers[i].ControlPoints[3].Equals(testBeziers[i].ControlPoints[3]));
+            }
+        }
     }
 }

--- a/Elements/test/CircleTests.cs
+++ b/Elements/test/CircleTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Elements.Tests;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Elements.Geometry.Tests
+{
+    public class CircleTests : ModelTest
+    {
+        public CircleTests()
+        {
+            this.GenerateIfc = false;
+        }
+
+        [Fact, Trait("Category", "Examples")]
+        public void CircleExample()
+        {
+            this.Name = "Elements_Geometry_Circle";
+
+            // <example>
+            var a = new Vector3();
+            var b = 1.0;
+            var c = new Circle(a, b);
+            // </example>
+
+            this.Model.AddElement(c);
+        }
+
+        [Fact]
+        public void Equality()
+        {
+            var p = 1.0;
+            var circleA = new Circle(Vector3.Origin, p);
+            var circleB = new Circle(Vector3.Origin, p + 1E-4);
+            var circleC = new Circle(Vector3.Origin, p + 1E-6);
+
+            Assert.False(circleA.IsAlmostEqualTo(circleB));
+            Assert.True(circleA.IsAlmostEqualTo(circleB, 1E-3));
+            Assert.True(circleA.IsAlmostEqualTo(circleC));
+        }
+
+        [Fact]
+        public void Construct()
+        {
+            var a = new Vector3();
+            var b = 1.0;
+            var c = new Circle(a, b);
+            Assert.Equal(1.0, c.Radius);
+            Assert.Equal(new Vector3(0, 0), c.Center);
+            Assert.Equal(a + new Vector3(b, 0, 0), c.PointAt(-1e-10));
+        }
+
+        [Fact]
+        public void ZeroRadius_ThrowsException()
+        {
+            var a = new Vector3();
+            Assert.Throws<ArgumentException>(() => new Circle(a, 0));
+        }
+
+        [Fact]
+        public void DivideIntoEqualSegments()
+        {
+            var l = new Line(Vector3.Origin, new Vector3(100, 0));
+            var segments = l.DivideIntoEqualSegments(41);
+            var len = l.Length();
+            Assert.Equal(41, segments.Count);
+            foreach (var s in segments)
+            {
+                Assert.Equal(s.Length(), len / 41, 5);
+            }
+        }
+
+        [Fact]
+        public void DivideIntoEqualSegmentsSingle()
+        {
+            var l = new Line(Vector3.Origin, new Vector3(100, 0));
+            var segments = l.DivideIntoEqualSegments(1);
+            Assert.Single(segments);
+            Assert.True(segments.First().Start.IsAlmostEqualTo(l.Start, 1e-10));
+            Assert.True(segments.First().End.IsAlmostEqualTo(l.End, 1e-10));
+        }
+
+        [Fact]
+        public void DivideByLength()
+        {
+            var l = new Line(Vector3.Origin, new Vector3(5, 0));
+            var segments = l.DivideByLength(1.1);
+            Assert.Equal(6, segments.Count());
+
+            var segments1 = l.DivideByLength(2);
+            Assert.Equal(4, segments1.Count());
+        }
+
+        [Fact]
+        public void GetParameterAt()
+        {
+            var center = Vector3.Origin;
+            var radius = 5.0;
+            var circle = new Circle(center, radius);
+            var start = new Vector3(5.0, 0.0, 0.0);
+            var mid = new Vector3(-5.0, 0.0, 0.0);
+
+            Assert.Equal(0, circle.GetParameterAt(start));
+
+            var almostEqualStart = new Vector3(5.000001, 0.000005, 0);
+            Assert.True(start.IsAlmostEqualTo(almostEqualStart));
+
+            Assert.True(Math.Abs(circle.GetParameterAt(mid) - Math.PI) < double.Epsilon ? true : false);
+
+            var vector = new Vector3(3.535533, 3.535533, 0.0);
+            var uValue = circle.GetParameterAt(vector);
+            var expectedVector = circle.PointAt(uValue);
+            Assert.InRange(uValue, 0, circle.Circumference);
+            Assert.True(vector.IsAlmostEqualTo(expectedVector));
+
+            var parameter = 0.5;
+            var testParameterMidpoint = circle.PointAtNormalizedLength(parameter);
+            Assert.True(testParameterMidpoint.IsAlmostEqualTo(mid));
+
+            var midlength = circle.Circumference * parameter;
+            var testLengthMidpoint = circle.PointAtLength(midlength);
+            Assert.True(testLengthMidpoint.IsAlmostEqualTo(testParameterMidpoint));
+
+            var midpoint = circle.MidPoint();
+            Assert.True(midpoint.IsAlmostEqualTo(testLengthMidpoint));
+        }
+
+        [Fact]
+        public void PointOnLine()
+        {
+            Circle circle = new Circle(Vector3.Origin, 5.0);
+
+            Assert.False(Circle.PointOnCircle(Vector3.Origin, circle));
+            Assert.False(Circle.PointOnCircle(new Vector3(4, 0, 0), circle));
+            Assert.True(Circle.PointOnCircle(circle.PointAtNormalizedLength(0.5), circle));
+        }
+    }
+}

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -163,11 +163,11 @@ namespace Elements.Geometry.Tests
         public void DivideByLength()
         {
             var l = new Line(Vector3.Origin, new Vector3(5, 0));
-            var segments = l.DivideByLength(1.1, true);
-            Assert.Equal(4, segments.Count);
+            var segments = l.DivideByLength(1.1);
+            Assert.Equal(6, segments.Count());
 
-            var segments1 = l.DivideByLength(1.1);
-            Assert.Equal(5, segments1.Count);
+            var segments1 = l.DivideByLength(2);
+            Assert.Equal(4, segments1.Count());
         }
 
         [Fact]
@@ -650,6 +650,17 @@ namespace Elements.Geometry.Tests
             var expectedVector = line.PointAt(uValue);
             Assert.InRange(uValue, 0, line.Length());
             Assert.True(vector.IsAlmostEqualTo(expectedVector));
+
+            var parameter = 0.5;
+            var testParameterMidpoint = line.PointAtNormalizedLength(parameter);
+            Assert.True(testParameterMidpoint.IsAlmostEqualTo(middle));
+
+            var midlength = line.Length() * parameter;
+            var testLengthMidpoint = line.PointAtLength(midlength);
+            Assert.True(testLengthMidpoint.IsAlmostEqualTo(testParameterMidpoint));
+
+            var midpoint = line.MidPoint();
+            Assert.True(midpoint.IsAlmostEqualTo(testLengthMidpoint));
         }
 
         [Theory]
@@ -1110,7 +1121,7 @@ namespace Elements.Geometry.Tests
             Assert.Equal(delta.Length(), (new Line(pt12, pt11)).DistanceTo(new Line(pt21, pt22)), 12);
             Assert.Equal(delta.Length(), (new Line(pt12, pt11)).DistanceTo(new Line(pt22, pt21)), 12);
             //The segments (pt12, pt13) and (pt21, pt22) does not intersect.
-            //The shortest distance is from an endpoint to another segment - difference between lines plus between endpoints. 
+            //The shortest distance is from an endpoint to another segment - difference between lines plus between endpoints.
             var expected = (q12 * v1).DistanceTo(new Line(delta + q21 * v2, delta + q22 * v2));
             Assert.Equal(expected, (new Line(pt12, pt13)).DistanceTo(new Line(pt21, pt22)), 12);
             Assert.Equal(expected, (new Line(pt12, pt13)).DistanceTo(new Line(pt22, pt21)), 12);

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -618,7 +618,6 @@ namespace Elements.Geometry.Tests
             Assert.Equal(new Line((5, 0, 0), (10, 0, 0)), overlap);
         }
 
-
         [Fact]
         public void GetParameterAt()
         {

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -270,7 +270,6 @@ namespace Elements.Geometry.Tests
             var parameter = 0.5;
             var testMidpoint = new Vector3(5.0, 14.560525, 0); // Midpoint
             var testParameterMidpoint = polyline.PointAtNormalizedLength(parameter);
-            var t = testParameterMidpoint.IsAlmostEqualTo(testMidpoint);
             Assert.True(testParameterMidpoint.IsAlmostEqualTo(testMidpoint));
 
             var midlength = polyline.Length() * parameter;

--- a/Elements/test/PolylineTests.cs
+++ b/Elements/test/PolylineTests.cs
@@ -257,6 +257,77 @@ namespace Elements.Geometry.Tests
             Assert.Equal(1.5, resultParameter);
             var testPoint = polyline.PointAt(resultParameter);
             Assert.True(point.IsAlmostEqualTo(testPoint));
+
+            polyline = new Polyline(
+              new List<Vector3>()
+              {
+                  new Vector3(1, 5, 0),
+                  new Vector3(5, 20, 0),
+                  new Vector3(5, 0, 0),
+                  new Vector3(9, 5, 0),
+              }
+            );
+            var parameter = 0.5;
+            var testMidpoint = new Vector3(5.0, 14.560525, 0); // Midpoint
+            var testParameterMidpoint = polyline.PointAtNormalizedLength(parameter);
+            var t = testParameterMidpoint.IsAlmostEqualTo(testMidpoint);
+            Assert.True(testParameterMidpoint.IsAlmostEqualTo(testMidpoint));
+
+            var midlength = polyline.Length() * parameter;
+            var testLengthMidpoint = polyline.PointAtLength(midlength);
+            Assert.True(testLengthMidpoint.IsAlmostEqualTo(testParameterMidpoint));
+
+            var midpoint = polyline.MidPoint();
+            Assert.True(midpoint.IsAlmostEqualTo(testLengthMidpoint));
+        }
+
+        [Fact]
+        public void DivideByLength_SingleSegment()
+        {
+            // Arrange
+            var start = new Vector3(1, 2);
+            var end = new Vector3(1, 4);
+            var polyline = new Polyline(new[] { start, end });
+            var divisionLength = 1.0;
+
+            // Act
+            var segments = polyline.DivideByLength(divisionLength);
+
+            // Assert
+            Assert.Equal(3, segments.Count());
+            Assert.Equal(start, segments[0]);
+            Assert.Equal(new Vector3(1, 3), segments[1]);
+            Assert.Equal(end, segments[2]);
+        }
+
+        [Fact]
+        public void DivideByLength_MultipleSegments()
+        {
+            // Arrange
+            var polyline = new Polyline(new List<Vector3>()
+            {
+                new Vector3(1, 5, 0),
+                new Vector3(5, 20, 0),
+                new Vector3(5, 0, 0),
+                new Vector3(9, 5, 0),
+            });
+            var divisionLength = 5.0;
+
+            // Act
+            var segments = polyline.DivideByLength(divisionLength);
+
+            // Assert
+            Assert.Equal(10, segments.Count());
+            Assert.Equal(new Vector3(1.0, 5.0, 0), segments[0]);
+            Assert.Equal(new Vector3(2.288313, 9.831174, 0), segments[1]);
+            Assert.Equal(new Vector3(3.576626, 14.662349, 0), segments[2]);
+            Assert.Equal(new Vector3(4.864939, 19.493524, 0), segments[3]);
+            Assert.Equal(new Vector3(5.0, 15.524174, 0), segments[4]);
+            Assert.Equal(new Vector3(5.0, 10.524174, 0), segments[5]);
+            Assert.Equal(new Vector3(5.0, 5.524174, 0), segments[6]);
+            Assert.Equal(new Vector3(5.0, 0.524174, 0), segments[7]);
+            Assert.Equal(new Vector3(7.796025, 3.495032, 0), segments[8]);
+            Assert.Equal(new Vector3(9, 5, 0), segments[9]);
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
- In our transition to 2.0 much of our curve behavior changes in lieu of their parameterization, here we introduce a new interface IHasArcLength which enforces Midpoint(), PointAtLength(), PointAtNormalizedLength(), and DivideByLength() which applies to Circles, Lines, Polylines, and Beziers.
- Additionally Bezier felt unloved given the push to supporting curves, to perk it up we introduce Split functionality and normalized parameterization + parameter at functionality, and Bezier.ConstructPiecewiseCubicBezier()

DESCRIPTION:
- Gives Circles, Lines, Polylines, and Beziers more flexibility in the information they can return.

TESTING:
- Play around with Circles, Lines, Polylines, and Beziers looking at Midpoint(), PointAtLength(), PointAtNormalizedLength(), and DivideByLength() and for Bezier poke around ParameterAt(), PointAtNormalized() Building multi point Bezier.ConstructPiecewiseCubicBezier(), dividing Beziers, spliting Beziers.
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [ x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.
