### PR TITLE
don't permit arcs to have decreasing angle domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `Polyline` is now parameterized 0->length.
 - `Arc` now inherits from `TrimmedCurve<Circle>`.
 - `Arc` is now parameterized 0->2Pi
+- `Arc` now automatically corrects decreasing angle domains to be increasing, while preserving direction.
 - `Line` now inherits from `TrimmedCurve<InfiniteLine>`.
 - `Line` is now parameterized 0->length.
 - `Bezier` now inherits from `BoundedCurve`.

--- a/Elements/test/ArcTests.cs
+++ b/Elements/test/ArcTests.cs
@@ -322,9 +322,11 @@ namespace Hypar.Tests
             Assert.Equal(arc1.Start, arc2.End);
             Assert.Equal(arc2.Start, arc1.End);
             Assert.Equal(arc1.PointAtNormalized(0.2), arc2.PointAtNormalized(0.8));
+            Assert.True(arc1.TransformAtNormalized(0.2).ZAxis.Dot(arc2.TransformAtNormalized(0.8).ZAxis) < -0.9999);
             Assert.Equal(arc3.Start, arc4.End);
             Assert.Equal(arc4.Start, arc3.End);
             Assert.Equal(arc3.PointAtNormalized(0.2), arc4.PointAtNormalized(0.8));
+            Assert.True(arc3.TransformAtNormalized(0.2).ZAxis.Dot(arc4.TransformAtNormalized(0.8).ZAxis) < -0.9999);
             var xPos = 0.0;
             foreach (var arc in arcs)
             {
@@ -351,9 +353,11 @@ namespace Hypar.Tests
             Assert.Equal(arc1.Start, arc2.End);
             Assert.Equal(arc2.Start, arc1.End);
             Assert.Equal(arc1.PointAtNormalized(0.2), arc2.PointAtNormalized(0.8));
+            Assert.True(arc1.TransformAtNormalized(0.2).ZAxis.Dot(arc2.TransformAtNormalized(0.8).ZAxis) < -0.9999);
             Assert.Equal(arc3.Start, arc4.End);
             Assert.Equal(arc4.Start, arc3.End);
             Assert.Equal(arc3.PointAtNormalized(0.2), arc4.PointAtNormalized(0.8));
+            Assert.True(arc3.TransformAtNormalized(0.2).ZAxis.Dot(arc4.TransformAtNormalized(0.8).ZAxis) < -0.9999);
             var xPos = 0.0;
             foreach (var arc in arcs)
             {
@@ -382,12 +386,15 @@ namespace Hypar.Tests
             Assert.Equal(arc1.Start, arc2.End);
             Assert.Equal(arc2.Start, arc1.End);
             Assert.Equal(arc1.PointAtNormalized(0.2), arc2.PointAtNormalized(0.8));
+            Assert.True(arc1.TransformAtNormalized(0.2).ZAxis.Dot(arc2.TransformAtNormalized(0.8).ZAxis) < -0.9999);
             Assert.Equal(arc3.Start, arc4.End);
             Assert.Equal(arc4.Start, arc3.End);
             Assert.Equal(arc3.PointAtNormalized(0.2), arc4.PointAtNormalized(0.8));
+            Assert.True(arc3.TransformAtNormalized(0.2).ZAxis.Dot(arc4.TransformAtNormalized(0.8).ZAxis) < -0.9999);
             Assert.Equal(arc5.Start, arc6.End);
             Assert.Equal(arc6.Start, arc5.End);
             Assert.Equal(arc5.PointAtNormalized(0.2), arc6.PointAtNormalized(0.8));
+            Assert.True(arc5.TransformAtNormalized(0.2).ZAxis.Dot(arc6.TransformAtNormalized(0.8).ZAxis) < -0.9999);
             var xPos = 0.0;
             foreach (var arc in arcs)
             {

--- a/Elements/test/ArcTests.cs
+++ b/Elements/test/ArcTests.cs
@@ -281,6 +281,125 @@ namespace Hypar.Tests
         }
 
         [Fact]
+        private void ReversedArcs_CRAAConstructor()
+        {
+            Name = nameof(ReversedArcs_CRAAConstructor);
+            var line = new Line((0, 0, 0), (6, 0, 0));
+            Model.AddElement(new ModelCurve(line, BuiltInMaterials.Points));
+            var arc1 = new Arc((0, 0, 0), 1, 0, 90);
+            var arc2 = new Arc((0, 0, 0), 1, 90, 0);
+            var arc3 = new Arc((0, 0, 0), 1, -90, 0);
+            var arc4 = new Arc((0, 0, 0), 1, 0, -90);
+            var arcs = new[] { arc1, arc2, arc3, arc4 };
+            Assert.Equal(arc1.Start, arc2.End);
+            Assert.Equal(arc2.Start, arc1.End);
+            Assert.Equal(arc1.PointAtNormalized(0.2), arc2.PointAtNormalized(0.8));
+            Assert.Equal(arc3.Start, arc4.End);
+            Assert.Equal(arc4.Start, arc3.End);
+            Assert.Equal(arc3.PointAtNormalized(0.2), arc4.PointAtNormalized(0.8));
+            var xPos = 0.0;
+            foreach (var arc in arcs)
+            {
+                var displayXform = new Transform((xPos, 0, 0));
+                Model.AddElement(new ModelCurve(arc, BuiltInMaterials.Steel, displayXform));
+                var transform = arc.TransformAtNormalized(0.2);
+                Model.AddElements(transform.ToModelCurves(displayXform));
+                xPos += 2.0;
+            }
+        }
+
+        [Fact]
+        private void ReversedArcs_RAAConstructor()
+        {
+            Name = nameof(ReversedArcs_RAAConstructor);
+            var line = new Line((0, 0, 0), (6, 0, 0));
+            Model.AddElement(new ModelCurve(line, BuiltInMaterials.Points));
+            var arc1 = new Arc(1, 0, 90);
+            var arc2 = new Arc(1, 90, 0);
+            var arc3 = new Arc(1, -90, 0);
+            var arc4 = new Arc(1, 0, -90);
+            var arcs = new[] { arc1, arc2, arc3, arc4 };
+            Assert.Equal(arc1.Start, arc2.End);
+            Assert.Equal(arc2.Start, arc1.End);
+            Assert.Equal(arc1.PointAtNormalized(0.2), arc2.PointAtNormalized(0.8));
+            Assert.Equal(arc3.Start, arc4.End);
+            Assert.Equal(arc4.Start, arc3.End);
+            Assert.Equal(arc3.PointAtNormalized(0.2), arc4.PointAtNormalized(0.8));
+            var xPos = 0.0;
+            foreach (var arc in arcs)
+            {
+                var displayXform = new Transform((xPos, 0, 0));
+                Model.AddElement(new ModelCurve(arc, BuiltInMaterials.Steel, displayXform));
+                var transform = arc.TransformAtNormalized(0.2);
+                Model.AddElements(transform.ToModelCurves(displayXform));
+                xPos += 2.0;
+            }
+        }
+
+        [Fact]
+        private void ReversedArcs_CPPConstructor()
+        {
+            Name = nameof(ReversedArcs_CPPConstructor);
+            var line = new Line((4, 5, 6), (10, 5, 6));
+            Model.AddElement(new ModelCurve(line, BuiltInMaterials.Points));
+            var circle = new Circle(new Transform((4, 5, 6), new Vector3(1, 1, 1).Unitized()), 1.0);
+            var arc1 = new Arc(circle, 0, Math.PI / 2.0);
+            var arc2 = new Arc(circle, Math.PI / 2.0, 0);
+            var arc3 = new Arc(circle, -Math.PI / 2.0, 0);
+            var arc4 = new Arc(circle, 0, -Math.PI / 2.0);
+            var arcs = new[] { arc1, arc2, arc3, arc4 };
+            Assert.Equal(arc1.Start, arc2.End);
+            Assert.Equal(arc2.Start, arc1.End);
+            Assert.Equal(arc1.PointAtNormalized(0.2), arc2.PointAtNormalized(0.8));
+            Assert.Equal(arc3.Start, arc4.End);
+            Assert.Equal(arc4.Start, arc3.End);
+            Assert.Equal(arc3.PointAtNormalized(0.2), arc4.PointAtNormalized(0.8));
+            var xPos = 0.0;
+            foreach (var arc in arcs)
+            {
+                var displayXform = new Transform((xPos, 0, 0));
+                Model.AddElement(new ModelCurve(arc, BuiltInMaterials.Steel, displayXform));
+                var transform = arc.TransformAtNormalized(0.2);
+                Model.AddElements(transform.ToModelCurves(displayXform));
+                xPos += 2.0;
+            }
+        }
+
+        [Fact]
+        private void ReversedArcs_TRPPConstructor()
+        {
+            Name = nameof(ReversedArcs_TRPPConstructor);
+            var line = new Line((4, 5, 6), (4 + 2 * 6, 5, 6));
+            Model.AddElement(new ModelCurve(line, BuiltInMaterials.Points));
+            var transform = new Transform((4, 5, 6), new Vector3((1, 1, 1)).Unitized());
+            var arc1 = new Arc(transform, 2, 0, Math.PI / 2.0);
+            var arc2 = new Arc(transform, 2, Math.PI / 2.0, 0);
+            var arc3 = new Arc(transform, 2, -Math.PI / 2.0, 0);
+            var arc4 = new Arc(transform, 2, 0, -Math.PI / 2.0);
+            var arc5 = new Arc(transform, 4, .234, 0.697);
+            var arc6 = new Arc(transform, 4, 0.697, .234);
+            var arcs = new[] { arc1, arc2, arc3, arc4, arc5, arc6 };
+            Assert.Equal(arc1.Start, arc2.End);
+            Assert.Equal(arc2.Start, arc1.End);
+            Assert.Equal(arc1.PointAtNormalized(0.2), arc2.PointAtNormalized(0.8));
+            Assert.Equal(arc3.Start, arc4.End);
+            Assert.Equal(arc4.Start, arc3.End);
+            Assert.Equal(arc3.PointAtNormalized(0.2), arc4.PointAtNormalized(0.8));
+            Assert.Equal(arc5.Start, arc6.End);
+            Assert.Equal(arc6.Start, arc5.End);
+            Assert.Equal(arc5.PointAtNormalized(0.2), arc6.PointAtNormalized(0.8));
+            var xPos = 0.0;
+            foreach (var arc in arcs)
+            {
+                var displayXform = new Transform((xPos, 0, 0));
+                Model.AddElement(new ModelCurve(arc, BuiltInMaterials.Steel, displayXform));
+                var ptTransform = arc.TransformAtNormalized(0.2);
+                Model.AddElements(ptTransform.ToModelCurves(displayXform));
+                xPos += 4.0;
+            }
+        }
+
+        [Fact]
         public void PointAtNormalizedReturnsSameValue()
         {
             var line = ModelTest.TestLine;
@@ -324,6 +443,15 @@ namespace Hypar.Tests
         }
 
         [Fact]
+        public void ReversedArcCreatesPolyline()
+        {
+            Name = nameof(ReversedArcCreatesPolyline);
+            var arc1 = new Arc(Vector3.Origin, 2.0, 0.0, -90.0);
+            var p = arc1.ToPolyline();
+            Model.AddElement(new ModelCurve(p, BuiltInMaterials.XAxis));
+        }
+
+        [Fact]
         public void TransformAtNormalizedReturnsSameValue()
         {
             var line = ModelTest.TestLine;
@@ -348,5 +476,6 @@ namespace Hypar.Tests
             Assert.Equal(curve.TransformAt(curve.Domain.Min), curve.TransformAtNormalized(0.0));
             Assert.Equal(curve.TransformAt(curve.Domain.Max), curve.TransformAtNormalized(1.0));
         }
+
     }
 }

--- a/Elements/test/IndexedPolyCurveTests.cs
+++ b/Elements/test/IndexedPolyCurveTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Elements.Geometry;
 using Newtonsoft.Json;
@@ -60,6 +61,28 @@ namespace Elements.Tests
                     Model.AddElements(arc.BasisCurve.Transform.ToModelCurves());
                 }
             }
+        }
+
+        [Fact]
+        public void PolyCurveWithBackwardsArc()
+        {
+            Name = nameof(PolyCurveWithBackwardsArc);
+            var line1 = new Line((0, 0), (10, 0));
+            var line2 = new Line((10, 0), (10, 8));
+            var arc3 = new Arc((10, 10), 2, 270, 180);
+            var line4 = new Line((8, 10), (0, 10));
+            var line5 = new Line((0, 10), (0, 0));
+            var polycurve = new IndexedPolycurve(new List<BoundedCurve> { line1, line2, arc3, line4, line5 });
+            Model.AddElement(new ModelCurve(polycurve, BuiltInMaterials.XAxis));
+            var vectors = new List<(Vector3 location, Vector3 direction, double magnitude, Color? color)>();
+            for (int i = 0; i < 100; i++)
+            {
+                var transform = polycurve.TransformAtNormalized(i / 100.0);
+                var normal = transform.ZAxis.Negate();
+                vectors.Add((transform.Origin, normal, 0.1, Colors.Magenta));
+            }
+            var ma = new ModelArrows(vectors);
+            Model.AddElement(ma);
         }
 
         private IndexedPolycurve CreateTestPolycurve()


### PR DESCRIPTION
BACKGROUND:
- https://github.com/hypar-io/Elements/issues/994
- We want to allow users to construct Arcs with apparently decreasing angle domains, in order to have intuitive control over arc direction.

DESCRIPTION:
- Updates Arc constructors to ensure that `EndAngle` is always greater than `StartAngle`.

TESTING:
- I added a test for every modified constructor, to verify that for any pair of angles A,B, arc(A,B) looked just like arc(B,A), but parameterized in the opposite direction. 
- I added a test to construct an `IndexedPolycurve` containing an arc which runs "clockwise" with respect to its circle / the Z axis, to ensure consistency in direction of the overall polycurve:
![image](https://github.com/hypar-io/Elements/assets/31935763/5057dd1d-d1c4-4f17-8e8f-f62d151c3127)
- I added a test for issue #994's original complaint, and visually verified that it worked. 
- All tests pass. 
  
FUTURE WORK:
- We may need to introduce a notion of `SenseAgreement` as STEP does for more complex curves, such that a subcurve could act like it was running in the opposite direction from its basis curve. Or maybe not `¯\_(ツ)_/¯`

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/999)
<!-- Reviewable:end -->
