### PR TITLE
Implement Intersects for ICurve and all subtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## 2.0.1
 
+### Added
+
+`Units.AdjustRadian(double parameter, double reference)`
+`Equations`
+`Vector3Extensions.UniqueAverageWithinTolerance(this IEnumerable<Vector3> vectors, double tolerance = Vector3.EPSILON)`
+`Vector3.ClosestPointOn(InfiniteLine line)`
+`Plane.Intersects(Plane other, out InfiniteLine result)`
+`ICurve.Intersects(ICurve curve, out List<Vector3> results)`
+`InfiniteLine.ParameterAt(Vector3 pt, out double t)`
+`InfiniteLine.Intersects(Plane plane, out Vector3 result)`
+`InfiniteLine.Intersects(InfiniteLine other, out List<Vector3> results)`
+`InfiniteLine.Intersects(Circle circle, out List<Vector3> results)`
+`InfiniteLine.Intersects(Ellipse ellipse, out List<Vector3> results)`
+`InfiniteLine.Intersects(BoundedCurve curve, out List<Vector3> results)`
+`Circle.Normal`
+`Circle.ParameterAt(Vector3 pt, out double t)`
+`Circle.Intersects(Circle other, out List<Vector3> results)`
+`Circle.Intersects(InfiniteLine line, out List<Vector3> results)`
+`Circle.Intersects(Ellipse ellipse, out List<Vector3> results)`
+`Circle.Intersects(BoundedCurve curve, out List<Vector3> results)`
+`Ellipse.Normal`
+`Ellipse.ParameterAt(Vector3 pt, out double t)`
+`Ellipse.Intersects(InfiniteLine line, out List<Vector3> results)`
+`Ellipse.Intersects(Circle circle, out List<Vector3> results)`
+`Ellipse.Intersects(Ellipse other, out List<Vector3> results)`
+`Ellipse.Intersects(BoundedCurve curve, out List<Vector3> results)`
+`TrimmedCurve.PointOnDomain(Vector3 point)`
+`TrimmedCurve.Intersects(InfiniteLine line, out List<Vector3> results)`
+`TrimmedCurve.Intersects(Circle circle, out List<Vector3> results)`
+`TrimmedCurve.Intersects(Ellipse ellipse, out List<Vector3> results)`
+`TrimmedCurve.Intersects<T>(TrimmedCurve<T> curve, out List<Vector3> results) where T : ICurve`
+`TrimmedCurve.Intersects(Bezier bezier, out List<Vector3> results)`
+`Bezier.Intersects(InfiniteLine line, out List<Vector3> results)`
+`Bezier.Intersects(Circle circle, out List<Vector3> results)`
+`Bezier.Intersects(Ellipse ellipse, out List<Vector3> results)`
+`Bezier.Intersects(Bezier other, out List<Vector3> results)`
+
 ### Fixed
 
 - `Polygon.Contains3D` passed wrong `out Containment containment` parameter in some cases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,41 +4,41 @@
 
 ### Added
 
-`Units.AdjustRadian(double parameter, double reference)`
-`Equations`
-`Vector3Extensions.UniqueAverageWithinTolerance(this IEnumerable<Vector3> vectors, double tolerance = Vector3.EPSILON)`
-`Vector3.ClosestPointOn(InfiniteLine line)`
-`Plane.Intersects(Plane other, out InfiniteLine result)`
-`ICurve.Intersects(ICurve curve, out List<Vector3> results)`
-`InfiniteLine.ParameterAt(Vector3 pt, out double t)`
-`InfiniteLine.Intersects(Plane plane, out Vector3 result)`
-`InfiniteLine.Intersects(InfiniteLine other, out List<Vector3> results)`
-`InfiniteLine.Intersects(Circle circle, out List<Vector3> results)`
-`InfiniteLine.Intersects(Ellipse ellipse, out List<Vector3> results)`
-`InfiniteLine.Intersects(BoundedCurve curve, out List<Vector3> results)`
-`Circle.Normal`
-`Circle.ParameterAt(Vector3 pt, out double t)`
-`Circle.Intersects(Circle other, out List<Vector3> results)`
-`Circle.Intersects(InfiniteLine line, out List<Vector3> results)`
-`Circle.Intersects(Ellipse ellipse, out List<Vector3> results)`
-`Circle.Intersects(BoundedCurve curve, out List<Vector3> results)`
-`Ellipse.Normal`
-`Ellipse.Circumference()`
-`Ellipse.ParameterAt(Vector3 pt, out double t)`
-`Ellipse.Intersects(InfiniteLine line, out List<Vector3> results)`
-`Ellipse.Intersects(Circle circle, out List<Vector3> results)`
-`Ellipse.Intersects(Ellipse other, out List<Vector3> results)`
-`Ellipse.Intersects(BoundedCurve curve, out List<Vector3> results)`
-`TrimmedCurve.PointOnDomain(Vector3 point)`
-`TrimmedCurve.Intersects(InfiniteLine line, out List<Vector3> results)`
-`TrimmedCurve.Intersects(Circle circle, out List<Vector3> results)`
-`TrimmedCurve.Intersects(Ellipse ellipse, out List<Vector3> results)`
-`TrimmedCurve.Intersects<T>(TrimmedCurve<T> curve, out List<Vector3> results) where T : ICurve`
-`TrimmedCurve.Intersects(Bezier bezier, out List<Vector3> results)`
-`Bezier.Intersects(InfiniteLine line, out List<Vector3> results)`
-`Bezier.Intersects(Circle circle, out List<Vector3> results)`
-`Bezier.Intersects(Ellipse ellipse, out List<Vector3> results)`
-`Bezier.Intersects(Bezier other, out List<Vector3> results)`
+- `Units.AdjustRadian(double parameter, double reference)`
+- `Equations`
+- `Vector3Extensions.UniqueAverageWithinTolerance(this IEnumerable<Vector3> vectors, double tolerance = Vector3.EPSILON)`
+- `Vector3.ClosestPointOn(InfiniteLine line)`
+- `Plane.Intersects(Plane other, out InfiniteLine result)`
+- `ICurve.Intersects(ICurve curve, out List<Vector3> results)`
+- `InfiniteLine.ParameterAt(Vector3 pt, out double t)`
+- `InfiniteLine.Intersects(Plane plane, out Vector3 result)`
+- `InfiniteLine.Intersects(InfiniteLine other, out List<Vector3> results)`
+- `InfiniteLine.Intersects(Circle circle, out List<Vector3> results)`
+- `InfiniteLine.Intersects(Ellipse ellipse, out List<Vector3> results)`
+- `InfiniteLine.Intersects(BoundedCurve curve, out List<Vector3> results)`
+- `Circle.Normal`
+- `Circle.ParameterAt(Vector3 pt, out double t)`
+- `Circle.Intersects(Circle other, out List<Vector3> results)`
+- `Circle.Intersects(InfiniteLine line, out List<Vector3> results)`
+- `Circle.Intersects(Ellipse ellipse, out List<Vector3> results)`
+- `Circle.Intersects(BoundedCurve curve, out List<Vector3> results)`
+- `Ellipse.Normal`
+- `Ellipse.Circumference()`
+- `Ellipse.ParameterAt(Vector3 pt, out double t)`
+- `Ellipse.Intersects(InfiniteLine line, out List<Vector3> results)`
+- `Ellipse.Intersects(Circle circle, out List<Vector3> results)`
+- `Ellipse.Intersects(Ellipse other, out List<Vector3> results)`
+- `Ellipse.Intersects(BoundedCurve curve, out List<Vector3> results)`
+- `TrimmedCurve.PointOnDomain(Vector3 point)`
+- `TrimmedCurve.Intersects(InfiniteLine line, out List<Vector3> results)`
+- `TrimmedCurve.Intersects(Circle circle, out List<Vector3> results)`
+- `TrimmedCurve.Intersects(Ellipse ellipse, out List<Vector3> results)`
+- `TrimmedCurve.Intersects<T>(TrimmedCurve<T> curve, out List<Vector3> results) where T : ICurve`
+- `TrimmedCurve.Intersects(Bezier bezier, out List<Vector3> results)`
+- `Bezier.Intersects(InfiniteLine line, out List<Vector3> results)`
+- `Bezier.Intersects(Circle circle, out List<Vector3> results)`
+- `Bezier.Intersects(Ellipse ellipse, out List<Vector3> results)`
+- `Bezier.Intersects(Bezier other, out List<Vector3> results)`
 - `Elements.Geometry.ThickenedPolyline`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 `Circle.Intersects(Ellipse ellipse, out List<Vector3> results)`
 `Circle.Intersects(BoundedCurve curve, out List<Vector3> results)`
 `Ellipse.Normal`
+`Ellipse.Circumference()`
 `Ellipse.ParameterAt(Vector3 pt, out double t)`
 `Ellipse.Intersects(InfiniteLine line, out List<Vector3> results)`
 `Ellipse.Intersects(Circle circle, out List<Vector3> results)`

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -527,71 +527,7 @@ namespace Elements.Geometry
             return this.BasisCurve.ParameterAtDistanceFromParameter(distance, start);
         }
 
-        public bool Intersects(Arc other, out List<Vector3> results)
-        {
-            results = new List<Vector3>();
-            if (BasisCurve.Intersects(other.BasisCurve, out var candidates))
-            {
-                foreach (var item in candidates)
-                {
-                    if (this.PointOnDomain(item) && other.PointOnDomain(item))
-                    {
-                        results.Add(item);
-                    }
-                }
-            }
-            return results.Any();
-        }
-
-        public bool Intersects(Circle other, out List<Vector3> results)
-        {
-            results = new List<Vector3>();
-            if (BasisCurve.Intersects(other, out var candidates))
-            {
-                foreach (var item in candidates)
-                {
-                    if (this.PointOnDomain(item))
-                    {
-                        results.Add(item);
-                    }
-                }
-            }
-            return results.Any();
-        }
-
-        public bool Intersects(InfiniteLine other, out List<Vector3> results)
-        {
-            results = new List<Vector3>();
-            if (BasisCurve.Intersects(other, out var candidates))
-            {
-                foreach (var item in candidates)
-                {
-                    if (PointOnDomain(item))
-                    {
-                        results.Add(item);
-                    }
-                }
-            }
-            return results.Any();
-        }
-
-        public bool Intersects(Line line, out List<Vector3> results)
-        {
-            results = new List<Vector3>();
-            if (BasisCurve.Intersects(line.BasisCurve, out var candidates))
-            {
-                foreach (var item in candidates)
-                {
-                    if (this.PointOnDomain(item) && line.PointOnLine(item, true))
-                    {
-                        results.Add(item);
-                    }
-                }
-            }
-            return results.Any();
-        }
-
-        public bool PointOnDomain(Vector3 point)
+        public override bool PointOnDomain(Vector3 point)
         {
             if (!BasisCurve.ParameterAt(point, out var parameter))
             {

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -591,7 +591,7 @@ namespace Elements.Geometry
             return results.Any();
         }
 
-        private bool PointOnDomain(Vector3 point)
+        public bool PointOnDomain(Vector3 point)
         {
             if (!BasisCurve.ParameterAt(point, out var parameter))
             {

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -527,6 +527,7 @@ namespace Elements.Geometry
             return this.BasisCurve.ParameterAtDistanceFromParameter(distance, start);
         }
 
+        /// <inheritdoc/>
         public override bool PointOnDomain(Vector3 point)
         {
             if (!BasisCurve.ParameterAt(point, out var parameter))

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -2,6 +2,7 @@ using Elements.Validators;
 using System;
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Elements.Geometry
 {
@@ -524,6 +525,89 @@ namespace Elements.Geometry
             }
 
             return this.BasisCurve.ParameterAtDistanceFromParameter(distance, start);
+        }
+
+        public bool Intersects(Arc other, out List<Vector3> results)
+        {
+            results = new List<Vector3>();
+            if (BasisCurve.Intersects(other.BasisCurve, out var candidates))
+            {
+                foreach (var item in candidates)
+                {
+                    if (this.PointOnDomain(item) && other.PointOnDomain(item))
+                    {
+                        results.Add(item);
+                    }
+                }
+            }
+            return results.Any();
+        }
+
+        public bool Intersects(Circle other, out List<Vector3> results)
+        {
+            results = new List<Vector3>();
+            if (BasisCurve.Intersects(other, out var candidates))
+            {
+                foreach (var item in candidates)
+                {
+                    if (this.PointOnDomain(item))
+                    {
+                        results.Add(item);
+                    }
+                }
+            }
+            return results.Any();
+        }
+
+        public bool Intersects(InfiniteLine other, out List<Vector3> results)
+        {
+            results = new List<Vector3>();
+            if (BasisCurve.Intersects(other, out var candidates))
+            {
+                foreach (var item in candidates)
+                {
+                    if (PointOnDomain(item))
+                    {
+                        results.Add(item);
+                    }
+                }
+            }
+            return results.Any();
+        }
+
+        public bool Intersects(Line line, out List<Vector3> results)
+        {
+            results = new List<Vector3>();
+            if (BasisCurve.Intersects(line.BasisCurve, out var candidates))
+            {
+                foreach (var item in candidates)
+                {
+                    if (this.PointOnDomain(item) && line.PointOnLine(item, true))
+                    {
+                        results.Add(item);
+                    }
+                }
+            }
+            return results.Any();
+        }
+
+        private bool PointOnDomain(Vector3 point)
+        {
+            if (!BasisCurve.ParameterAt(point, out var parameter))
+            {
+                return false;
+            }
+
+            parameter = NormalizedParameter(parameter);
+            var normalizedDomain = new Domain1d(NormalizedParameter(Domain.Min), NormalizedParameter(Domain.Max));
+            return parameter >= normalizedDomain.Min && parameter <= normalizedDomain.Max;
+        }
+
+        private double NormalizedParameter(double parameter)
+        {
+            var numberOfRotation = Math.Floor(parameter / (2 * Math.PI));
+            var normalized = parameter - numberOfRotation * 2 * Math.PI;
+            return normalized;
         }
     }
 }

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -534,15 +534,9 @@ namespace Elements.Geometry
                 return false;
             }
 
-            parameter = Units.NormalizedRadian(parameter);
-            var min = Units.NormalizedRadian(Domain.Min);
-            var max = Units.NormalizedRadian(Domain.Max);
-            if (min > max)
-            {
-                (max, min) = (min, max);
-            }
-            var normalizedDomain = new Domain1d(min, max);
-            return parameter >= normalizedDomain.Min && parameter <= normalizedDomain.Max;
+            parameter = Units.AdjustRadian(parameter, Domain.Min);
+            return parameter - Domain.Min > -Vector3.EPSILON * Vector3.EPSILON &&
+                   parameter - Domain.Max < Vector3.EPSILON * Vector3.EPSILON;
         }
     }
 }

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -534,16 +534,15 @@ namespace Elements.Geometry
                 return false;
             }
 
-            parameter = NormalizedParameter(parameter);
-            var normalizedDomain = new Domain1d(NormalizedParameter(Domain.Min), NormalizedParameter(Domain.Max));
+            parameter = Units.NormalizedRadian(parameter);
+            var min = Units.NormalizedRadian(Domain.Min);
+            var max = Units.NormalizedRadian(Domain.Max);
+            if (min > max)
+            {
+                (max, min) = (min, max);
+            }
+            var normalizedDomain = new Domain1d(min, max);
             return parameter >= normalizedDomain.Min && parameter <= normalizedDomain.Max;
-        }
-
-        private double NormalizedParameter(double parameter)
-        {
-            var numberOfRotation = Math.Floor(parameter / (2 * Math.PI));
-            var normalized = parameter - numberOfRotation * 2 * Math.PI;
-            return normalized;
         }
     }
 }

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -391,7 +391,7 @@ namespace Elements.Geometry
 
             // Iteratively, find points on Bezier with 0 distance to the line.
             // It Bezier was limited to 4 points - more effective approach could be used.
-            var roots = Equations.SolveIterative(Domain.Min, Domain.Max, 45,
+            var roots = Equations.SolveIterative(Domain.Min, Domain.Max, 100,
                     new Func<double, double>((t) =>
                     {
                         var p = PointAt(t);
@@ -425,7 +425,7 @@ namespace Elements.Geometry
 
             // Iteratively, find points on Bezier with radius distance to the circle.
             var invertedT = circle.Transform.Inverted();
-            var roots = Equations.SolveIterative(Domain.Min, Domain.Max, 45,
+            var roots = Equations.SolveIterative(Domain.Min, Domain.Max, 100,
                     new Func<double, double>((t) =>
                     {
                         var p = PointAt(t);
@@ -461,7 +461,7 @@ namespace Elements.Geometry
             // Iteratively, find points on ellipse with distance
             // to other ellipse equal to its focal distance.
             var invertedT = ellipse.Transform.Inverted();
-            var roots = Equations.SolveIterative(Domain.Min, Domain.Max, 45,
+            var roots = Equations.SolveIterative(Domain.Min, Domain.Max, 100,
                 new Func<double, double>((t) =>
                 {
                     var p = PointAt(t);

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -379,7 +379,7 @@ namespace Elements.Geometry
                 return false;
             }
 
-            var roots = Equations.SolveIterative(Domain.Min, Domain.Max,
+            var roots = Equations.SolveIterative(Domain.Min, Domain.Max, 45,
                     new Func<double, double>((t) =>
                     {
                         var p = PointAt(t);
@@ -393,7 +393,7 @@ namespace Elements.Geometry
         public bool Intersects(Circle circle, out List<Vector3> results)
         {
             var invertedT = circle.Transform.Inverted();
-            var roots = Equations.SolveIterative(Domain.Min, Domain.Max,
+            var roots = Equations.SolveIterative(Domain.Min, Domain.Max, 45,
                     new Func<double, double>((t) =>
                     {
                         var p = PointAt(t);
@@ -417,7 +417,7 @@ namespace Elements.Geometry
             }
 
             var invertedT = ellipse.Transform.Inverted();
-            var roots = Equations.SolveIterative(Domain.Min, Domain.Max,
+            var roots = Equations.SolveIterative(Domain.Min, Domain.Max, 45,
                 new Func<double, double>((t) =>
                 {
                     var p = PointAt(t);

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -386,7 +386,8 @@ namespace Elements.Geometry
                         return (p - p.ClosestPointOn(line)).LengthSquared();
                     }), Vector3.EPSILON * Vector3.EPSILON);
 
-            results = Equations.ConvertRoots(this, roots, Vector3.EPSILON * 2);
+            results = roots.Select(r => PointAt(r)).UniqueAverageWithinTolerance(
+                Vector3.EPSILON * 2).ToList();
             return results.Any();
         }
 
@@ -401,7 +402,8 @@ namespace Elements.Geometry
                         return local.LengthSquared() - circle.Radius * circle.Radius;
                     }), Vector3.EPSILON * Vector3.EPSILON);
 
-            results = Equations.ConvertRoots(this, roots, Vector3.EPSILON * 2);
+            results = roots.Select(r => PointAt(r)).UniqueAverageWithinTolerance(
+                Vector3.EPSILON * 2).ToList();
             return results.Any();
         }
 
@@ -427,7 +429,8 @@ namespace Elements.Geometry
                     return dx + dy + local.Z * local.Z - 1;
                 }), Vector3.EPSILON * Vector3.EPSILON);
 
-            results = Equations.ConvertRoots(this, roots, Vector3.EPSILON * 2);
+            results = roots.Select(r => PointAt(r)).UniqueAverageWithinTolerance(
+                Vector3.EPSILON * 2).ToList();
             return results.Any();
         }
 

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -386,7 +386,7 @@ namespace Elements.Geometry
                         return (p - p.ClosestPointOn(line)).LengthSquared();
                     }), Vector3.EPSILON * Vector3.EPSILON);
 
-            results = Equations.ConvertRoots(this, roots);
+            results = Equations.ConvertRoots(this, roots, Vector3.EPSILON * 2);
             return results.Any();
         }
 
@@ -401,7 +401,7 @@ namespace Elements.Geometry
                         return local.LengthSquared() - circle.Radius * circle.Radius;
                     }), Vector3.EPSILON * Vector3.EPSILON);
 
-            results = Equations.ConvertRoots(this, roots);
+            results = Equations.ConvertRoots(this, roots, Vector3.EPSILON * 2);
             return results.Any();
         }
 
@@ -427,7 +427,7 @@ namespace Elements.Geometry
                     return dx + dy + local.Z * local.Z - 1;
                 }), Vector3.EPSILON * Vector3.EPSILON);
 
-            results = Equations.ConvertRoots(this, roots);
+            results = Equations.ConvertRoots(this, roots, Vector3.EPSILON * 2);
             return results.Any();
         }
 

--- a/Elements/src/Geometry/Bezier.cs
+++ b/Elements/src/Geometry/Bezier.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Elements.Geometry.Interfaces;
 using Newtonsoft.Json;
 
 namespace Elements.Geometry
@@ -340,6 +342,46 @@ namespace Elements.Geometry
         {
             ArcLengthUntil(start, distance, out var end);
             return end;
+        }
+
+        public override bool Intersects(ICurve curve, out List<Vector3> results)
+        {
+            switch (curve)
+            {
+                case Line line:
+                    return line.Intersects(this, out results);
+                case Arc arc:
+                    return arc.Intersects(this, out results);
+                case EllipticalArc ellipticArc:
+                    return ellipticArc.Intersects(this, out results);
+                case InfiniteLine line:
+                    return Intersects(line, out results);
+                case Circle circle:
+                    return Intersects(circle, out results);
+                case Ellipse elliplse:
+                    return Intersects(elliplse, out results);
+                case IndexedPolycurve polycurve:
+                    return polycurve.Intersects(this, out results);
+                case Bezier bezier:
+                    return Intersects(bezier, out results);
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        public bool Intersects(InfiniteLine line, out List<Vector3> results)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Intersects(Circle circle, out List<Vector3> results)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Intersects(Ellipse line, out List<Vector3> results)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/Elements/src/Geometry/Circle.cs
+++ b/Elements/src/Geometry/Circle.cs
@@ -122,18 +122,24 @@ namespace Elements.Geometry
             return new Vector3(x, y);
         }
 
-        public bool ParameterAt(Vector3 pt, out double parameter)
+        /// <summary>
+        /// Check if certain point is on the circle.
+        /// </summary>
+        /// <param name="pt">Point to check.</param>
+        /// <param name="t">Calculated parameter of point on circle.</param>
+        /// <returns>True if point lays on the circle.</returns>
+        public bool ParameterAt(Vector3 pt, out double t)
         {
             var local = Transform.Inverted().OfPoint(pt);
             if (local.Z.ApproximatelyEquals(0) &&
                 local.LengthSquared().ApproximatelyEquals(
                     Radius * Radius, Vector3.EPSILON * Vector3.EPSILON))
             {
-                parameter = ParameterAtUntransformed(local);
+                t = ParameterAtUntransformed(local);
                 return true;
             }
 
-            parameter = 0;
+            t = 0;
             return false;
         }
 
@@ -181,6 +187,7 @@ namespace Elements.Geometry
             return start + theta;
         }
 
+        /// <inheritdoc/>
         public override bool Intersects(ICurve curve, out List<Vector3> results)
         {
             switch (curve)
@@ -198,6 +205,13 @@ namespace Elements.Geometry
             }
         }
 
+        /// <summary>
+        /// Does this circle intersects with other circle?
+        /// Circles with the same positions and radii are not considered as intersecting.
+        /// </summary>
+        /// <param name="other">Other circle to intersect.</param>
+        /// <param name="results">List containing up to two intersection points.</param>
+        /// <returns>True if any intersections exist, otherwise false.</returns>
         public bool Intersects(Circle other, out List<Vector3> results)
         {
             results = new List<Vector3>();
@@ -255,6 +269,12 @@ namespace Elements.Geometry
             return results.Any();
         }
 
+        /// <summary>
+        /// Does this circle intersects with an infinite line?
+        /// </summary>
+        /// <param name="line">Infinite line to intersect.</param>
+        /// <param name="results">List containing up to two intersection points.</param>
+        /// <returns>True if any intersections exist, otherwise false.</returns>
         public bool Intersects(InfiniteLine line, out List<Vector3> results)
         {
             results = new List<Vector3>();
@@ -295,14 +315,28 @@ namespace Elements.Geometry
             return results.Any();
         }
 
+        /// <summary>
+        /// Does this circle intersects with an ellipse?
+        /// Circle and ellipse that are coincides are not considered as intersecting.
+        /// <see cref="Ellipse.Intersects(Circle, out List{Vector3})"/>
+        /// </summary>
+        /// <param name="ellipse">Ellipse to intersect.</param>
+        /// <param name="results">List containing up to four intersection points.</param>
+        /// <returns>True if any intersections exist, otherwise false.</returns>
         public bool Intersects(Ellipse ellipse, out List<Vector3> results)
         {
             return ellipse.Intersects(this, out results);
         }
 
-        public bool Intersects(BoundedCurve bounded, out List<Vector3> results)
+        /// <summary>
+        /// Does this circle intersects with a bounded curve?
+        /// </summary>
+        /// <param name="curve">Curve to intersect.</param>
+        /// <param name="results">List containing intersection points.</param>
+        /// <returns>True if any intersections exist, otherwise false.</returns>
+        public bool Intersects(BoundedCurve curve, out List<Vector3> results)
         {
-            return bounded.Intersects(this, out results);
+            return curve.Intersects(this, out results);
         }
     }
 }

--- a/Elements/src/Geometry/Circle.cs
+++ b/Elements/src/Geometry/Circle.cs
@@ -139,7 +139,7 @@ namespace Elements.Geometry
 
         private double ParameterAtUntransformed(Vector3 pt)
         {
-            var v = (pt - this.Center) / Radius;
+            var v = pt / Radius;
             return Math.Atan2(v.Y, v.X);
         }
 

--- a/Elements/src/Geometry/Circle.cs
+++ b/Elements/src/Geometry/Circle.cs
@@ -220,7 +220,7 @@ namespace Elements.Geometry
             Plane planeB = new Plane(other.Center, other.Normal);
 
             // Check if two circles are on the same plane. 
-            if (Normal.IsAlmostEqualTo(other.Normal) &&
+            if (Normal.IsParallelTo(other.Normal, Vector3.EPSILON * Vector3.EPSILON) &&
                 other.Center.DistanceTo(planeA).ApproximatelyEquals(0))
             {
                 var delta = other.Center - Center;

--- a/Elements/src/Geometry/Circle.cs
+++ b/Elements/src/Geometry/Circle.cs
@@ -181,6 +181,23 @@ namespace Elements.Geometry
             return start + theta;
         }
 
+        public override bool Intersects(ICurve curve, out List<Vector3> results)
+        {
+            switch (curve)
+            {
+                case BoundedCurve boundedCurve:
+                    return boundedCurve.Intersects(this, out results);
+                case InfiniteLine line :
+                    return Intersects(line, out results);
+                case Circle circle:
+                    return Intersects(circle, out results);
+                case Ellipse elliplse:
+                    return Intersects(elliplse, out results);
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
         public bool Intersects(Circle other, out List<Vector3> results)
         {
             results = new List<Vector3>();
@@ -276,6 +293,16 @@ namespace Elements.Geometry
             }
 
             return results.Any();
+        }
+
+        public bool Intersects(Ellipse ellipse, out List<Vector3> results)
+        {
+            return ellipse.Intersects(this, out results);
+        }
+
+        public bool Intersects(BoundedCurve bounded, out List<Vector3> results)
+        {
+            return bounded.Intersects(this, out results);
         }
     }
 }

--- a/Elements/src/Geometry/Circle.cs
+++ b/Elements/src/Geometry/Circle.cs
@@ -126,7 +126,7 @@ namespace Elements.Geometry
         {
             var local = Transform.Inverted().OfPoint(pt);
             if (local.Z.ApproximatelyEquals(0) &&
-                (local - Center).LengthSquared().ApproximatelyEquals(
+                local.LengthSquared().ApproximatelyEquals(
                     Radius * Radius, Vector3.EPSILON * Vector3.EPSILON))
             {
                 parameter = ParameterAtUntransformed(local);

--- a/Elements/src/Geometry/Curve.cs
+++ b/Elements/src/Geometry/Curve.cs
@@ -1,5 +1,7 @@
 using Elements.Geometry.Interfaces;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
 
 namespace Elements.Geometry
 {
@@ -38,5 +40,7 @@ namespace Elements.Geometry
         /// <param name="distance">The distance from the start parameter.</param>
         /// <param name="start">The parameter from which to measure the distance.</param>
         public abstract double ParameterAtDistanceFromParameter(double distance, double start);
+
+        public abstract bool Intersects(ICurve curve, out List<Vector3> results);
     }
 }

--- a/Elements/src/Geometry/Curve.cs
+++ b/Elements/src/Geometry/Curve.cs
@@ -41,6 +41,7 @@ namespace Elements.Geometry
         /// <param name="start">The parameter from which to measure the distance.</param>
         public abstract double ParameterAtDistanceFromParameter(double distance, double start);
 
+        /// <inheritdoc/>
         public abstract bool Intersects(ICurve curve, out List<Vector3> results);
     }
 }

--- a/Elements/src/Geometry/Ellipse.cs
+++ b/Elements/src/Geometry/Ellipse.cs
@@ -311,7 +311,7 @@ namespace Elements.Geometry
                 }
 
                 var localCenter = Transform.Inverted().OfPoint(circle.Center);
-                var roots = Equations.SolveIterative(0, Math.PI * 2,
+                var roots = Equations.SolveIterative(0, Math.PI * 2, 45,
                     new Func<double, double>((t) =>
                     {
                         var d = PointAtUntransformed(t) - localCenter;
@@ -379,7 +379,7 @@ namespace Elements.Geometry
                 var inverted = Transform.Inverted();
                 var ellipseToEllipse = Transform.Concatenated(other.Transform.Inverted());
 
-                var roots = Equations.SolveIterative(0, Math.PI * 2,
+                var roots = Equations.SolveIterative(0, Math.PI * 2, 45,
                     new Func<double, double>((t) =>
                     {
                         var d = PointAtUntransformed(t);

--- a/Elements/src/Geometry/Ellipse.cs
+++ b/Elements/src/Geometry/Ellipse.cs
@@ -328,14 +328,14 @@ namespace Elements.Geometry
                 }
 
                 // Too far away (rough estimation)
-                if (Center.DistanceTo(circle.Center) > MajorAxis + circle.Radius)
+                if (Center.DistanceTo(circle.Center) > Math.Max(MajorAxis, MinorAxis) + circle.Radius)
                 {
                     return false;
                 }
 
                 // Iteratively, find points in ellipse with distance to circle equal its radius. 
                 var localCenter = Transform.Inverted().OfPoint(circle.Center);
-                var roots = Equations.SolveIterative(0, Math.PI * 2, 45,
+                var roots = Equations.SolveIterative(0, Math.PI * 2, 90,
                     new Func<double, double>((t) =>
                     {
                         var d = PointAtUntransformed(t) - localCenter;
@@ -414,7 +414,7 @@ namespace Elements.Geometry
 
                 // Iteratively, find points on ellipse with distance
                 // to other ellipse equal to its focal distance.
-                var roots = Equations.SolveIterative(0, Math.PI * 2, 45,
+                var roots = Equations.SolveIterative(0, Math.PI * 2, 90,
                     new Func<double, double>((t) =>
                     {
                         var d = PointAtUntransformed(t);

--- a/Elements/src/Geometry/Ellipse.cs
+++ b/Elements/src/Geometry/Ellipse.cs
@@ -333,9 +333,11 @@ namespace Elements.Geometry
                     return false;
                 }
 
+                var div = (int)Math.Round(this.Circumference() / BoundedCurve.DefaultMinimumChordLength);
+
                 // Iteratively, find points in ellipse with distance to circle equal its radius. 
                 var localCenter = Transform.Inverted().OfPoint(circle.Center);
-                var roots = Equations.SolveIterative(0, Math.PI * 2, 90,
+                var roots = Equations.SolveIterative(0, Math.PI * 2, div,
                     new Func<double, double>((t) =>
                     {
                         var d = PointAtUntransformed(t) - localCenter;
@@ -411,10 +413,11 @@ namespace Elements.Geometry
 
                 var inverted = Transform.Inverted();
                 var ellipseToEllipse = Transform.Concatenated(other.Transform.Inverted());
+                var div = (int)Math.Round(this.Circumference() / BoundedCurve.DefaultMinimumChordLength);
 
                 // Iteratively, find points on ellipse with distance
                 // to other ellipse equal to its focal distance.
-                var roots = Equations.SolveIterative(0, Math.PI * 2, 90,
+                var roots = Equations.SolveIterative(0, Math.PI * 2, div,
                     new Func<double, double>((t) =>
                     {
                         var d = PointAtUntransformed(t);
@@ -456,6 +459,15 @@ namespace Elements.Geometry
         public bool Intersects(BoundedCurve curve, out List<Vector3> results)
         {
             return curve.Intersects(this, out results);
+        }
+
+        /// <summary>
+        /// Approximate circumference of the ellipse.
+        /// </summary>
+        public double Circumference()
+        {
+            return Math.PI * (3 * (MajorAxis + MinorAxis) - 
+                Math.Sqrt((3 * MajorAxis + MinorAxis) * (MajorAxis + 3 * MinorAxis)));
         }
 
         internal double ArcLength(double t0,

--- a/Elements/src/Geometry/Ellipse.cs
+++ b/Elements/src/Geometry/Ellipse.cs
@@ -316,7 +316,7 @@ namespace Elements.Geometry
             Plane planeB = new Plane(circle.Center, circle.Normal);
 
             // Check if circle and ellipse are on the same plane. 
-            if (Normal.IsAlmostEqualTo(circle.Normal) &&
+            if (Normal.IsParallelTo(circle.Normal, Vector3.EPSILON * Vector3.EPSILON) &&
                 circle.Center.DistanceTo(planeA).ApproximatelyEquals(0))
             {
                 // Circle and Ellipse are the same.
@@ -381,7 +381,7 @@ namespace Elements.Geometry
             Plane planeB = new Plane(other.Center, other.Normal);
 
             // Check if circle and ellipse are on the same plane. 
-            if (Normal.IsAlmostEqualTo(other.Normal) &&
+            if (Normal.IsParallelTo(other.Normal, Vector3.EPSILON * Vector3.EPSILON) &&
                 other.Center.DistanceTo(planeA).ApproximatelyEquals(0))
             {
                 // Ellipses are the same.

--- a/Elements/src/Geometry/Ellipse.cs
+++ b/Elements/src/Geometry/Ellipse.cs
@@ -316,16 +316,8 @@ namespace Elements.Geometry
                     {
                         var d = PointAtUntransformed(t) - localCenter;
                         return d.LengthSquared() - circle.Radius * circle.Radius;
-                    }));
-                foreach (var root in roots)
-                {
-                    Vector3 intersection = PointAtUntransformed(root);
-                    var global = Transform.OfPoint(intersection);
-                    if (!results.Any() || !global.IsAlmostEqualTo(results.Last()))
-                    {
-                        results.Add(global);
-                    }
-                }
+                    }), Vector3.EPSILON * Vector3.EPSILON);
+                results.AddRange(Equations.ConvertRoots(this, roots));
             }
             // Ignore parallel planes.
             // Find intersection line between two planes.
@@ -378,7 +370,8 @@ namespace Elements.Geometry
                 }
 
                 // Too far away
-                if (Center.DistanceTo(other.Center) > MajorAxis + other.MajorAxis)
+                if (Center.DistanceTo(other.Center) > 
+                    Math.Max(MajorAxis, MinorAxis) + Math.Max(other.MajorAxis, other.MinorAxis))
                 {
                     return false;
                 }
@@ -394,16 +387,8 @@ namespace Elements.Geometry
                         var dx = Math.Pow(otherD.X / other.MajorAxis, 2);
                         var dy = Math.Pow(otherD.Y / other.MinorAxis, 2);
                         return dx + dy - 1;
-                    }));
-                foreach (var root in roots)
-                {
-                    Vector3 intersection = PointAtUntransformed(root);
-                    var global = Transform.OfPoint(intersection);
-                    if (!results.Any() || !global.IsAlmostEqualTo(results.Last()))
-                    {
-                        results.Add(global);
-                    }
-                }
+                    }), Vector3.EPSILON * Vector3.EPSILON);
+                results.AddRange(Equations.ConvertRoots(this, roots));
             }
             // Ignore parallel planes.
             // Find intersection line between two planes.

--- a/Elements/src/Geometry/Ellipse.cs
+++ b/Elements/src/Geometry/Ellipse.cs
@@ -317,7 +317,7 @@ namespace Elements.Geometry
                         var d = PointAtUntransformed(t) - localCenter;
                         return d.LengthSquared() - circle.Radius * circle.Radius;
                     }), Vector3.EPSILON * Vector3.EPSILON);
-                results.AddRange(Equations.ConvertRoots(this, roots));
+                results.AddRange(Equations.ConvertRoots(this, roots, Vector3.EPSILON * 2));
             }
             // Ignore parallel planes.
             // Find intersection line between two planes.
@@ -388,7 +388,7 @@ namespace Elements.Geometry
                         var dy = Math.Pow(otherD.Y / other.MinorAxis, 2);
                         return dx + dy - 1;
                     }), Vector3.EPSILON * Vector3.EPSILON);
-                results.AddRange(Equations.ConvertRoots(this, roots));
+                results.AddRange(Equations.ConvertRoots(this, roots, Vector3.EPSILON * 2));
             }
             // Ignore parallel planes.
             // Find intersection line between two planes.

--- a/Elements/src/Geometry/Ellipse.cs
+++ b/Elements/src/Geometry/Ellipse.cs
@@ -318,7 +318,8 @@ namespace Elements.Geometry
                         var d = PointAtUntransformed(t) - localCenter;
                         return d.LengthSquared() - circle.Radius * circle.Radius;
                     }), Vector3.EPSILON * Vector3.EPSILON);
-                results.AddRange(Equations.ConvertRoots(this, roots, Vector3.EPSILON * 2));
+                results = roots.Select(r => PointAt(r)).UniqueAverageWithinTolerance(
+                    Vector3.EPSILON * 2).ToList();
             }
             // Ignore parallel planes.
             // Find intersection line between two planes.
@@ -389,7 +390,8 @@ namespace Elements.Geometry
                         var dy = Math.Pow(otherD.Y / other.MinorAxis, 2);
                         return dx + dy - 1;
                     }), Vector3.EPSILON * Vector3.EPSILON);
-                results.AddRange(Equations.ConvertRoots(this, roots, Vector3.EPSILON * 2));
+                results = roots.Select(r => PointAt(r)).UniqueAverageWithinTolerance(
+                    Vector3.EPSILON * 2).ToList();
             }
             // Ignore parallel planes.
             // Find intersection line between two planes.

--- a/Elements/src/Geometry/Ellipse.cs
+++ b/Elements/src/Geometry/Ellipse.cs
@@ -128,7 +128,7 @@ namespace Elements.Geometry
         public bool ParameterAt(Vector3 pt, out double parameter)
         {
             var local = Transform.Inverted().OfPoint(pt);
-            if (local.Z.ApproximatelyEquals(0) && OnEllipseUntransformed(pt))
+            if (local.Z.ApproximatelyEquals(0) && OnEllipseUntransformed(local))
             {
                 parameter = ParameterAtUntransformed(local);
                 return true;

--- a/Elements/src/Geometry/EllipticalArc.cs
+++ b/Elements/src/Geometry/EllipticalArc.cs
@@ -214,16 +214,15 @@ namespace Elements.Geometry
                 return false;
             }
 
-            parameter = NormalizedParameter(parameter);
-            var normalizedDomain = new Domain1d(NormalizedParameter(Domain.Min), NormalizedParameter(Domain.Max));
+            parameter = Units.NormalizedRadian(parameter);
+            var min = Units.NormalizedRadian(Domain.Min);
+            var max = Units.NormalizedRadian(Domain.Max);
+            if (min > max)
+            {
+                (max, min) = (min, max);
+            }
+            var normalizedDomain = new Domain1d(min, max);
             return parameter >= normalizedDomain.Min && parameter <= normalizedDomain.Max;
-        }
-
-        private double NormalizedParameter(double parameter)
-        {
-            var numberOfRotation = Math.Floor(parameter / (2 * Math.PI));
-            var normalized = parameter - numberOfRotation * 2 * Math.PI;
-            return normalized;
         }
     }
 }

--- a/Elements/src/Geometry/EllipticalArc.cs
+++ b/Elements/src/Geometry/EllipticalArc.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 
@@ -188,6 +189,41 @@ namespace Elements.Geometry
 
             this.BasisCurve.ArcLengthUntil(start, this.Domain.Max, distance, out var end);
             return end;
+        }
+
+        public bool Intersects(EllipticalArc other, out List<Vector3> results)
+        {
+            results = new List<Vector3>();
+            if (BasisCurve.Intersects(other.BasisCurve, out var candidates))
+            {
+                foreach (var item in candidates)
+                {
+                    if (this.PointOnDomain(item) && other.PointOnDomain(item))
+                    {
+                        results.Add(item);
+                    }
+                }
+            }
+            return results.Any();
+        }
+
+        public override bool PointOnDomain(Vector3 point)
+        {
+            if (!BasisCurve.ParameterAt(point, out var parameter))
+            {
+                return false;
+            }
+
+            parameter = NormalizedParameter(parameter);
+            var normalizedDomain = new Domain1d(NormalizedParameter(Domain.Min), NormalizedParameter(Domain.Max));
+            return parameter >= normalizedDomain.Min && parameter <= normalizedDomain.Max;
+        }
+
+        private double NormalizedParameter(double parameter)
+        {
+            var numberOfRotation = Math.Floor(parameter / (2 * Math.PI));
+            var normalized = parameter - numberOfRotation * 2 * Math.PI;
+            return normalized;
         }
     }
 }

--- a/Elements/src/Geometry/EllipticalArc.cs
+++ b/Elements/src/Geometry/EllipticalArc.cs
@@ -214,15 +214,12 @@ namespace Elements.Geometry
                 return false;
             }
 
-            parameter = Units.NormalizedRadian(parameter);
-            var min = Units.NormalizedRadian(Domain.Min);
-            var max = Units.NormalizedRadian(Domain.Max);
-            if (min > max)
-            {
-                (max, min) = (min, max);
-            }
-            var normalizedDomain = new Domain1d(min, max);
-            return parameter >= normalizedDomain.Min && parameter <= normalizedDomain.Max;
+            (double min, double max) = Domain.Max < Domain.Min ?
+                (Domain.Max, Domain.Min) : (Domain.Min, Domain.Max);
+
+            parameter = Units.AdjustRadian(parameter, min);
+            return parameter - min > -Vector3.EPSILON * Vector3.EPSILON &&
+                   parameter - max < Vector3.EPSILON * Vector3.EPSILON;
         }
     }
 }

--- a/Elements/src/Geometry/EllipticalArc.cs
+++ b/Elements/src/Geometry/EllipticalArc.cs
@@ -191,22 +191,7 @@ namespace Elements.Geometry
             return end;
         }
 
-        public bool Intersects(EllipticalArc other, out List<Vector3> results)
-        {
-            results = new List<Vector3>();
-            if (BasisCurve.Intersects(other.BasisCurve, out var candidates))
-            {
-                foreach (var item in candidates)
-                {
-                    if (this.PointOnDomain(item) && other.PointOnDomain(item))
-                    {
-                        results.Add(item);
-                    }
-                }
-            }
-            return results.Any();
-        }
-
+        /// <inheritdoc/>
         public override bool PointOnDomain(Vector3 point)
         {
             if (!BasisCurve.ParameterAt(point, out var parameter))

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -528,6 +528,7 @@ namespace Elements.Geometry
             return true;
         }
 
+        /// <inheritdoc/>
         public override bool Intersects(ICurve curve, out List<Vector3> results)
         {
             results = new List<Vector3>();

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -1,8 +1,10 @@
+using Elements.Geometry.Interfaces;
 using Elements.Validators;
 using Newtonsoft.Json;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Elements.Geometry
 {
@@ -524,6 +526,20 @@ namespace Elements.Geometry
                 }
             }
             return true;
+        }
+
+        public override bool Intersects(ICurve curve, out List<Vector3> results)
+        {
+            results = new List<Vector3>();
+            foreach (var segment in _curves)
+            {
+                if (segment.Intersects(curve, out var intersections))
+                {
+                    results.AddRange(intersections);
+                }
+            }
+            results = results.Distinct().ToList();
+            return results.Any();
         }
 
         /// <summary>

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -535,10 +535,16 @@ namespace Elements.Geometry
             {
                 if (segment.Intersects(curve, out var intersections))
                 {
-                    results.AddRange(intersections);
+                    foreach (var item in intersections)
+                    {
+                        if (!results.Any() || 
+                            !results.First().IsAlmostEqualTo(item) && !results.Last().IsAlmostEqualTo(item))
+                        {
+                            results.Add(item);
+                        }
+                    }
                 }
             }
-            results = results.Distinct().ToList();
             return results.Any();
         }
 

--- a/Elements/src/Geometry/InfiniteLine.cs
+++ b/Elements/src/Geometry/InfiniteLine.cs
@@ -60,6 +60,12 @@ namespace Elements.Geometry
             return new Transform(PointAt(u), Direction.Negate());
         }
 
+        /// <summary>
+        /// Check if certain point is on the infinite line.
+        /// </summary>
+        /// <param name="pt">Point to check.</param>
+        /// <param name="t">Calculated parameter of point on infinite line.</param>
+        /// <returns>True if point lays on the infinite line.</returns>
         public bool ParameterAt(Vector3 pt, out double t)
         { 
             t = (pt - Origin).Dot(Direction) / Direction.LengthSquared();
@@ -81,6 +87,12 @@ namespace Elements.Geometry
             return start + distance;
         }
 
+        /// <summary>
+        /// Does infinite line intersect with a plane but not on it?
+        /// </summary>
+        /// <param name="plane">Plane to intersect.</param>
+        /// <param name="result">True if plane intersects with the line, false if not intersects or line is lying on it.</param>
+        /// <returns></returns>
         public bool Intersects(Plane plane, out Vector3 result)
         {
             result = default;
@@ -96,6 +108,7 @@ namespace Elements.Geometry
             return true;
         }
 
+        /// <inheritdoc/>
         public override bool Intersects(ICurve curve, out List<Vector3> results)
         {
             switch (curve)
@@ -113,6 +126,13 @@ namespace Elements.Geometry
             }
         }
 
+        /// <summary>
+        /// Does this infinite line intersects with other infinite line?
+        /// Same lines are not considered as intersecting.
+        /// </summary>
+        /// <param name="other">Other infinite line to intersect.</param>
+        /// <param name="results">List containing up to one intersection point.</param>
+        /// <returns>True if intersection exists, otherwise false.</returns>
         public bool Intersects(InfiniteLine other, out List<Vector3> results)
         {
             results = new List<Vector3>();
@@ -136,19 +156,39 @@ namespace Elements.Geometry
             return true;
         }
 
+        /// <summary>
+        /// Does this infinite line intersects with a circle?
+        /// <see cref="Circle.Intersects(InfiniteLine, out List{Vector3})"/>
+        /// </summary>
+        /// <param name="circle">Circle to intersect.</param>
+        /// <param name="results">List containing up to two intersection points.</param>
+        /// <returns>True if any intersections exist, otherwise false.</returns>
         public bool Intersects(Circle circle, out List<Vector3> results)
         {
             return circle.Intersects(this, out results);
         }
 
+        /// <summary>
+        /// Does this infinite line intersects with an ellipse?
+        /// <see cref="Ellipse.Intersects(InfiniteLine, out List{Vector3})"/>
+        /// </summary>
+        /// <param name="ellipse">Ellipse to intersect.</param>
+        /// <param name="results">List containing up to two intersection points.</param>
+        /// <returns>True if any intersections exist, otherwise false.</returns>
         public bool Intersects(Ellipse ellipse, out List<Vector3> results)
         {
             return ellipse.Intersects(this, out results);
         }
 
-        public bool Intersects(BoundedCurve bounded, out List<Vector3> results)
+        /// <summary>
+        /// Does this infinite line intersects with a bounded curve?
+        /// </summary>
+        /// <param name="curve">Curve to intersect.</param>
+        /// <param name="results">List containing intersection points.</param>
+        /// <returns>True if any intersections exist, otherwise false.</returns>
+        public bool Intersects(BoundedCurve curve, out List<Vector3> results)
         {
-            return bounded.Intersects(this, out results);
+            return curve.Intersects(this, out results);
         }
     }
 }

--- a/Elements/src/Geometry/InfiniteLine.cs
+++ b/Elements/src/Geometry/InfiniteLine.cs
@@ -1,3 +1,4 @@
+using Elements.Geometry.Interfaces;
 using System;
 using System.Collections.Generic;
 
@@ -95,6 +96,23 @@ namespace Elements.Geometry
             return true;
         }
 
+        public override bool Intersects(ICurve curve, out List<Vector3> results)
+        {
+            switch (curve)
+            {
+                case BoundedCurve boundedCurve:
+                    return boundedCurve.Intersects(this, out results);
+                case Circle circle:
+                    return Intersects(circle, out results);
+                case Ellipse elliplse:
+                    return Intersects(elliplse, out results);
+                case InfiniteLine line:
+                    return Intersects(line, out results);
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
         public bool Intersects(InfiniteLine other, out List<Vector3> results)
         {
             results = new List<Vector3>();
@@ -116,6 +134,21 @@ namespace Elements.Geometry
             var t = (normal.Dot(other.Origin) - normal.Dot(Origin)) / normal.Dot(Direction);
             results.Add(Origin + Direction * t);
             return true;
+        }
+
+        public bool Intersects(Circle circle, out List<Vector3> results)
+        {
+            return circle.Intersects(this, out results);
+        }
+
+        public bool Intersects(Ellipse ellipse, out List<Vector3> results)
+        {
+            return ellipse.Intersects(this, out results);
+        }
+
+        public bool Intersects(BoundedCurve bounded, out List<Vector3> results)
+        {
+            return bounded.Intersects(this, out results);
         }
     }
 }

--- a/Elements/src/Geometry/InfiniteLine.cs
+++ b/Elements/src/Geometry/InfiniteLine.cs
@@ -117,8 +117,8 @@ namespace Elements.Geometry
                     return boundedCurve.Intersects(this, out results);
                 case Circle circle:
                     return Intersects(circle, out results);
-                case Ellipse elliplse:
-                    return Intersects(elliplse, out results);
+                case Ellipse ellipse:
+                    return Intersects(ellipse, out results);
                 case InfiniteLine line:
                     return Intersects(line, out results);
                 default:

--- a/Elements/src/Geometry/InfiniteLine.cs
+++ b/Elements/src/Geometry/InfiniteLine.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace Elements.Geometry
 {
     /// TODO: Rename this class to Line
@@ -56,6 +59,17 @@ namespace Elements.Geometry
             return new Transform(PointAt(u), Direction.Negate());
         }
 
+        public bool ParameterAt(Vector3 pt, out double t)
+        { 
+            t = (pt - Origin).Dot(Direction) / Direction.LengthSquared();
+            var pointOnLine = Origin + Direction * t;
+            if (pointOnLine.IsAlmostEqualTo(pt))
+            {
+                return true;
+            }
+            return false;
+        }
+
         /// <summary>
         /// Get the parameter at a distance from the start parameter along the curve.
         /// </summary>
@@ -64,6 +78,44 @@ namespace Elements.Geometry
         public override double ParameterAtDistanceFromParameter(double distance, double start)
         {
             return start + distance;
+        }
+
+        public bool Intersects(Plane plane, out Vector3 result)
+        {
+            result = default;
+            
+            // Test for perpendicular.
+            if (plane.Normal.Dot(Direction).ApproximatelyEquals(0))
+            {
+                return false;
+            }
+
+            var t = (plane.Normal.Dot(plane.Origin) - plane.Normal.Dot(Origin)) / plane.Normal.Dot(Direction);
+            result = Origin + Direction * t;
+            return true;
+        }
+
+        public bool Intersects(InfiniteLine other, out List<Vector3> results)
+        {
+            results = new List<Vector3>();
+
+            // Check and return if two lines are parallel.
+            var normal = Direction.Cross(other.Direction);
+            if (normal.LengthSquared() < Vector3.EPSILON * Vector3.EPSILON)
+            {
+                return false;
+            }
+
+            // Check and return if two lines are not coplanar 
+            if (Math.Abs((Origin - other.Origin).Dot(normal)) > Vector3.EPSILON)
+            {
+                return false;
+            }
+
+            normal = other.Direction.Cross(normal);
+            var t = (normal.Dot(other.Origin) - normal.Dot(Origin)) / normal.Dot(Direction);
+            results.Add(Origin + Direction * t);
+            return true;
         }
     }
 }

--- a/Elements/src/Geometry/Interfaces/ICurve.cs
+++ b/Elements/src/Geometry/Interfaces/ICurve.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Elements.Geometry.Interfaces
 {
     /// <summary>
@@ -25,5 +27,7 @@ namespace Elements.Geometry.Interfaces
         /// <param name="distance">The distance from the start parameter.</param>
         /// <param name="parameter">The parameter from which to measure the distance.</param>
         double ParameterAtDistanceFromParameter(double distance, double parameter);
+
+        bool Intersects(ICurve curve, out List<Vector3> results);
     }
 }

--- a/Elements/src/Geometry/Interfaces/ICurve.cs
+++ b/Elements/src/Geometry/Interfaces/ICurve.cs
@@ -28,6 +28,12 @@ namespace Elements.Geometry.Interfaces
         /// <param name="parameter">The parameter from which to measure the distance.</param>
         double ParameterAtDistanceFromParameter(double distance, double parameter);
 
+        /// <summary>
+        /// Does this curve intersect the provided curve?
+        /// </summary>
+        /// <param name="curve">Curve to intersect.</param>
+        /// <param name="results">List of intersection points, empty if there is no intersection.</param>
+        /// <returns>True if any intersections exist, otherwise false.</returns>
         bool Intersects(ICurve curve, out List<Vector3> results);
     }
 }

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -462,54 +462,15 @@ namespace Elements.Geometry
             return results.Any();
         }
 
-        public bool Intersects(InfiniteLine other, out List<Vector3> results)
+        public override bool PointOnDomain(Vector3 point)
         {
-            results = new List<Vector3>();
-            if (BasisCurve.Intersects(other, out var candidates))
+            if (!BasisCurve.ParameterAt(point, out var parameter))
             {
-                foreach (var item in candidates)
-                {
-                    if (PointOnLine(item, true))
-                    {
-                        results.Add(item);
-                    }
-                }
+                return false;
             }
-            return results.Any();
-        }
 
-        public bool Intersects(Line other, out List<Vector3> results)
-        {
-            results = new List<Vector3>();
-            if (BasisCurve.Intersects(other.BasisCurve, out var candidates))
-            {
-                foreach (var item in candidates)
-                {
-                    if (PointOnLine(item, true) && other.PointOnLine(item, true))
-                    {
-                        results.Add(item);
-                    }
-                }
-            }
-            return results.Any();
+            return parameter >= Domain.Min && parameter <= Domain.Max;
         }
-
-        public bool Intersects(Circle circle, out List<Vector3> results)
-        {
-            results = new List<Vector3>();
-            if (circle.Intersects(BasisCurve, out var candidates))
-            {
-                foreach (var item in candidates)
-                {
-                    if (this.PointOnLine(item, true))
-                    {
-                        results.Add(item);
-                    }
-                }
-            }
-            return results.Any();
-        }
-
 
         private static bool IsAlmostZero(double a)
         {

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -462,6 +462,55 @@ namespace Elements.Geometry
             return results.Any();
         }
 
+        public bool Intersects(InfiniteLine other, out List<Vector3> results)
+        {
+            results = new List<Vector3>();
+            if (BasisCurve.Intersects(other, out var candidates))
+            {
+                foreach (var item in candidates)
+                {
+                    if (PointOnLine(item, true))
+                    {
+                        results.Add(item);
+                    }
+                }
+            }
+            return results.Any();
+        }
+
+        public bool Intersects(Line other, out List<Vector3> results)
+        {
+            results = new List<Vector3>();
+            if (BasisCurve.Intersects(other.BasisCurve, out var candidates))
+            {
+                foreach (var item in candidates)
+                {
+                    if (PointOnLine(item, true) && other.PointOnLine(item, true))
+                    {
+                        results.Add(item);
+                    }
+                }
+            }
+            return results.Any();
+        }
+
+        public bool Intersects(Circle circle, out List<Vector3> results)
+        {
+            results = new List<Vector3>();
+            if (circle.Intersects(BasisCurve, out var candidates))
+            {
+                foreach (var item in candidates)
+                {
+                    if (this.PointOnLine(item, true))
+                    {
+                        results.Add(item);
+                    }
+                }
+            }
+            return results.Any();
+        }
+
+
         private static bool IsAlmostZero(double a)
         {
             return Math.Abs(a) < Vector3.EPSILON;

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -462,6 +462,7 @@ namespace Elements.Geometry
             return results.Any();
         }
 
+        /// <inheritdoc/>
         public override bool PointOnDomain(Vector3 point)
         {
             if (!BasisCurve.ParameterAt(point, out var parameter))
@@ -469,7 +470,8 @@ namespace Elements.Geometry
                 return false;
             }
 
-            return parameter >= Domain.Min && parameter <= Domain.Max;
+            return parameter - Domain.Min > -Vector3.EPSILON * Vector3.EPSILON &&
+                   parameter - Domain.Max < Vector3.EPSILON * Vector3.EPSILON;
         }
 
         private static bool IsAlmostZero(double a)

--- a/Elements/src/Geometry/Plane.cs
+++ b/Elements/src/Geometry/Plane.cs
@@ -177,6 +177,25 @@ namespace Elements.Geometry
             return false;
         }
 
+        public bool Intersects(Plane other, out InfiniteLine result)
+        {
+            var cross = this.Normal.Cross(other.Normal);
+            if (cross.IsZero())
+            {
+                result = default;
+                return false;
+            }
+
+            var dir = other.Normal.Cross(cross);
+            var distance = this.Normal.Dot(dir);
+            Vector3 planeDelta = Origin - other.Origin;
+            var t = Normal.Dot(planeDelta) / distance;
+            var p = other.Origin + t * dir;
+
+            result = new InfiniteLine(p, cross);
+            return true;
+        }
+
         /// <summary>
         /// The world XY Plane.
         /// </summary>

--- a/Elements/src/Geometry/Plane.cs
+++ b/Elements/src/Geometry/Plane.cs
@@ -177,6 +177,12 @@ namespace Elements.Geometry
             return false;
         }
 
+        /// <summary>
+        /// Does this plane intersect the other plane?
+        /// </summary>
+        /// <param name="other">The other plane.</param>
+        /// <param name="result">The line of intersection.</param>
+        /// <returns>True if an intersection exists, otherwise false.</returns>
         public bool Intersects(Plane other, out InfiniteLine result)
         {
             var cross = this.Normal.Cross(other.Normal);

--- a/Elements/src/Geometry/TrimmedCurve.cs
+++ b/Elements/src/Geometry/TrimmedCurve.cs
@@ -39,8 +39,8 @@ namespace Elements.Geometry
                     return Intersects(line, out results);
                 case Circle circle:
                     return Intersects(circle, out results);
-                case Ellipse elliplse:
-                    return Intersects(elliplse, out results);
+                case Ellipse ellipse:
+                    return Intersects(ellipse, out results);
                 case IndexedPolycurve polycurve:
                     return polycurve.Intersects(this, out results);
                 case Bezier bezier:

--- a/Elements/src/Geometry/TrimmedCurve.cs
+++ b/Elements/src/Geometry/TrimmedCurve.cs
@@ -17,8 +17,14 @@ namespace Elements.Geometry
         [JsonIgnore]
         public TBasis BasisCurve { get; protected set; }
 
+        /// <summary>
+        /// Check if point is on the domain of the curve.
+        /// </summary>
+        /// <param name="point">Point to check.</param>
+        /// <returns>True if point is on trimmed domain of the curve.</returns>
         public abstract bool PointOnDomain(Vector3 point);
 
+        /// <inheritdoc/>
         public override bool Intersects(ICurve curve, out List<Vector3> results)
         {
             switch (curve)
@@ -44,6 +50,14 @@ namespace Elements.Geometry
             }
         }
 
+        /// <summary>
+        /// Does this trimmed curve intersects with an infinite line?
+        /// If they coincides, they are not considered as intersecting,
+        /// unless their domain only touches each other at end points.
+        /// </summary>
+        /// <param name="line">Infinite line to intersect.</param>
+        /// <param name="results">List containing up to twp intersection points.</param>
+        /// <returns>True if intersection exists, otherwise false.</returns>
         public bool Intersects(InfiniteLine line, out List<Vector3> results)
         {
             results = new List<Vector3>();
@@ -60,6 +74,14 @@ namespace Elements.Geometry
             return results.Any();
         }
 
+        /// <summary>
+        /// Does this trimmed curve intersects with a circle?
+        /// If they coincides, they are not considered as intersecting,
+        /// unless their domain only touches each other at end points.
+        /// </summary>
+        /// <param name="circle">Circle to intersect.</param>
+        /// <param name="results">List containing up to four intersection points.</param>
+        /// <returns>True if any intersections exist, otherwise false.</returns>
         public bool Intersects(Circle circle, out List<Vector3> results)
         {
             results = new List<Vector3>();
@@ -76,6 +98,14 @@ namespace Elements.Geometry
             return results.Any();
         }
 
+        /// <summary>
+        /// Does this trimmed curve intersects with an ellipse?
+        /// If they coincides, they are not considered as intersecting,
+        /// unless their domain only touches each other at end points.
+        /// </summary>
+        /// <param name="ellipse">Ellipse to intersect.</param>
+        /// <param name="results">List containing up to four intersection points.</param>
+        /// <returns>True if any intersections exist, otherwise false.</returns>
         public bool Intersects(Ellipse ellipse, out List<Vector3> results)
         {
             results = new List<Vector3>();
@@ -92,6 +122,14 @@ namespace Elements.Geometry
             return results.Any();
         }
 
+        /// <summary>
+        /// Does this trimmed curve intersects with other trimmed curve?
+        /// If they coincides, they are not considered as intersecting,
+        /// unless their domain only touches each other at end points.
+        /// </summary>
+        /// <param name="curve">Trimmed curve to intersect.</param>
+        /// <param name="results">List containing intersection points.</param>
+        /// <returns>True if any intersections exist, otherwise false.</returns>
         public bool Intersects<T>(TrimmedCurve<T> curve, out List<Vector3> results) where T : ICurve
         {
             results = new List<Vector3>();
@@ -146,6 +184,12 @@ namespace Elements.Geometry
             return results.Any();
         }
 
+        /// <summary>
+        /// Does this trimmed curve intersects with a Bezier curve?
+        /// </summary>
+        /// <param name="bezier">Bezier curve to intersect.</param>
+        /// <param name="results">List containing intersection points.</param>
+        /// <returns>True if any intersections exist, otherwise false.</returns>
         public bool Intersects(Bezier bezier, out List<Vector3> results)
         {
             results = new List<Vector3>();

--- a/Elements/src/Geometry/TrimmedCurve.cs
+++ b/Elements/src/Geometry/TrimmedCurve.cs
@@ -105,6 +105,44 @@ namespace Elements.Geometry
                     }
                 }
             }
+            else
+            {
+                // Overlapping curves are not considered intersecting.
+                // However, if their domains are not overlap,
+                // end points that belongs to both curves are recorded as intersections.
+                bool startOnStart = Start.IsAlmostEqualTo(curve.Start);
+                bool startOnEnd = Start.IsAlmostEqualTo(curve.End);
+                bool endOnStart = End.IsAlmostEqualTo(curve.Start);
+                bool endOnEnd = End.IsAlmostEqualTo(curve.End);
+                if (startOnStart || startOnEnd)
+                {
+                    if (endOnStart || endOnEnd)
+                    {
+                        if (!curve.PointOnDomain(Mid()))
+                        {
+                            results.Add(Start);
+                            results.Add(End);
+                        }
+                    }
+                    else
+                    {
+                        var other = startOnStart ? curve.End : curve.Start;
+                        if (!curve.PointOnDomain(End) && !PointOnDomain(other))
+                        {
+                            results.Add(Start);
+                        }
+                    }
+                }
+                else if (endOnStart || endOnEnd)
+                {
+                    var other = endOnStart ? curve.End : curve.Start;
+                    if (!curve.PointOnDomain(Start) && !PointOnDomain(other))
+                    {
+                        results.Add(End);
+                    }
+                }
+            }
+
             return results.Any();
         }
 

--- a/Elements/src/Geometry/TrimmedCurve.cs
+++ b/Elements/src/Geometry/TrimmedCurve.cs
@@ -1,5 +1,8 @@
 using Elements.Geometry.Interfaces;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Elements.Geometry
 {
@@ -13,5 +16,112 @@ namespace Elements.Geometry
         /// </summary>
         [JsonIgnore]
         public TBasis BasisCurve { get; protected set; }
+
+        public abstract bool PointOnDomain(Vector3 point);
+
+        public override bool Intersects(ICurve curve, out List<Vector3> results)
+        {
+            switch (curve)
+            {
+                case Line line:
+                    return Intersects(line, out results);
+                case Arc arc:
+                    return Intersects(arc, out results);
+                case EllipticalArc ellipticArc:
+                    return Intersects(ellipticArc, out results);
+                case InfiniteLine line:
+                    return Intersects(line, out results);
+                case Circle circle:
+                    return Intersects(circle, out results);
+                case Ellipse elliplse:
+                    return Intersects(elliplse, out results);
+                case IndexedPolycurve polycurve:
+                    return polycurve.Intersects(this, out results);
+                case Bezier bezier:
+                    return Intersects(bezier, out results);
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        public bool Intersects(InfiniteLine line, out List<Vector3> results)
+        {
+            results = new List<Vector3>();
+            if (BasisCurve.Intersects(line, out var candidates))
+            {
+                foreach (var item in candidates)
+                {
+                    if (this.PointOnDomain(item))
+                    {
+                        results.Add(item);
+                    }
+                }
+            }
+            return results.Any();
+        }
+
+        public bool Intersects(Circle circle, out List<Vector3> results)
+        {
+            results = new List<Vector3>();
+            if (BasisCurve.Intersects(circle, out var candidates))
+            {
+                foreach (var item in candidates)
+                {
+                    if (this.PointOnDomain(item))
+                    {
+                        results.Add(item);
+                    }
+                }
+            }
+            return results.Any();
+        }
+
+        public bool Intersects(Ellipse ellipse, out List<Vector3> results)
+        {
+            results = new List<Vector3>();
+            if (BasisCurve.Intersects(ellipse, out var candidates))
+            {
+                foreach (var item in candidates)
+                {
+                    if (PointOnDomain(item))
+                    {
+                        results.Add(item);
+                    }
+                }
+            }
+            return results.Any();
+        }
+
+        public bool Intersects<T>(TrimmedCurve<T> curve, out List<Vector3> results) where T : ICurve
+        {
+            results = new List<Vector3>();
+            if (BasisCurve.Intersects(curve.BasisCurve, out var candidates))
+            {
+                foreach (var item in candidates)
+                {
+                    if (this.PointOnDomain(item) && curve.PointOnDomain(item))
+                    {
+                        results.Add(item);
+                    }
+                }
+            }
+            return results.Any();
+        }
+
+        public bool Intersects(Bezier bezier, out List<Vector3> results)
+        {
+            results = new List<Vector3>();
+            if (bezier.Intersects(BasisCurve, out var candidates))
+            {
+                foreach (var item in candidates)
+                {
+                    if (PointOnDomain(item))
+                    {
+                        results.Add(item);
+                    }
+                }
+            }
+            return results.Any();
+        }
     }
 }

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -1,4 +1,3 @@
-using ClipperLib;
 using Elements.Validators;
 using Newtonsoft.Json;
 using System;

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -851,6 +851,11 @@ namespace Elements.Geometry
             return prod;
         }
 
+        /// <summary>
+        /// Get the closest point on the infinite line from this point.
+        /// </summary>
+        /// <param name="line">The infinite line on which to find the closest point.</param>
+        /// <returns>The closest point on the infinite line from this point.</returns>
         public Vector3 ClosestPointOn(InfiniteLine line)
         {
             var v = this - line.Origin;

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -1,3 +1,4 @@
+using ClipperLib;
 using Elements.Validators;
 using Newtonsoft.Json;
 using System;
@@ -849,6 +850,14 @@ namespace Elements.Geometry
             var prod = a.Dot(b.Cross(c));
             return prod;
         }
+
+        public Vector3 ClosestPointOn(InfiniteLine line)
+        {
+            var v = this - line.Origin;
+            var d = v.Dot(line.Direction);
+            return line.Origin + line.Direction * d;
+        }
+
 
         /// <summary>
         /// Get the closest point on the line from this point.

--- a/Elements/src/Geometry/Vector3Extensions.cs
+++ b/Elements/src/Geometry/Vector3Extensions.cs
@@ -308,7 +308,8 @@ namespace Elements.Geometry
         /// <param name="vectors">List of vectors</param>
         /// <param name="tolerance">Distance tolerance</param>
         /// <returns>A new collection of vectors with duplicates removed.</returns>
-        public static IEnumerable<Vector3> UniqueWithinTolerance(this IEnumerable<Vector3> vectors, double tolerance = Vector3.EPSILON)
+        public static IEnumerable<Vector3> UniqueWithinTolerance(
+            this IEnumerable<Vector3> vectors, double tolerance = Vector3.EPSILON)
         {
             var output = new List<Vector3>();
             foreach (var vector in vectors)
@@ -321,6 +322,32 @@ namespace Elements.Geometry
             }
 
             return output;
+        }
+
+        /// <summary>
+        /// De-duplicate a collection of Vectors, averaging vectors within tolerance of each other.
+        /// </summary>
+        /// <param name="vectors">List of vectors</param>
+        /// <param name="tolerance">Distance tolerance</param>
+        /// <returns>A new collection of vectors with only averaged vectors.</returns>
+        public static IEnumerable<Vector3> UniqueAverageWithinTolerance(
+            this IEnumerable<Vector3> vectors, double tolerance = Vector3.EPSILON)
+        {
+            List<List<Vector3>> groups = new List<List<Vector3>>();
+            foreach (var v in vectors)
+            {
+                var group = groups.FirstOrDefault(g => g.First().IsAlmostEqualTo(v, tolerance));
+                if (group != null)
+                {
+                    group.Add(v);
+                }
+                else
+                {
+                    groups.Add(new List<Vector3>() { v });
+                }
+            }
+
+            return groups.Select(g => g.Average());
         }
     }
 

--- a/Elements/src/Geometry/Vector3Extensions.cs
+++ b/Elements/src/Geometry/Vector3Extensions.cs
@@ -326,6 +326,7 @@ namespace Elements.Geometry
 
         /// <summary>
         /// De-duplicate a collection of Vectors, averaging vectors within tolerance of each other.
+        /// Points that are further than tolerance away can still be in one group if they are connected by other points.
         /// </summary>
         /// <param name="vectors">List of vectors</param>
         /// <param name="tolerance">Distance tolerance</param>
@@ -336,7 +337,7 @@ namespace Elements.Geometry
             List<List<Vector3>> groups = new List<List<Vector3>>();
             foreach (var v in vectors)
             {
-                var group = groups.FirstOrDefault(g => g.First().IsAlmostEqualTo(v, tolerance));
+                var group = groups.FirstOrDefault(g => g.Any(p => p.IsAlmostEqualTo(v, tolerance)));
                 if (group != null)
                 {
                     group.Add(v);

--- a/Elements/src/Math/Equations.cs
+++ b/Elements/src/Math/Equations.cs
@@ -1,0 +1,77 @@
+﻿using Elements.Geometry;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Elements
+{
+    public static class Equations
+    {
+        public static IEnumerable<double> SolveQuadratic(double a, double b, double c)
+        {
+            double discriminant = b * b - 4 * a * c;
+
+            if (discriminant.ApproximatelyEquals(0))
+            {
+                double t = -b / (2 * a);
+                yield return t;
+            }
+            else if (discriminant < 0)
+            {
+                yield break;
+            }
+            else
+            {
+                double t1 = (-b + Math.Sqrt(discriminant)) / (2 * a);
+                yield return t1;
+                double t2 = (-b - Math.Sqrt(discriminant)) / (2 * a);
+                yield return t2;
+            }
+        }
+
+        public static IEnumerable<double> SolveIterative(
+            double start, double end, Func<double, double> evaluate)
+        {
+            var step = (end - start) / 45;
+            int lastSign = 0;
+            double lastFx = 0;
+            double lastDelta = 0;
+
+            for (double i = start; i < end; i += step)
+            {
+                var fx = evaluate(i);
+                if (fx.ApproximatelyEquals(0, Vector3.EPSILON * Vector3.EPSILON))
+                {
+                    yield return i;
+                    lastSign = 0;
+                }
+                else
+                {
+                    var sign = Math.Sign(fx);
+                    if (lastSign != 0 && sign != lastSign)
+                    {
+                        foreach(var r in SolveIterative(i - step, i, evaluate))
+                        {
+                            yield return r;
+                        }
+                    }
+                    else if (lastDelta < 0 && fx - lastFx >= 0 && Math.Min(fx, lastFx) < step * 2)
+                    {
+                        foreach (var r in SolveIterative(i - step * 2, i, evaluate))
+                        {
+                            yield return r;
+                        }
+                    }
+                    lastSign = sign;
+                }
+                lastFx = fx;
+
+                if (lastFx != 0)
+                {
+                    lastDelta = fx - lastFx;
+                }
+            }
+        }
+    }
+}

--- a/Elements/src/Math/Equations.cs
+++ b/Elements/src/Math/Equations.cs
@@ -97,21 +97,12 @@ namespace Elements
             }
         }
 
-        public static List<Vector3> ConvertRoots(ICurve curve, IEnumerable<double> roots)
+        public static List<Vector3> ConvertRoots(ICurve curve,
+                                                 IEnumerable<double> roots,
+                                                 double tolerance = Vector3.EPSILON)
         {
-            var results = new List<Vector3>();
-            foreach (var root in roots)
-            {
-                var p = curve.PointAt(root);
-                // Filter roots that are too close together.
-                // Also, if domain is periodic, first root can also be duplicated.
-                if (!results.Any() || (!p.IsAlmostEqualTo(results.First()) &&
-                                       !p.IsAlmostEqualTo(results.Last())))
-                {
-                    results.Add(p);
-                }
-            }
-            return results;
+            var results = roots.Select(r => curve.PointAt(r)).UniqueAverageWithinTolerance(tolerance);
+            return results.ToList();
         }
     }
 }

--- a/Elements/src/Math/Equations.cs
+++ b/Elements/src/Math/Equations.cs
@@ -34,20 +34,19 @@ namespace Elements
         }
 
         public static IEnumerable<double> SolveIterative(
-            double start, double end,
+            double start, double end, int steps,
             Func<double, double> evaluate,
             double tolerance = Vector3.EPSILON)
         {
-            int numSteps = 45;
-            var step = (end - start) / numSteps;
+            var step = (end - start) / steps;
             int lastSign = 0;
             double lastFx = 0;
             double lastDelta = 0;
             double? lastRoot = null;
 
-            for (int  i = 0; i <= numSteps; i++)
+            for (int  i = 0; i <= steps; i++)
             {
-                var t = i == numSteps ? end : start + i * step;
+                var t = i == steps ? end : start + i * step;
                 var fx = evaluate(t);
                 if (fx.ApproximatelyEquals(0, tolerance))
                 {
@@ -63,7 +62,7 @@ namespace Elements
                     var sign = Math.Sign(fx);
                     if (lastSign != 0 && sign != lastSign)
                     {
-                        foreach (var r in SolveIterative(t - step, t, evaluate, tolerance))
+                        foreach (var r in SolveIterative(t - step, t, steps, evaluate, tolerance))
                         {
                             if (!lastRoot.HasValue || Math.Abs(fx - lastRoot.Value) > tolerance * 2)
                             {
@@ -77,7 +76,7 @@ namespace Elements
                         var min = Math.Min(fx, lastFx);
                         if (min > 0 && min < step * 2)
                         {
-                            foreach (var r in SolveIterative(t - step * 2, t, evaluate, tolerance))
+                            foreach (var r in SolveIterative(t - step * 2, t, steps, evaluate, tolerance))
                             {
                                 if (!lastRoot.HasValue || Math.Abs(fx - lastRoot.Value) > tolerance * 2)
                                 {
@@ -104,6 +103,8 @@ namespace Elements
             foreach (var root in roots)
             {
                 var p = curve.PointAt(root);
+                // Filter roots that are too close together.
+                // Also, if domain is periodic, first root can also be duplicated.
                 if (!results.Any() || (!p.IsAlmostEqualTo(results.First()) &&
                                        !p.IsAlmostEqualTo(results.Last())))
                 {

--- a/Elements/src/Math/Equations.cs
+++ b/Elements/src/Math/Equations.cs
@@ -7,8 +7,20 @@ using System.Text;
 
 namespace Elements
 {
+    /// <summary>
+    /// Finding roots of a function.
+    /// </summary>
     public static class Equations
     {
+        /// <summary>
+        /// Solve a quadratic equation and return the roots if any.
+        /// https://en.wikipedia.org/wiki/Quadratic_equation
+        /// </summary>
+        /// <param name="a">A parameter of quadratic equation.</param>
+        /// <param name="b">B parameter of quadratic equation.</param>
+        /// <param name="c">C parameter of quadratic equation.</param>
+        /// <param name="tolerance">Zero discriminant tolerance.</param>
+        /// <returns>One or two roots if equation can be solved, empty if it can't be.</returns>
         public static IEnumerable<double> SolveQuadratic(
             double a, double b, double c,
             double tolerance = Vector3.EPSILON)
@@ -33,6 +45,16 @@ namespace Elements
             }
         }
 
+        /// <summary>
+        /// Solve equation by iterating through parametric range with certain step.
+        /// TODO INTERSECT
+        /// </summary>
+        /// <param name="start"></param>
+        /// <param name="end"></param>
+        /// <param name="steps"></param>
+        /// <param name="evaluate"></param>
+        /// <param name="tolerance"></param>
+        /// <returns></returns>
         public static IEnumerable<double> SolveIterative(
             double start, double end, int steps,
             Func<double, double> evaluate,

--- a/Elements/src/Math/Equations.cs
+++ b/Elements/src/Math/Equations.cs
@@ -47,7 +47,7 @@ namespace Elements
 
         /// <summary>
         /// Solve equation by iterating through parametric range with certain step.
-        /// TODO INTERSECT
+        /// At each step only one root can be found.
         /// </summary>
         /// <param name="start"></param>
         /// <param name="end"></param>
@@ -65,7 +65,7 @@ namespace Elements
             double lastFx = 0;
             double lastDelta = 0;
 
-            for (int  i = 0; i <= steps; i++)
+            for (int i = 0; i <= steps; i++)
             {
                 var t = i == steps ? end : start + i * step;
                 var fx = evaluate(t);
@@ -79,20 +79,14 @@ namespace Elements
                     var sign = Math.Sign(fx);
                     if (lastSign != 0 && sign != lastSign)
                     {
-                        foreach (var r in SolveIterative(t - step, t, steps, evaluate, tolerance))
+                        var r = FindCrossingRoot(t - step, lastFx, t, fx, evaluate, tolerance);
+                        yield return r;
+                    }
+                    else if (lastDelta < 0 && fx - lastFx >= 0 && Math.Min(fx, lastFx) > 0)
+                    {
+                        if (TryFindTouchingRoot(t - step * 2, t, evaluate, tolerance, out var r))
                         {
                             yield return r;
-                        }
-                    }
-                    else if (lastDelta < 0 && fx - lastFx >= 0)
-                    {
-                        var min = Math.Min(fx, lastFx);
-                        if (min > 0 && min < step * 2)
-                        {
-                            foreach (var r in SolveIterative(t - step * 2, t, steps, evaluate, tolerance))
-                            {
-                                yield return r;
-                            }
                         }
                     }
                     lastSign = sign;
@@ -104,6 +98,96 @@ namespace Elements
                 }
                 lastFx = fx;
             }
+        }
+
+        private static double FindCrossingRoot(
+            double start, double startFn, double end, double endFn,
+            Func<double, double> evaluate,
+            double tolerance)
+        {
+            while (true)
+            {
+                // https://en.wikipedia.org/wiki/Secant_method
+                var t = end - endFn * (end - start) / (endFn - startFn);
+                var tFn = evaluate(t);
+                if (tFn.ApproximatelyEquals(0, tolerance))
+                {
+                    return t;
+                }
+
+                start = end;
+                startFn = endFn;
+                end = t;
+                endFn = tFn;
+            }
+        }
+
+        private static bool TryFindTouchingRoot(
+            double start, double end,
+            Func<double, double> evaluate,
+            double tolerance,
+            out double t)
+        {
+            t = 0;
+            var startFn = evaluate(start);
+            var endFn = evaluate(end);
+            while (true)
+            {
+                var d = (end - start) / 3;
+                var t0 = start + d;
+                var t0Fn = evaluate(t0);
+                if (t0Fn.ApproximatelyEquals(0, tolerance))
+                {
+                    t = t0;
+                    return true;
+                }
+
+                var t1 = start + d * 2;
+                var t1Fn = evaluate(t1);
+                if (t1Fn.ApproximatelyEquals(0, tolerance))
+                {
+                    t = t1;
+                    return true;
+                }
+
+                if (t0Fn.ApproximatelyEquals(t1Fn, tolerance))
+                {
+                    // Touching root can't be searched forever.
+                    // Stop if function value is more than searching domain.
+                    // This may fail if curve has sharp angles.
+                    var factor = Math.Max(startFn - t0Fn, endFn - t1Fn);
+                    if (t0Fn > factor * 2)
+                    {
+                        break;
+                    }
+
+                    start = t0;
+                    startFn = t0Fn;
+                    end = t1;
+                    endFn = t1Fn;
+                }
+                else if (t0Fn > t1Fn)
+                {
+                    var factor = Math.Max(t0Fn - t1Fn, endFn - t1Fn);
+                    if (t1Fn > factor * 2)
+                    {
+                        break;
+                    }
+                    start = t0;
+                    startFn = t0Fn;
+                }
+                else
+                {
+                    var factor = Math.Max(startFn - t0Fn, t0Fn - t0Fn);
+                    if (t0Fn > factor * 2)
+                    {
+                        break;
+                    }
+                    end = t1;
+                    endFn = t1Fn;
+                }
+            }
+            return false;
         }
     }
 }

--- a/Elements/src/Math/Equations.cs
+++ b/Elements/src/Math/Equations.cs
@@ -11,7 +11,7 @@ namespace Elements
     {
         public static IEnumerable<double> SolveQuadratic(
             double a, double b, double c,
-            double tolerance = Vector3.EPSILON )
+            double tolerance = Vector3.EPSILON)
         {
             double discriminant = b * b - 4 * a * c;
 
@@ -42,7 +42,6 @@ namespace Elements
             int lastSign = 0;
             double lastFx = 0;
             double lastDelta = 0;
-            double? lastRoot = null;
 
             for (int  i = 0; i <= steps; i++)
             {
@@ -50,12 +49,8 @@ namespace Elements
                 var fx = evaluate(t);
                 if (fx.ApproximatelyEquals(0, tolerance))
                 {
-                    if (!lastRoot.HasValue || Math.Abs(fx - lastRoot.Value) > tolerance * 2)
-                    {
-                        yield return t;
-                        lastSign = 0;
-                        lastRoot = fx;
-                    }
+                    yield return t;
+                    lastSign = 0;
                 }
                 else
                 {
@@ -64,11 +59,7 @@ namespace Elements
                     {
                         foreach (var r in SolveIterative(t - step, t, steps, evaluate, tolerance))
                         {
-                            if (!lastRoot.HasValue || Math.Abs(fx - lastRoot.Value) > tolerance * 2)
-                            {
-                                yield return r;
-                                lastRoot = fx;
-                            }
+                            yield return r;
                         }
                     }
                     else if (lastDelta < 0 && fx - lastFx >= 0)
@@ -78,11 +69,7 @@ namespace Elements
                         {
                             foreach (var r in SolveIterative(t - step * 2, t, steps, evaluate, tolerance))
                             {
-                                if (!lastRoot.HasValue || Math.Abs(fx - lastRoot.Value) > tolerance * 2)
-                                {
-                                    yield return r;
-                                    lastRoot = fx;
-                                }
+                                yield return r;
                             }
                         }
                     }

--- a/Elements/src/Math/Equations.cs
+++ b/Elements/src/Math/Equations.cs
@@ -83,13 +83,5 @@ namespace Elements
                 lastFx = fx;
             }
         }
-
-        public static List<Vector3> ConvertRoots(ICurve curve,
-                                                 IEnumerable<double> roots,
-                                                 double tolerance = Vector3.EPSILON)
-        {
-            var results = roots.Select(r => curve.PointAt(r)).UniqueAverageWithinTolerance(tolerance);
-            return results.ToList();
-        }
     }
 }

--- a/Elements/src/Spatial/Grid2d.cs
+++ b/Elements/src/Spatial/Grid2d.cs
@@ -1046,7 +1046,7 @@ namespace Elements.Spatial
 
             var newLine = new Line(line.Start, line.End);
 
-            if (newLine.Intersects(possiblySkewedLine, out var intersection))
+            if (newLine.Intersects(possiblySkewedLine, out Vector3 intersection))
             {
                 // move to start and extend
                 var toStart = possiblySkewedLine.Start - intersection;

--- a/Elements/src/Spatial/Grid2d.cs
+++ b/Elements/src/Spatial/Grid2d.cs
@@ -1046,7 +1046,7 @@ namespace Elements.Spatial
 
             var newLine = new Line(line.Start, line.End);
 
-            if (newLine.Intersects(possiblySkewedLine, out Vector3 intersection))
+            if (newLine.Intersects(possiblySkewedLine, out var intersection))
             {
                 // move to start and extend
                 var toStart = possiblySkewedLine.Start - intersection;

--- a/Elements/src/Units.cs
+++ b/Elements/src/Units.cs
@@ -195,11 +195,11 @@ namespace Elements
             return string.Format("{0}{1} {2}\"", sign, inches, fraction).Trim();
         }
 
-        public static double NormalizedRadian(double parameter)
+        public static double AdjustRadian(double parameter, double reference)
         {
-            var numberOfRotation = Math.Floor(parameter / (2 * Math.PI));
-            var normalized = parameter - numberOfRotation * 2 * Math.PI;
-            return normalized;
+            double delta = parameter - reference;
+            double numberOfRotations = Math.Floor(delta / (Math.PI * 2));
+            return parameter - numberOfRotations * Math.PI * 2;
         }
 
         private static double RoundToSignificantDigits(double value, int digits)

--- a/Elements/src/Units.cs
+++ b/Elements/src/Units.cs
@@ -195,6 +195,13 @@ namespace Elements
             return string.Format("{0}{1} {2}\"", sign, inches, fraction).Trim();
         }
 
+        public static double NormalizedRadian(double parameter)
+        {
+            var numberOfRotation = Math.Floor(parameter / (2 * Math.PI));
+            var normalized = parameter - numberOfRotation * 2 * Math.PI;
+            return normalized;
+        }
+
         private static double RoundToSignificantDigits(double value, int digits)
         {
             if (value.ApproximatelyEquals(0))

--- a/Elements/src/Units.cs
+++ b/Elements/src/Units.cs
@@ -195,6 +195,12 @@ namespace Elements
             return string.Format("{0}{1} {2}\"", sign, inches, fraction).Trim();
         }
 
+        /// <summary>
+        /// Convert radian value to be bigger that reference but in the same rotation cycle, preserving its angle.
+        /// </summary>
+        /// <param name="parameter">Radian parameter with any value.</param>
+        /// <param name="reference">Reference value.</param>
+        /// <returns>Value with the same angle as parameter but in between reference and reference plus 2 PI.</returns>
         public static double AdjustRadian(double parameter, double reference)
         {
             double delta = parameter - reference;

--- a/Elements/test/ArcTests.cs
+++ b/Elements/test/ArcTests.cs
@@ -578,6 +578,21 @@ namespace Hypar.Tests
             // Arc doesn't intersect
             a0 = new Arc(t, 5, Math.PI / 4, Math.PI);
             Assert.False(a0.Intersects(a1, out intersections));
+
+            // Overlapping arcs
+            a1 = new Arc(t, 5, 0, Math.PI);
+            Assert.False(a0.Intersects(a1, out intersections));
+
+            // Touching overlapping arcs
+            a1 = new Arc(t, 5, Math.PI, Math.PI * 2);
+            Assert.True(a0.Intersects(a1, out intersections));
+            Assert.Single(intersections);
+            Assert.Contains(new Vector3(0, 0, 6), intersections);
+            a1 = new Arc(t, 5, Math.PI, Math.PI * 2 + Math.PI / 4);
+            Assert.True(a0.Intersects(a1, out intersections));
+            Assert.Equal(2, intersections.Count());
+            Assert.Contains(new Vector3(0, 0, 6), intersections);
+            Assert.Contains(new Vector3(0, 3.5355339, -2.5355339), intersections);
         }
 
         private void TestTransformAtNormalized(BoundedCurve curve)

--- a/Elements/test/ArcTests.cs
+++ b/Elements/test/ArcTests.cs
@@ -477,6 +477,109 @@ namespace Hypar.Tests
             TestTransformAtNormalized(polygon);
         }
 
+        [Fact]
+        public void IntersectsInfiniteLine()
+        {
+            var line = new InfiniteLine(Vector3.Origin, Vector3.YAxis);
+
+            // Arc intersects at two points. [0; 360] domain.
+            var arc = new Arc(Vector3.Origin, 2.0, 60, 300);
+            Assert.True(arc.Intersects(line, out var intersections));
+            Assert.Equal(2, intersections.Count());
+            Assert.Contains(new Vector3(0, 2), intersections);
+            Assert.Contains(new Vector3(0, -2), intersections);
+
+            // Arc touches at one point and intersects at other. [-360; 0] domain.
+            arc = new Arc(Vector3.Origin, 3.0, -90, -300);
+            Assert.True(arc.Intersects(line, out intersections));
+            Assert.Equal(2, intersections.Count());
+            Assert.Contains(new Vector3(0, 3), intersections);
+            Assert.Contains(new Vector3(0, -3), intersections);
+
+            // Arc intersects at one point. [360; 720] domain.
+            arc = new Arc(Vector3.Origin, 4, 500, 700);
+            Assert.True(arc.Intersects(line, out intersections));
+            Assert.Single(intersections);
+            Assert.Contains(new Vector3(0, -4), intersections);
+
+            // Arc domain doesn't intersect
+            arc = new Arc(Vector3.Origin, 5, -45, 45);
+            Assert.False(arc.Intersects(line, out intersections));
+            arc = new Arc(Vector3.Origin, 5, 100, 260);
+            Assert.False(arc.Intersects(line, out intersections));
+        }
+
+        [Fact]
+        public void IntersectsLine()
+        {
+            var arc = new Arc(Vector3.Origin, 2.0, 300, 60);
+
+            // Arc intersects at two points.
+            var line = new Line(new Vector3(0, -2), new Vector3(0, 5));
+            Assert.True(arc.Intersects(line, out var intersections));
+            Assert.Equal(2, intersections.Count());
+            Assert.Contains(new Vector3(0, 2), intersections);
+            Assert.Contains(new Vector3(0, -2), intersections);
+
+            // Arc intersects at one point.
+            line = new Line(new Vector3(0, 1), new Vector3(0, 3));
+            Assert.True(arc.Intersects(line, out intersections));
+            Assert.Single(intersections);
+            Assert.Contains(new Vector3(0, 2), intersections);
+
+            // Arc intersects at one point.
+            line = new Line(new Vector3(0, 5), new Vector3(0, 3));
+            Assert.False(arc.Intersects(line, out intersections));
+        }
+
+        [Fact]
+        public void IntersectsCircle()
+        {
+            Transform t = new Transform(new Vector3(0, 0, 1), Vector3.XAxis);
+            Circle c = new Circle(t, 5);
+
+            // Arc intersects at two points.
+            var arc = new Arc(new Vector3(1, 0, 0), 5, 90, 270);
+            Assert.True(arc.Intersects(c, out var intersections));
+            Assert.Equal(2, intersections.Count());
+            Assert.Contains(new Vector3(0, 4.8989795), intersections);
+            Assert.Contains(new Vector3(0, -4.8989795), intersections);
+
+            // Arc intersects at one point.
+            arc = new Arc(new Vector3(1, 0, 0), 5, 0, 180);
+            Assert.True(arc.Intersects(c, out intersections));
+            Assert.Single(intersections);
+            Assert.Contains(new Vector3(0, 4.8989795), intersections);
+
+            // Arc doesn't intersect
+            arc = new Arc(new Vector3(1, 0, 0), 5, -180, 180);
+            Assert.False(arc.Intersects(c, out intersections));
+        }
+
+        [Fact]
+        public void IntersectsArc()
+        {
+            Transform t = new Transform(new Vector3(0, 0, 1), Vector3.ZAxis.Negate(), Vector3.XAxis);
+            Arc a0 = new Arc(t, 5, Math.PI / 4, Math.PI * 2 - Math.PI / 4);
+
+            // Arc intersects at two points..
+            var a1 = new Arc(new Vector3(1, 0, 0), 5, 90, 270);
+            Assert.True(a0.Intersects(a1, out var intersections));
+            Assert.Equal(2, intersections.Count());
+            Assert.Contains(new Vector3(0, 4.8989795), intersections);
+            Assert.Contains(new Vector3(0, -4.8989795), intersections);
+
+            // Arc intersects at one point.
+            a1 = new Arc(new Vector3(1, 0, 0), 5, 120, 270);
+            Assert.True(a0.Intersects(a1, out intersections));
+            Assert.Single(intersections);
+            Assert.Contains(new Vector3(0, -4.8989795), intersections);
+
+            // Arc doesn't intersect
+            a0 = new Arc(t, 5, Math.PI / 4, Math.PI);
+            Assert.False(a0.Intersects(a1, out intersections));
+        }
+
         private void TestTransformAtNormalized(BoundedCurve curve)
         {
             Assert.Equal(curve.TransformAt(curve.Domain.Mid()), curve.TransformAtNormalized(0.5));

--- a/Elements/test/ArcTests.cs
+++ b/Elements/test/ArcTests.cs
@@ -552,7 +552,7 @@ namespace Hypar.Tests
             Assert.Contains(new Vector3(0, 4.8989795), intersections);
 
             // Arc doesn't intersect
-            arc = new Arc(new Vector3(1, 0, 0), 5, -180, 180);
+            arc = new Arc(new Vector3(1, 0, 0), 5, -80, 80);
             Assert.False(arc.Intersects(c, out intersections));
         }
 

--- a/Elements/test/BezierTests.cs
+++ b/Elements/test/BezierTests.cs
@@ -67,5 +67,112 @@ namespace Hypar.Tests
             var polylineLength = bezier.ToPolyline(divisions).Length();
             Assert.Equal(polylineLength, bezier.Length());
         }
+
+        [Fact]
+        public void IntersectsLine()
+        {
+            var a = Vector3.Origin;
+            var b = new Vector3(0, 5);
+            var c = new Vector3(5, 5);
+            var d = new Vector3(5, 0);
+            var ctrlPts = new List<Vector3> { a, b, c, d };
+            var bezier = new Bezier(ctrlPts);
+
+            var line = new Line(new Vector3(0, 2), new Vector3(5, 2));
+            Assert.True(bezier.Intersects(line, out var results));
+            Assert.Equal(2, results.Count);
+            Assert.All(results, r => Assert.True(r.DistanceTo(line) < Vector3.EPSILON));
+
+            line = new Line(new Vector3(5, 0, 5), new Vector3(5, 0, 0));
+            Assert.True(bezier.Intersects(line, out results));
+            Assert.Single(results);
+            Assert.Contains(new Vector3(5, 0), results);
+
+            line = new Line(new Vector3(5, 5), new Vector3(0, 5));
+            Assert.False(bezier.Intersects(line, out results));
+        }
+
+        [Fact]
+        public void IntersectsCircle()
+        {
+            var a = Vector3.Origin;
+            var b = new Vector3(0, 5);
+            var c = new Vector3(5, 5);
+            var d = new Vector3(5, 0);
+            var ctrlPts = new List<Vector3> { a, b, c, d };
+            var bezier = new Bezier(ctrlPts);
+
+            var arc = new Arc(new Vector3(2.5, 2.5), 2.5, 180, 270);
+            Assert.True(bezier.Intersects(arc, out var results));
+            Assert.Single(results);
+
+            Transform t = new Transform(new Vector3(2.5, 0), Vector3.YAxis);
+            arc = new Arc(new Vector3(2.5, 0), 2.5, 0, -180);
+            Assert.True(bezier.Intersects(arc, out results));
+            Assert.Equal(2, results.Count);
+            Assert.Contains(new Vector3(5, 0), results);
+            Assert.Contains(new Vector3(0, 0), results);
+        }
+
+        [Fact]
+        public void IntersectsEllipse()
+        {
+            var a = Vector3.Origin;
+            var b = new Vector3(0, 5);
+            var c = new Vector3(5, 5);
+            var d = new Vector3(5, 0);
+            var ctrlPts = new List<Vector3> { a, b, c, d };
+            var bezier = new Bezier(ctrlPts);
+
+            var arc = new EllipticalArc(new Vector3(2.5, 2), 3.5, 2, 0, 270);
+            Assert.True(bezier.Intersects(arc, out var results));
+            Assert.Equal(3, results.Count);
+
+            Transform t = new Transform(new Vector3(2.5, 0), Vector3.YAxis);
+            arc = new EllipticalArc(new Vector3(2.5, 0), 2.5, 2, 0, -180);
+            Assert.True(bezier.Intersects(arc, out results));
+            Assert.Equal(2, results.Count);
+            Assert.Contains(new Vector3(5, 0), results);
+            Assert.Contains(new Vector3(0, 0), results);
+        }
+
+        [Fact]
+        public void IntersectsPolycurve()
+        {
+            var a = Vector3.Origin;
+            var b = new Vector3(0, 5);
+            var c = new Vector3(5, 5);
+            var d = new Vector3(5, 0);
+            var ctrlPts = new List<Vector3> { a, b, c, d };
+            var bezier = new Bezier(ctrlPts);
+
+            var polygon = new Polygon(new Vector3[]{
+                (0, 3), (6, 3), (4, 1), (-2, 1)
+            }); 
+            
+            Assert.True(bezier.Intersects(polygon, out var results));
+            Assert.Equal(4, results.Count);
+            Assert.Contains(new Vector3(0.9347526, 3), results);
+            Assert.Contains(new Vector3(4.0652474, 3), results);
+            Assert.Contains(new Vector3(4.7513222, 1.751333), results);
+            Assert.Contains(new Vector3(0.0736794, 1), results);
+        }
+
+        [Fact]
+        public void IntersectsBezier()
+        {
+            var a = Vector3.Origin;
+            var b = new Vector3(0, 5);
+            var c = new Vector3(5, 5);
+            var d = new Vector3(5, 0);
+            var ctrlPts = new List<Vector3> { a, b, c, d };
+            var bezier = new Bezier(ctrlPts);
+
+            var other = new Bezier(new List<Vector3> { b, a, d, c });
+            Assert.True(bezier.Intersects(other, out var results));
+            Assert.Equal(2, results.Count);
+            Assert.Contains(new Vector3(0.5755, 2.5), results);
+            Assert.Contains(new Vector3(4.4245, 2.5), results);
+        }
     }
 }

--- a/Elements/test/BezierTests.cs
+++ b/Elements/test/BezierTests.cs
@@ -124,11 +124,10 @@ namespace Hypar.Tests
             var ctrlPts = new List<Vector3> { a, b, c, d };
             var bezier = new Bezier(ctrlPts);
 
-            var arc = new EllipticalArc(new Vector3(2.5, 2), 3.5, 2, 0, 270);
+            var arc = new EllipticalArc(new Vector3(2.5, 2), 3.5, 1, 0, 270);
             Assert.True(bezier.Intersects(arc, out var results));
             Assert.Equal(3, results.Count);
 
-            Transform t = new Transform(new Vector3(2.5, 0), Vector3.YAxis);
             arc = new EllipticalArc(new Vector3(2.5, 0), 2.5, 2, 0, -180);
             Assert.True(bezier.Intersects(arc, out results));
             Assert.Equal(2, results.Count);

--- a/Elements/test/BezierTests.cs
+++ b/Elements/test/BezierTests.cs
@@ -151,10 +151,10 @@ namespace Hypar.Tests
             
             Assert.True(bezier.Intersects(polygon, out var results));
             Assert.Equal(4, results.Count);
-            Assert.Contains(new Vector3(0.9347526, 3), results);
-            Assert.Contains(new Vector3(4.0652474, 3), results);
-            Assert.Contains(new Vector3(4.7513222, 1.751333), results);
-            Assert.Contains(new Vector3(0.0736794, 1), results);
+            Assert.Contains(new Vector3(0.93475, 3), results);
+            Assert.Contains(new Vector3(4.06525, 3), results);
+            Assert.Contains(new Vector3(4.75132, 1.75133), results);
+            Assert.Contains(new Vector3(0.07367, 1), results);
         }
 
         [Fact]

--- a/Elements/test/CircleTests.cs
+++ b/Elements/test/CircleTests.cs
@@ -1,0 +1,108 @@
+﻿using Elements;
+using Elements.Geometry;
+using Elements.Tests;
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Hypar.Tests
+{
+    public class CircleTests
+    {
+        [Fact]
+        public void CirceIntersectsCircle()
+        {
+            // Planar intersecting circles 
+            Circle c0 = new Circle(5);
+            Circle c1 = new Circle(new Vector3(8, 0, 0), 5);
+            Assert.True(c0.Intersects(c1, out var results));
+            Assert.Equal(2, results.Count());
+            Assert.Contains(new Vector3(4, 3, 0), results);
+            Assert.Contains(new Vector3(4, -3, 0), results);
+
+            // Planar touching circles
+            c1 = new Circle(new Vector3(8, 0, 0), 3);
+            Assert.True(c0.Intersects(c1, out results));
+            Assert.Single(results);
+            Assert.Contains(new Vector3(5, 0, 0), results);
+            c1 = new Circle(new Vector3(-3, 0, 0), 2);
+            Assert.True(c0.Intersects(c1, out results));
+            Assert.Single(results);
+            Assert.Contains(new Vector3(-5, 0, 0), results);
+
+            // Planar one circle inside other
+            c1 = new Circle(new Vector3(1, 0, 0), 3);
+            Assert.False(c0.Intersects(c1, out _));
+
+            // Planar non-intersecting circles
+            c1 = new Circle(new Vector3(10, 0, 0), 3);
+            Assert.False(c0.Intersects(c1, out _));
+
+            // Non-planar intersecting circles
+            var t = new Transform(new Vector3(4, 0, 4), Vector3.XAxis);
+            c1 = new Circle(t, 5);
+            Assert.True(c0.Intersects(c1, out results));
+            Assert.Equal(2, results.Count());
+            Assert.Contains(new Vector3(4, 3, 0), results);
+            Assert.Contains(new Vector3(4, -3, 0), results);
+
+            // Non-planar touching circles
+            t = new Transform(new Vector3(0, 7, 2), new Vector3(0, 1, -1).Unitized());
+            c1 = new Circle(t, Math.Sqrt(2) * 2);
+            Assert.True(c0.Intersects(c1, out results));
+            Assert.Single(results);
+            Assert.Contains(new Vector3(0, 5, 0), results);
+
+            // Non-planar non-intersecting circles
+            t = new Transform(new Vector3(0, 7, 2), new Vector3(0, -1, -1).Unitized());
+            c1 = new Circle(t, 1);
+            Assert.False(c0.Intersects(c1, out _));
+
+            // Same normal different origins
+            c1 = new Circle(new Vector3(0, 0, 10), 5);
+            Assert.False(c0.Intersects(c1, out _));
+
+            // Same circle
+            c1 = new Circle(5);
+            Assert.False(c0.Intersects(c1, out _));
+        }
+
+        [Fact]
+        public void CircleIntersectsLine()
+        {
+            var circleDir = new Vector3(1, 0, 1);
+            var t = new Transform(new Vector3(1, 1, 1), circleDir);
+            var circle = new Circle(t, 2);
+
+            // Planar intersecting
+            var line = new InfiniteLine(new Vector3(2, 0, 0), Vector3.YAxis);
+            Assert.True(circle.Intersects(line, out var results));
+            Assert.Equal(2, results.Count());
+            Assert.Contains(new Vector3(2, 1 + Math.Sqrt(2), 0), results);
+            Assert.Contains(new Vector3(2, 1 - Math.Sqrt(2), 0), results);
+
+            // Planar touching
+            var dir = circleDir.Cross(Vector3.YAxis);
+            line = new InfiniteLine(new Vector3(2, -1, 0), dir);
+            Assert.True(circle.Intersects(line, out results));
+            Assert.Single(results);
+            Assert.Contains(new Vector3(1, -1, 1), results);
+
+            // Planar non-intersecting
+            line = new InfiniteLine(new Vector3(3, 0, 0), dir);
+            Assert.False(circle.Intersects(line, out _));
+
+            // Non-planar touching
+            line = new InfiniteLine(new Vector3(1 + Math.Sqrt(2), 1, 3), Vector3.ZAxis);
+            Assert.True(circle.Intersects(line, out results));
+            Assert.Single(results);
+            Assert.Contains(new Vector3(1 + Math.Sqrt(2), 1, 1 - Math.Sqrt(2)), results);
+
+            // Non-planar non-intersecting
+            line = new InfiniteLine(new Vector3(1, 1, 1), Vector3.ZAxis);
+            Assert.False(circle.Intersects(line, out _));
+        }
+    }
+}

--- a/Elements/test/CircleTests.cs
+++ b/Elements/test/CircleTests.cs
@@ -27,6 +27,13 @@ namespace Hypar.Tests
             Assert.Contains(new Vector3(1.5, 4.769696, 0), results);
             Assert.Contains(new Vector3(1.5, -4.769696, 0), results);
 
+            // Planar intersecting circles with opposite normals
+            c1 = new Circle(new Transform(new Vector3(8, 0, 0), Vector3.ZAxis.Negate()), 5);
+            Assert.True(c0.Intersects(c1, out results));
+            Assert.Equal(2, results.Count());
+            Assert.Contains(new Vector3(4, 3, 0), results);
+            Assert.Contains(new Vector3(4, -3, 0), results);
+
             // Planar touching circles
             c1 = new Circle(new Vector3(8, 0, 0), 3);
             Assert.True(c0.Intersects(c1, out results));

--- a/Elements/test/CircleTests.cs
+++ b/Elements/test/CircleTests.cs
@@ -109,5 +109,24 @@ namespace Hypar.Tests
             line = new InfiniteLine(new Vector3(1, 1, 1), Vector3.ZAxis);
             Assert.False(circle.Intersects(line, out _));
         }
+
+        [Fact]
+        public void AdjustRadian()
+        {
+            double reference = Units.DegreesToRadians(45);
+            Assert.Equal(Units.DegreesToRadians(385), Units.AdjustRadian(Units.DegreesToRadians(25), reference), 6);
+            Assert.Equal(Units.DegreesToRadians(60), Units.AdjustRadian(Units.DegreesToRadians(420), reference), 6);
+            Assert.Equal(Units.DegreesToRadians(260), Units.AdjustRadian(Units.DegreesToRadians(-100), reference), 6);
+
+            reference = Units.DegreesToRadians(400);
+            Assert.Equal(Units.DegreesToRadians(745), Units.AdjustRadian(Units.DegreesToRadians(25), reference), 6);
+            Assert.Equal(Units.DegreesToRadians(400), Units.AdjustRadian(Units.DegreesToRadians(400), reference), 6);
+            Assert.Equal(Units.DegreesToRadians(620), Units.AdjustRadian(Units.DegreesToRadians(-100), reference), 6);
+
+            reference = Units.DegreesToRadians(-160);
+            Assert.Equal(Units.DegreesToRadians(25), Units.AdjustRadian(Units.DegreesToRadians(25), reference), 6);
+            Assert.Equal(Units.DegreesToRadians(60), Units.AdjustRadian(Units.DegreesToRadians(420), reference), 6);
+            Assert.Equal(Units.DegreesToRadians(-100), Units.AdjustRadian(Units.DegreesToRadians(-100), reference), 6);
+        }
     }
 }

--- a/Elements/test/CircleTests.cs
+++ b/Elements/test/CircleTests.cs
@@ -21,6 +21,11 @@ namespace Hypar.Tests
             Assert.Equal(2, results.Count());
             Assert.Contains(new Vector3(4, 3, 0), results);
             Assert.Contains(new Vector3(4, -3, 0), results);
+            c1 = new Circle(new Vector3(3, 0, 0), 5);
+            Assert.True(c0.Intersects(c1, out results));
+            Assert.Equal(2, results.Count());
+            Assert.Contains(new Vector3(1.5, 4.769696, 0), results);
+            Assert.Contains(new Vector3(1.5, -4.769696, 0), results);
 
             // Planar touching circles
             c1 = new Circle(new Vector3(8, 0, 0), 3);

--- a/Elements/test/CurveTests.cs
+++ b/Elements/test/CurveTests.cs
@@ -58,12 +58,12 @@ namespace Elements
                 (3, 3)
             });
 
-            //left.Intersects(right, out _);
-            //right.Intersects(left, out _);
+            left.Intersects(right, out _);
+            right.Intersects(left, out _);
 
-            //right = new Line((0, 0), (10, 10));
-            //left.Intersects(right, out _);
-            //right.Intersects(left, out _);
+            right = new Line((0, 0), (10, 10));
+            left.Intersects(right, out _);
+            right.Intersects(left, out _);
         }
 
         [Fact]

--- a/Elements/test/CurveTests.cs
+++ b/Elements/test/CurveTests.cs
@@ -1,0 +1,93 @@
+﻿using Elements.Geometry;
+using Elements.Geometry.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Elements
+{
+    public class CurveTests
+    {
+        [Fact]
+        public void CurveIntersectsNotThrows()
+        {
+            ICurve left = new InfiniteLine(Vector3.Origin, Vector3.XAxis);
+            ICurve right = new Circle(Vector3.Origin, 4);
+            left.Intersects(right, out _);
+            right.Intersects(left, out _);
+            right = new Ellipse(Vector3.Origin, 4, 5);
+            left.Intersects(right, out _);
+            right.Intersects(left, out _);
+            left = new InfiniteLine(Vector3.Origin, Vector3.YAxis);
+            left.Intersects(right, out _);
+
+            right = new Arc(Vector3.Origin, 3, 45, 90);
+            left.Intersects(right, out _);
+            right.Intersects(left, out _);
+            left = new Line(new Vector3(0, 4, 0), new Vector3(2, 2, 0));
+            left.Intersects(right, out _);
+            right.Intersects(left, out _);
+
+            right = new Polygon(new Vector3[]
+            {
+                (2, 2), (4, 2), (4, 4), (2, 4)
+            });
+            left.Intersects(right, out _);
+            right.Intersects(left, out _);
+
+            left = new Circle(Vector3.Origin, 4);
+            left.Intersects(right, out _);
+            right.Intersects(left, out _);
+
+            left = new IndexedPolycurve(new List<BoundedCurve>
+            {
+                new Line((0, 0), (0, 5)),
+                new Arc((0, 10), 5, 180, 0),
+                new Line((0, 10), (0, 15))
+            });
+            left.Intersects(right, out _);
+            right.Intersects(left, out _);
+
+            left = new Bezier(new List<Vector3>()
+            {
+                (0, 0),
+                (1, 2),
+                (3, 3)
+            });
+
+            //left.Intersects(right, out _);
+            //right.Intersects(left, out _);
+
+            //right = new Line((0, 0), (10, 10));
+            //left.Intersects(right, out _);
+            //right.Intersects(left, out _);
+        }
+
+        [Fact]
+        public void DynamicsCalls()
+        {
+            Random r = new Random();
+            ICurve left = new Line(Vector3.Origin, Vector3.XAxis);
+            for (int i = 0; i < 500_000; i++)
+            {
+                ICurve right = new Arc(Vector3.Origin, r.NextDouble(), -45, 90);
+                left.Intersects(right, out _);
+            }
+        }
+
+        [Fact]
+        public void DirectCalls()
+        {
+            Random r = new Random();
+            Line left = new Line(Vector3.Origin, Vector3.XAxis);
+            for (int i = 0; i < 500_000; i++)
+            {
+                Arc right = new Arc(Vector3.Origin, r.NextDouble(), -45, 90);
+                left.Intersects(right, out _);
+            }
+        }
+    }
+}

--- a/Elements/test/EllipseTests.cs
+++ b/Elements/test/EllipseTests.cs
@@ -135,7 +135,7 @@ namespace Hypar.Tests
 
             // Planar no intersection
             ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
-            other = new Ellipse(new Vector3(0, 1, 0), 1.5, 0.5);
+            other = new Ellipse(new Vector3(0, 1, 0), 0.5, 1.5);
             Assert.False(ellipse.Intersects(other, out results));
 
             // Overlapping 

--- a/Elements/test/EllipseTests.cs
+++ b/Elements/test/EllipseTests.cs
@@ -1,0 +1,168 @@
+﻿using Elements.Geometry;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Hypar.Tests
+{
+    public class EllipseTests
+    {
+        [Fact]
+        public void EllipseIntersectsLine()
+        {
+            var origin = new Vector3(0, 0, 2);
+            Transform t = new Transform(new Vector3(0, 0, 2), new Vector3(-1, 0, 1));
+            var ellipse = new Ellipse(t, 4, 2);
+            var majorOffset =  ellipse.Transform.XAxis * ellipse.MajorAxis;
+            var minorOffset = ellipse.Transform.YAxis * ellipse.MinorAxis;
+
+            // Planar intersecting
+            var line = new InfiniteLine(origin, ellipse.Transform.XAxis);
+            Assert.True(ellipse.Intersects(line, out var results));
+            Assert.Equal(2, results.Count());
+            Assert.Contains(origin + majorOffset, results);
+            Assert.Contains(origin - majorOffset, results);
+
+            // Planar touching
+            var p = origin + majorOffset + minorOffset;
+            line = new InfiniteLine(p, ellipse.Transform.XAxis);
+            Assert.True(ellipse.Intersects(line, out results));
+            Assert.Single(results);
+            Assert.Contains(origin + minorOffset, results);
+
+            // Planar non-intersecting
+            p = origin + minorOffset * 2;
+            line = new InfiniteLine(p, ellipse.Transform.XAxis);
+            Assert.False(ellipse.Intersects(line, out _));
+
+            // Non-planar touching
+            p = ellipse.PointAt(Math.PI - Math.PI / 4);
+            line = new InfiniteLine(new Vector3(p.X, p.Y, 0), Vector3.ZAxis);
+            Assert.True(ellipse.Intersects(line, out results));
+            Assert.Single(results);
+            Assert.Contains(p, results);
+
+            // Non-planar non-intersecting
+            line = new InfiniteLine(origin, Vector3.ZAxis);
+            Assert.False(ellipse.Intersects(line, out _));
+        }
+
+        [Fact]
+        public void EllipseIntersectsCircle()
+        {
+            // Planar intersection 4 intersections.
+            Ellipse ellipse = new Ellipse(new Vector3(1, 1), 2, 4);
+            Circle circle = new Circle(new Vector3(1, 1, 0), 3);
+            Assert.True(ellipse.Intersects(circle, out var results));
+            Assert.Equal(4, results.Count());
+
+            // Planar intersection 3 intersections.
+            ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
+            circle = new Circle(new Vector3(-2, 1, 0), 5);
+            Assert.True(ellipse.Intersects(circle, out results));
+            Assert.Equal(3, results.Count());
+
+            // Planar intersection 2 intersections.
+            ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
+            circle = new Circle(new Vector3(-2, 1, 0), 3);
+            Assert.True(ellipse.Intersects(circle, out results));
+            Assert.Equal(2, results.Count());
+
+            // TO DO: make it work
+            // Planar intersection 1 intersection.
+            //ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
+            //circle = new Circle(new Vector3(0, 1, 0), 1);
+            //Assert.True(ellipse.Intersects(circle, out results));
+            //Assert.Single(results);
+
+            // Planar no intersection
+            ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
+            circle = new Circle(new Vector3(0, 1, 0), 0.5);
+            Assert.False(ellipse.Intersects(circle, out results));
+
+            // Overlapping 
+            ellipse = new Ellipse(new Vector3(1, 1), 2, 2);
+            circle = new Circle(new Vector3(1, 1), 2);
+            Assert.False(ellipse.Intersects(circle, out results));
+
+            // Non-planar intersection 2 intersections.
+            Transform t = new Transform(new Vector3(2, 0, 2), Vector3.ZAxis, Vector3.XAxis);
+            ellipse = new Ellipse(t, 4, 2);
+            circle = new Circle(new Vector3(2, 0, 2), 2);
+            Assert.True(ellipse.Intersects(circle, out results));
+            Assert.Equal(2, results.Count());
+
+            // Non-planar intersection 1 intersection.
+            ellipse = new Ellipse(t, 2, 4);
+            circle = new Circle(new Vector3(0, 0, 0), 2);
+            Assert.True(ellipse.Intersects(circle, out results));
+            Assert.Single(results);
+
+            // Non-planar no intersection
+            ellipse = new Ellipse(t, 4, 2);
+            circle = new Circle(new Vector3(0, 0, 0), 2);
+            Assert.False(ellipse.Intersects(circle, out results));
+        }
+
+        [Fact]
+        public void EllipseIntersectsEllipse()
+        {
+            // Planar intersection 4 intersections.
+            Ellipse ellipse = new Ellipse(new Vector3(1, 1), 2, 4);
+            Ellipse other = new Ellipse(new Vector3(1, 1), 4, 2);
+            Assert.True(ellipse.Intersects(other, out var results));
+            Assert.Equal(4, results.Count());
+
+            // Planar intersection 3 intersections.
+            ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
+            other = new Ellipse(new Vector3(-2, 1, 0), 5, 2);
+            Assert.True(ellipse.Intersects(other, out results));
+            Assert.Equal(3, results.Count());
+
+            // Planar intersection 2 intersections.
+            ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
+            other = new Ellipse(new Vector3(-2, 1, 0), 4, 3);
+            Assert.True(ellipse.Intersects(other, out results));
+            Assert.Equal(2, results.Count());
+
+            // TO DO: make it work
+            // Planar intersection 1 intersection.
+            //ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
+            //circle = new Circle(new Vector3(0, 1, 0), 1);
+            //Assert.True(ellipse.Intersects(circle, out results));
+            //Assert.Single(results);
+
+            // Planar no intersection
+            ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
+            other = new Ellipse(new Vector3(0, 1, 0), 1.5, 0.5);
+            Assert.False(ellipse.Intersects(other, out results));
+
+            // Overlapping 
+            ellipse = new Ellipse(new Vector3(1, 1), 2, 4);
+            Transform t = new Transform(new Vector3(1, 1), Vector3.YAxis, Vector3.ZAxis);
+            other = new Ellipse(t, 4, 2);
+            Assert.False(ellipse.Intersects(other, out results));
+
+            // Non-planar intersection 2 intersections.
+            t = new Transform(new Vector3(2, 0, 2), Vector3.ZAxis, Vector3.XAxis);
+            ellipse = new Ellipse(t, 4, 2);
+            other = new Ellipse(new Vector3(2, 0, 2), 3, 2);
+            Assert.True(ellipse.Intersects(other, out results));
+            Assert.Equal(2, results.Count());
+
+            // Non-planar intersection 1 intersection.
+            ellipse = new Ellipse(t, 2, 4);
+            other = new Ellipse(new Vector3(0, 0, 0), 2, 3);
+            Assert.True(ellipse.Intersects(other, out results));
+            Assert.Single(results);
+
+            // Non-planar no intersection
+            ellipse = new Ellipse(t, 4, 2);
+            other = new Ellipse(new Vector3(0, 0, 0), 3, 2);
+            Assert.False(ellipse.Intersects(other, out results));
+        }
+    }
+}

--- a/Elements/test/EllipseTests.cs
+++ b/Elements/test/EllipseTests.cs
@@ -78,6 +78,20 @@ namespace Hypar.Tests
             Assert.True(ellipse.Intersects(circle, out results));
             Assert.Single(results);
 
+            // Planar intersection 1 intersection high slope.
+            ellipse = new Ellipse(new Vector3(0, 0), 2, 1000);
+            circle = new Circle(new Vector3(0, 1001), 1);
+            Assert.True(ellipse.Intersects(circle, out results));
+            Assert.Single(results);
+            circle = new Circle(new Vector3(3, 0), 1);
+            Assert.True(ellipse.Intersects(circle, out results));
+            Assert.Single(results);
+
+            // Planar no intersection close.
+            ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
+            circle = new Circle(new Vector3(0, 1, 0), 0.999);
+            Assert.False(ellipse.Intersects(circle, out results));
+
             // Planar no intersection
             ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
             circle = new Circle(new Vector3(0, 1, 0), 0.5);

--- a/Elements/test/EllipseTests.cs
+++ b/Elements/test/EllipseTests.cs
@@ -60,9 +60,9 @@ namespace Hypar.Tests
             Assert.True(ellipse.Intersects(circle, out var results));
             Assert.Equal(4, results.Count());
 
-            // Planar intersection 3 intersections.
+            // Planar intersection 3 intersections and negative normals.
             ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
-            circle = new Circle(new Vector3(-2, 1, 0), 5);
+            circle = new Circle(new Transform(new Vector3(-2, 1, 0), Vector3.ZAxis.Negate()), 5);
             Assert.True(ellipse.Intersects(circle, out results));
             Assert.Equal(3, results.Count());
 
@@ -130,9 +130,9 @@ namespace Hypar.Tests
             Assert.True(ellipse.Intersects(other, out var results));
             Assert.Equal(4, results.Count());
 
-            // Planar intersection 3 intersections.
+            // Planar intersection 3 intersections and negative normals.
             ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
-            other = new Ellipse(new Vector3(-2, 1, 0), 5, 2);
+            other = new Ellipse(new Transform(new Vector3(-2, 1, 0), Vector3.ZAxis.Negate()), 5, 2);
             Assert.True(ellipse.Intersects(other, out results));
             Assert.Equal(3, results.Count());
 

--- a/Elements/test/EllipseTests.cs
+++ b/Elements/test/EllipseTests.cs
@@ -71,12 +71,11 @@ namespace Hypar.Tests
             Assert.True(ellipse.Intersects(circle, out results));
             Assert.Equal(2, results.Count());
 
-            // TO DO: make it work
             // Planar intersection 1 intersection.
-            //ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
-            //circle = new Circle(new Vector3(0, 1, 0), 1);
-            //Assert.True(ellipse.Intersects(circle, out results));
-            //Assert.Single(results);
+            ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
+            circle = new Circle(new Vector3(0, 1, 0), 1);
+            Assert.True(ellipse.Intersects(circle, out results));
+            Assert.Single(results);
 
             // Planar no intersection
             ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
@@ -128,12 +127,11 @@ namespace Hypar.Tests
             Assert.True(ellipse.Intersects(other, out results));
             Assert.Equal(2, results.Count());
 
-            // TO DO: make it work
             // Planar intersection 1 intersection.
-            //ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
-            //circle = new Circle(new Vector3(0, 1, 0), 1);
-            //Assert.True(ellipse.Intersects(circle, out results));
-            //Assert.Single(results);
+            ellipse = new Ellipse(new Vector3(1, 1), 2, 6);
+            other = new Ellipse(new Vector3(1, 8), 2, 1);
+            Assert.True(ellipse.Intersects(other, out results));
+            Assert.Single(results);
 
             // Planar no intersection
             ellipse = new Ellipse(new Vector3(1, 1), 2, 6);

--- a/Elements/test/EllipseTests.cs
+++ b/Elements/test/EllipseTests.cs
@@ -20,14 +20,15 @@ namespace Hypar.Tests
             var minorOffset = ellipse.Transform.YAxis * ellipse.MinorAxis;
 
             // Planar intersecting
-            var line = new InfiniteLine(origin, ellipse.Transform.XAxis);
+            var p = origin + majorOffset / 2;
+            var line = new InfiniteLine(p, ellipse.Transform.XAxis);
             Assert.True(ellipse.Intersects(line, out var results));
             Assert.Equal(2, results.Count());
             Assert.Contains(origin + majorOffset, results);
             Assert.Contains(origin - majorOffset, results);
 
             // Planar touching
-            var p = origin + majorOffset + minorOffset;
+            p = origin + majorOffset + minorOffset + majorOffset / 3;
             line = new InfiniteLine(p, ellipse.Transform.XAxis);
             Assert.True(ellipse.Intersects(line, out results));
             Assert.Single(results);

--- a/Elements/test/EllipseTests.cs
+++ b/Elements/test/EllipseTests.cs
@@ -177,5 +177,15 @@ namespace Hypar.Tests
             other = new Ellipse(new Vector3(0, 0, 0), 3, 2);
             Assert.False(ellipse.Intersects(other, out results));
         }
+
+        [Fact]
+        public void Circumference()
+        {
+            var ellipse = new Ellipse(2, 2);
+            Assert.Equal(4 * Math.PI, ellipse.Circumference());
+
+            ellipse = new Ellipse(3, 4);
+            Assert.Equal(22.1035, ellipse.Circumference(), 4);
+        }
     }
 }

--- a/Elements/test/IndexedPolyCurveTests.cs
+++ b/Elements/test/IndexedPolyCurveTests.cs
@@ -167,5 +167,24 @@ namespace Elements.Tests
             Assert.Equal(pc.Vertices, pc2.Vertices);
             Assert.Equal(pc._bounds, pc2._bounds);
         }
+
+        [Fact]
+        public void Intersects()
+        {
+            var pc = CreateTestPolycurve();
+            var polygon = new Polygon(new Vector3[]
+            {
+                (0, 5),
+                (4, 9),
+                (8, 5),
+                (4, 1)
+            });
+
+            Assert.True(pc.Intersects(polygon, out var results));
+            Assert.Equal(3, results.Count);
+            Assert.Contains(new Vector3(0, 5), results);
+            Assert.Contains(new Vector3(5, 2), results);
+            Assert.Contains(new Vector3(2.5, 7.5), results);
+        }
     }
 }

--- a/Elements/test/InfiniteLineTests.cs
+++ b/Elements/test/InfiniteLineTests.cs
@@ -1,0 +1,36 @@
+﻿using Elements;
+using Elements.Geometry;
+using Elements.Tests;
+using System;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Hypar.Tests
+{
+    public class InfiniteLineTests
+    {
+        [Fact]
+        public void LineIntersectsLine()
+        {
+            // Parallel lines
+            var l1 = new InfiniteLine(new Vector3(0, 0), Vector3.XAxis);
+            var l2 = new InfiniteLine(new Vector3(0, 0, 5), Vector3.XAxis);
+            Assert.False(l1.Intersects(l2, out _));
+
+            // Not coplanar
+            l2 = new InfiniteLine(new Vector3(0, 5), Vector3.ZAxis);
+            Assert.False(l1.Intersects(l2, out _));
+
+            // Same line
+            l2 = new InfiniteLine(new Vector3(10, 0), Vector3.XAxis);
+            Assert.False(l1.Intersects(l2, out _));
+
+            // Intersecting lines
+            l2 = new InfiniteLine(new Vector3(10, 5, 5), new Vector3(-1, -1, -1));
+            Assert.True(l1.Intersects(l2, out var intersections));
+            Assert.Single(intersections);
+            Assert.True(intersections.First().Equals(new Vector3(5, 0)));
+        }
+    }
+}

--- a/Elements/test/InfiniteLineTests.cs
+++ b/Elements/test/InfiniteLineTests.cs
@@ -32,5 +32,17 @@ namespace Hypar.Tests
             Assert.Single(intersections);
             Assert.True(intersections.First().Equals(new Vector3(5, 0)));
         }
+
+        [Fact]
+        public void LineIntersectsPlane()
+        {
+            var l = new InfiniteLine(new Vector3(5, 0, 5), new Vector3(1, 1, 1));
+            var p = new Plane(Vector3.Origin, Vector3.ZAxis);
+            Assert.True(l.Intersects(p, out var intersection));
+            Assert.Equal(new Vector3(0, -5, 0), intersection);
+
+            l = new InfiniteLine(Vector3.Origin, Vector3.XAxis);
+            Assert.False(l.Intersects(p, out _));
+        }
     }
 }

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -199,7 +199,7 @@ namespace Elements.Geometry.Tests
             var l1 = new Line(new Vector3(0, 5), new Vector3(10, 5));
 
             // Intersecting lines.
-            Assert.True(l0.Intersects(l1, out var intersections));
+            Assert.True(l0.Intersects(l1, out List<Vector3> intersections));
             Assert.Single(intersections);
             Assert.Equal(new Vector3(5, 5), intersections.First());
 

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -221,7 +221,18 @@ namespace Elements.Geometry.Tests
 
             // Two lines are too short to intersect.
             l1 = new Line(new Vector3(0, 5), new Vector3(4, 5));
-            Assert.False(l0.Intersects(l1, out intersections));
+            Assert.False(l0.Intersects(l1, out _));
+
+            // Overlapping coincident lines
+            l0 = new Line(new Vector3(0, 0), new Vector3(10, 0));
+            l1 = new Line(new Vector3(10, 0), new Vector3(0, 0));
+            Assert.False(l0.Intersects(l1, out _));
+
+            // Touching coincident lines
+            l1 = new Line(new Vector3(0, 0), new Vector3(-5, 0));
+            Assert.True(l0.Intersects(l1, out intersections));
+            Assert.Single(intersections);
+            Assert.Equal(new Vector3(0, 0), intersections.First());
         }
 
         [Fact]

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -136,6 +136,94 @@ namespace Elements.Geometry.Tests
             Assert.False(l1.Intersects2D(l4));    // Coincident.
         }
 
+
+        [Fact]
+        public void IntersectsCircle()
+        {
+            Circle c = new Circle(new Vector3(5, 5, 5), 5);
+            
+            // Intersects circle at one point and touches at other.
+            Line l = new Line(new Vector3(0, 5, 5), new Vector3(15, 5, 5));
+            Assert.True(l.Intersects(c, out var results));
+            Assert.Equal(2, results.Count());
+            Assert.Contains(new Vector3(0, 5, 5), results);
+            Assert.Contains(new Vector3(10, 5, 5), results);
+
+            // Intersects circle at one point.
+            l = new Line(new Vector3(3, 5, 5), new Vector3(15, 5, 5));
+            Assert.True(l.Intersects(c, out results));
+            Assert.Single(results);
+            Assert.Contains(new Vector3(10, 5, 5), results);
+
+            // Line inside the circle.
+            l = new Line(new Vector3(3, 5, 5), new Vector3(8, 5, 5));
+            Assert.False(l.Intersects(c, out results));
+
+            // Lin is not on circle plane and just touches the circle.
+            l = new Line(new Vector3(0, 5, 0), new Vector3(0, 5, 10));
+            Assert.True(l.Intersects(c, out results));
+            Assert.Single(results);
+            Assert.Contains(new Vector3(0, 5, 5), results);
+
+            // Line is not on circle plane and does not intersect the circle.
+            l = new Line(new Vector3(0, 5, 6), new Vector3(0, 5, 10));
+            Assert.False(l.Intersects(c, out results));
+        }
+
+        [Fact]
+        public void IntersectsInfiniteLine()
+        {
+            var inf = new InfiniteLine(new Vector3(0, 0), Vector3.XAxis);
+
+            // Line intersects infinite line.
+            var line = new Line(new Vector3(0, 10), new Vector3(0, -10));
+            Assert.True(line.Intersects(inf, out var intersections));
+            Assert.Single(intersections);
+            Assert.Equal(new Vector3(0, 0), intersections.First());
+
+            // Line touches infinite line.
+            line = new Line(new Vector3(5, 5, 5), new Vector3(5, 0, 0));
+            Assert.True(line.Intersects(inf, out intersections));
+            Assert.Single(intersections);
+            Assert.Equal(new Vector3(5, 0, 0), intersections.First());
+
+            // Line too short to intersect infinite line.
+            line = new Line(new Vector3(4, 3, 0), new Vector3(1, 1, 0));
+            Assert.False(line.Intersects(inf, out intersections));
+        }
+
+        [Fact]
+        public void IntersectsLine()
+        {
+            var l0 = new Line(new Vector3(5, 0), new Vector3(5, 10));
+            var l1 = new Line(new Vector3(0, 5), new Vector3(10, 5));
+
+            // Intersecting lines.
+            Assert.True(l0.Intersects(l1, out var intersections));
+            Assert.Single(intersections);
+            Assert.Equal(new Vector3(5, 5), intersections.First());
+
+            // One line touches other in the middle.
+            l0 = new Line(new Vector3(5, 0), new Vector3(5, 5));
+            Assert.True(l0.Intersects(l1, out intersections));
+            Assert.Single(intersections);
+            Assert.Equal(new Vector3(5, 5), intersections.First());
+
+            // One line can't reach other.
+            l0 = new Line(new Vector3(5, 0), new Vector3(5, 4));
+            Assert.False(l0.Intersects(l1, out intersections));
+
+            // Two lines meet at a end point.
+            l1 = new Line(new Vector3(0, 5), new Vector3(5, 4));
+            Assert.True(l0.Intersects(l1, out intersections));
+            Assert.Single(intersections);
+            Assert.Equal(new Vector3(5, 4), intersections.First());
+
+            // Two lines are too short to intersect.
+            l1 = new Line(new Vector3(0, 5), new Vector3(4, 5));
+            Assert.False(l0.Intersects(l1, out intersections));
+        }
+
         [Fact]
         public void DivideIntoEqualSegments()
         {

--- a/Elements/test/PlaneTests.cs
+++ b/Elements/test/PlaneTests.cs
@@ -38,5 +38,25 @@ namespace Elements.Tests
             var intersects = a.Intersects(b, c, out Vector3 result);
             Assert.False(intersects);
         }
+
+        [Fact]
+        public void TwoPlanesIntersect()
+        {
+            var a = new Plane(new Vector3(2, 2, 2), Vector3.XAxis);
+            var b = new Plane(new Vector3(0, 0, 0), Vector3.ZAxis);
+            var intersects = a.Intersects(b, out InfiniteLine result);
+            Assert.True(intersects);
+            Assert.True(result.Direction.IsParallelTo(Vector3.YAxis));
+            Assert.True(result.ParameterAt(new Vector3(2, 0, 0), out _));
+        }
+
+        [Fact]
+        public void TwoPlanesDoNotIntersect()
+        {
+            var a = new Plane(new Vector3(2, 2, 2), Vector3.XAxis);
+            var b = new Plane(new Vector3(0, 0, 0), Vector3.XAxis);
+            var intersects = a.Intersects(b, out InfiniteLine result);
+            Assert.False(intersects);
+        }
     }
 }

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -572,6 +572,30 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void UniqueAverageWithinTolerance()
+        {
+            var tolerance = 0.2;
+
+            var vectorsList = new List<Vector3>
+            {
+                new Vector3(0.05, 0, 0),
+                Vector3.Origin,
+                new Vector3(0, -0.05, 0),
+                new Vector3(-0.05, 0.05, 0),
+                new Vector3(5, 5, 0.05),
+                new Vector3(5, 5),
+                new Vector3(5, 5, -0.05),
+                new Vector3(5, 5)
+            };
+
+            var result = vectorsList.UniqueAverageWithinTolerance(tolerance);
+
+            Assert.Collection(result,
+                x => x.IsAlmostEqualTo(Vector3.Origin),
+                x => x.IsAlmostEqualTo(new Vector3(5, 5)));
+        }
+
+        [Fact]
         public void PointsAreCoplanarWithinTolerance()
         {
             // Test with three points that are collinear.


### PR DESCRIPTION
BACKGROUND:
- Intent of this PR is to add Intersects function to ICurve, so it can be called for any pair of curves.

DESCRIPTION:
- There are next curve types that used for intersections: InfiniteLine, Circle, Ellipse and Bezier.
- Line. Arc and Elliptic arc are using intersection function of their base curve but with additional domain checks for each intersection point. Each type doesn't have specific Intersects, only PointOnDomain function implemented.
-  Every pair of ICurve is supported, but for simplicity, now every pair of specific curve type is represented. You can't call circle.Intersects(beizer) for example, only bezier.Intersects(circle). Some duplicating function are there, line ellipse.Intersects(circle) and cirlce.Intersects(ellipse) and they just call each other.
- Using interface is slightly slower than using direct functions since type switch must be done find exact Intersects function.    
- ParameterAt is added to InfiniteLine, Circle and Ellipse to be able to get parameter at certain point if it's on the curve.
- IndexedPolycurve calls Intersects on each of its subcurves.
- Ellipse to Circle, Ellipse to Ellipse can have up to 4 intersections and can't be solved by quadratic equation. Equation.SolveIterative is used for them.
- The same is true for Bezier to Line, Bezier to Circle and Bezier to Ellipse. Since Bezier is not limited to 4 control points in Elements, they can only be solved iteratively.
- Bezier to Bezier is solved by bisecting their bounding boxes. The approach is taken for the document mentioned in Bezier code file. 
- Equation. SolveIterative splits function for up to N steps and tried to find a root at each section - both when function crosses 0 or touches it, but only one per step. It's certainly possible to do further improvements for it, but it feels like overkill right now since there are many ways solving complex intersections, including using 3rd party libraries.
- There are other helper functions added: Units.AdjustRadian, Vector3Extensions.UniqueAverageWithinTolerance, Vector3.ClosestPointOn(InfiniteLine line),  Plane.Intersects(Plane other, out InfiniteLine result).

FUTURE WORK:
- Some functions feel obsolete after these changes: Line.PointOnLine, old Line.Intersects(Line), etc.

TESTING:
- Tests created for each new function.
 
REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
-  Elements.Tests.ContentTests.InstanceContentElement test is failing. I think it's because it's timer based and should be fixed again after restart. If this is the case this test must be either updated or removed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1008)
<!-- Reviewable:end -->
