### PR TITLE
fix docs on mid

### DIFF
--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -235,7 +235,7 @@ namespace Elements.Geometry
 
             // Construct new vectors that both
             // point away from the projected intersection.
-            // Use an arbitrary point on the line that 
+            // Use an arbitrary point on the line that
             // isn't the start or the end. This ensures
             // that the vectors will point in the correct direction,
             // regardless of the original lines' original orientation
@@ -311,9 +311,7 @@ namespace Elements.Geometry
             return this.BasisCurve.Radius * theta;
         }
 
-        /// <summary>
-        /// The mid point of the line.
-        /// </summary>
+        /// <inheritdoc/>
         public override Vector3 Mid()
         {
             return PointAt(this.Domain.Min + this.Domain.Length / 2);
@@ -470,7 +468,7 @@ namespace Elements.Geometry
                 pts.Add(PointAt(t));
             }
 
-            // We don't go all the way to the end parameter, and 
+            // We don't go all the way to the end parameter, and
             // add it here explicitly because rounding errors can
             // cause small imprecision which accumulates to make
             // the final parameter slightly more/less than the actual

--- a/Elements/src/Geometry/BoundedCurve.cs
+++ b/Elements/src/Geometry/BoundedCurve.cs
@@ -52,9 +52,7 @@ namespace Elements.Geometry
         /// </summary>
         public abstract double ArcLength(double start, double end);
 
-        /// <summary>
-        /// The mid point of the curve.
-        /// </summary>
+        /// <inheritdoc/>
         public virtual Vector3 Mid()
         {
             return PointAt(this.Domain.Mid());

--- a/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
+++ b/Elements/src/Geometry/Interfaces/IBoundedCurve.cs
@@ -17,7 +17,7 @@ namespace Elements.Geometry.Interfaces
         Vector3 End { get; }
 
         /// <summary>
-        /// The mid point of the curve.
+        /// The point at the middle of the curve's parameter space.
         /// </summary>
         Vector3 Mid();
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -576,7 +576,8 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// The mid point of the line.
+        /// The middle of the curve's parameter spaces
+        /// which is also the mid point of the line.
         /// </summary>
         public override Vector3 Mid()
         {
@@ -925,7 +926,7 @@ namespace Elements.Geometry
             // line vectors are not collinear, their directions share the common plane.
             else
             {
-                // dStartStart length is distance to the common plane. 
+                // dStartStart length is distance to the common plane.
                 dStartStart = dStartStart.ProjectOnto(cross);
                 Vector3 vStartStart = other.Start + dStartStart - this.Start;
                 Vector3 vStartEnd = other.Start + dStartStart - this.End;
@@ -1028,8 +1029,8 @@ namespace Elements.Geometry
                 var B = intersectionsOrdered[i + 1];
                 if (A.IsAlmostEqualTo(B)) // skip duplicate points
                 {
-                    // it's possible that A is outside, but B is at an edge, even 
-                    // if they are within tolerance of each other. 
+                    // it's possible that A is outside, but B is at an edge, even
+                    // if they are within tolerance of each other.
                     // This can happen due to floating point error when the point is almost exactly
                     // epsilon distance from the edge.
                     // so if we have duplicate points, we have to update the containment value.

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -575,10 +575,7 @@ namespace Elements.Geometry
             return lines;
         }
 
-        /// <summary>
-        /// The middle of the curve's parameter spaces
-        /// which is also the mid point of the line.
-        /// </summary>
+        /// <inheritdoc/>
         public override Vector3 Mid()
         {
             return Start.Average(End);


### PR DESCRIPTION
BACKGROUND:
- Docs for mid weren't quite right.

DESCRIPTION:
- Change docs for IBoundedCurve Mid to reflect that it is the parameter space mid point.
  - inheritdoc on BoundedCurve, Arc and line.

TESTING:
- n/a
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- ~[ ] All changes are up to date in `CHANGELOG.md`.~

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/997)
<!-- Reviewable:end -->
