### PR TITLE
topo elevations can be null

### DIFF
--- a/Elements/src/Topography.cs
+++ b/Elements/src/Topography.cs
@@ -233,7 +233,7 @@ namespace Elements
             this.RowWidth = topography.RowWidth;
             this.CellWidth = topography.CellWidth;
             this.CellHeight = topography.CellHeight;
-            this.Elevations = topography.Elevations.ToArray();
+            this.Elevations = topography.Elevations?.ToArray();
             this._depthBelowMinimumElevation = topography._depthBelowMinimumElevation;
             this._absoluteMinimumElevation = topography._absoluteMinimumElevation;
             this._minElevation = topography._minElevation;


### PR DESCRIPTION
BACKGROUND:
- goldbeck noticed an issue w/ the topography constructor which clones another topo — it would throw if `Elevations` is null, which it can be.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1004)
<!-- Reviewable:end -->
