### PR TITLE
Arc: fix interactions negative domain in GetSubdivisionParameters, Complement and ToPolyline.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
 - Fix the tests for 3dCentroid testing.
 - `Message` created from `Message.FromPoint` now has `Transform.Origin` set exactly on original point.
 - Certain `Triangle` constructors would not correctly update `Vertex.Triangles`, this is fixed.
+- `Arc.GetSubdivisionParameters` returns parameters starting from StartAngle even if StartAngle > EndAngle.EndAngle.
+- `Arc.ToPolyline` now works if StartAngle > EndAngle.EndAngle.
+- `Arc.Complement` now works if StartAngle > EndAngle.EndAngle or if both angles are negative.
 
 ## 1.6.0
 

--- a/Elements/test/ArcTests.cs
+++ b/Elements/test/ArcTests.cs
@@ -56,10 +56,27 @@ namespace Hypar.Tests
         }
 
         [Fact]
-        public void GetSampleParametersReversedCurveSucceeds()
+        public void GetSampleParametersSucceeds()
         {
             var arc = new Arc(Vector3.Origin, 2.0, 0.0, -90.0);
             var parameters = arc.GetSubdivisionParameters();
+            Assert.Equal(0, parameters.First());
+            foreach (var p in parameters)
+            {
+                arc.PointAt(p);
+            }
+
+            arc = new Arc(Vector3.Origin, 2.0, 45, 90);
+            parameters = arc.GetSubdivisionParameters();
+            Assert.Equal(Units.DegreesToRadians(45), parameters.First());
+            foreach (var p in parameters)
+            {
+                arc.PointAt(p);
+            }
+
+            arc = new Arc(Vector3.Origin, 2.0, 180, 90);
+            parameters = arc.GetSubdivisionParameters();
+            Assert.Equal(Units.DegreesToRadians(180), parameters.First());
             foreach (var p in parameters)
             {
                 arc.PointAt(p);
@@ -121,11 +138,31 @@ namespace Hypar.Tests
             var comp = arc.Complement();
             Assert.Equal(-340, comp.StartAngle);
             Assert.Equal(10, comp.EndAngle);
+            Assert.Equal(Units.DegreesToRadians(350), comp.Length());
 
             arc = new Arc(Vector3.Origin, 1, -10, 10);
             comp = arc.Complement();
             Assert.Equal(-350, comp.StartAngle);
             Assert.Equal(-10, comp.EndAngle);
+            Assert.Equal(Units.DegreesToRadians(340), comp.Length());
+
+            arc = new Arc(Vector3.Origin, 1, 40, 20);
+            comp = arc.Complement();
+            Assert.Equal(20, comp.StartAngle);
+            Assert.Equal(-320, comp.EndAngle);
+            Assert.Equal(Units.DegreesToRadians(340), comp.Length());
+
+            arc = new Arc(Vector3.Origin, 1, -80, -40);
+            comp = arc.Complement();
+            Assert.Equal(-40, comp.StartAngle);
+            Assert.Equal(280, comp.EndAngle);
+            Assert.Equal(Units.DegreesToRadians(320), comp.Length());
+
+            arc = new Arc(Vector3.Origin, 1, -40, -80);
+            comp = arc.Complement();
+            Assert.Equal(280, comp.StartAngle);
+            Assert.Equal(-40, comp.EndAngle);
+            Assert.Equal(Units.DegreesToRadians(320), comp.Length());
         }
 
         [Fact]
@@ -133,6 +170,12 @@ namespace Hypar.Tests
         {
             var arc = new Arc(Vector3.Origin, 1, 10, 20);
             var p = arc.ToPolyline(10);
+            Assert.Equal(10, p.Segments().Length);
+            Assert.Equal(arc.Start, p.Vertices[0]);
+            Assert.Equal(arc.End, p.Vertices[p.Vertices.Count - 1]);
+
+            arc = new Arc(Vector3.Origin, 1, 20, 10);
+            p = arc.ToPolyline(10);
             Assert.Equal(10, p.Segments().Length);
             Assert.Equal(arc.Start, p.Vertices[0]);
             Assert.Equal(arc.End, p.Vertices[p.Vertices.Count - 1]);


### PR DESCRIPTION
BACKGROUND:
- While working on Arc I realized that I can't call ToPolyon for the arc that has StartAngle > EndAngle. Result had only one point.

DESCRIPTION:
- Arc.GetSubdivisionParameters: returns parameters starting from StartAngle even if StartAngle > EndAngle.EndAngle.
- Arc,ToPolyline: now works if StartAngle > EndAngle.EndAngle.
- Arc.Complement: now works if StartAngle > EndAngle.EndAngle or if both angles are negative.

TESTING:
- Tests are added for each change
  
FUTURE WORK:
- There is discussion about the solution in https://github.com/hypar-io/Elements/issues/994 

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/998)
<!-- Reviewable:end -->
