### PR TITLE
Support `Color?` and `Vector3?` in elements code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `Polygon.Contains3D` passed wrong `out Containment containment` parameter in some cases.
+- Code generation supports `Vector3?` and `Color?` types.
 
 ## 2.0.0
 

--- a/Elements.CodeGeneration/src/Templates/Class.Constructor.Record.liquid
+++ b/Elements.CodeGeneration/src/Templates/Class.Constructor.Record.liquid
@@ -8,7 +8,7 @@
 
 {% assign sortedProperties = AllProperties | sort: "Name" -%}
 {% assign sortedParentProperties = parentProperties | sort: "Name" -%}
-
+{% if AllProperties[0] %}
 [JsonConstructor]
 {% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}({% for property in AllProperties -%}{% if skipComma -%}{% assign skipComma = false %}{% else %}, {% endif -%} {{ property.Type }} @{{ property.Name | safeidentifierlower | defaultforelementargument: baseClassName }}{% endfor -%})
 {% assign skipComma = true -%}
@@ -20,6 +20,7 @@
 this.{{property.PropertyName}} = @{{property.Name | safeidentifierlower}};
     {% endfor -%}
 }
+{% endif %}
 
 // Empty constructor
 {% if IsAbstract %}protected{% else %}public{% endif %} {{ClassName}}()

--- a/Elements.CodeGeneration/src/TypeGenerator.cs
+++ b/Elements.CodeGeneration/src/TypeGenerator.cs
@@ -413,8 +413,8 @@ namespace Elements.Generate
                 TypeNameGenerator = new ElementsTypeNameGenerator(),
                 PropertyNameGenerator = new ElementsPropertyNameGenerator(),
             };
-
-            var generator = new CSharpGenerator(schema, settings);
+            var typeResolver = new TypeResolver(settings);
+            var generator = new CSharpGenerator(schema, settings, typeResolver);
 
             var typeFiles = new Dictionary<string, string>();
             // We still need this call to GenerateFile() even though we don't use the file's

--- a/Elements.CodeGeneration/src/TypeResolver.cs
+++ b/Elements.CodeGeneration/src/TypeResolver.cs
@@ -1,0 +1,42 @@
+using NJsonSchema;
+using NJsonSchema.CodeGeneration;
+using NJsonSchema.CodeGeneration.CSharp;
+using System.Linq;
+
+namespace Elements.Generate
+{
+    public class TypeResolver : CSharpTypeResolver
+    {
+
+        private readonly string[] _typesToMakeNullable = new[] { "Vector3", "Color" };
+        public TypeResolver(CSharpGeneratorSettings settings) : base(settings)
+        {
+        }
+
+        public override string Resolve(JsonSchema schema, bool isNullable, string typeNameHint)
+        {
+            // NJsonSchema will treat a an object schema with empty `properties`
+            // as just an `object`, and then fail to codegen it. We need to
+            // force it to recognize even an empty input schema as valid, so it
+            // generates the Inputs class in all cases.
+            if (schema.Type == JsonObjectType.Object && schema.Properties.Count() == 0)
+            {
+                // `GetOrGenerateTypeName` has a side effect of storing the type
+                // in the Types dictionary, which is what governs which types
+                // get generated.
+                GetOrGenerateTypeName(schema, typeNameHint);
+                return typeNameHint;
+            }
+            var baseResult = base.Resolve(schema, isNullable, typeNameHint);
+            // if we encounter a built-in value type, like Vector3, which is supposed to be
+            // nullable, we should make it a nullable type.
+            // We could make this more future-proof by determining at runtime whether a type should
+            // get this treatment, instead of relying on a hard-coded list.
+            if (_typesToMakeNullable.Contains(baseResult) && isNullable)
+            {
+                return $"{baseResult}?";
+            }
+            return baseResult;
+        }
+    }
+}

--- a/Elements.CodeGeneration/test/TestData/NullableAndNonNullableTypesSchema.json
+++ b/Elements.CodeGeneration/test/TestData/NullableAndNonNullableTypesSchema.json
@@ -1,0 +1,66 @@
+{
+    "x-namespace": "Elements",
+    "required": [],
+    "type": "object",
+    "title": "NullableAndNonNullableTypes",
+    "properties": {
+        "NonNullableVector": {
+            "$ref": "https://schemas.hypar.io/Vector3.json"
+        },
+        "NullableVector": {
+            "x-namespace": "Elements.Geometry",
+            "required": [],
+            "properties": {
+                "X": {
+                    "description": "The X component of the vector.",
+                    "type": "number"
+                },
+                "Y": {
+                    "description": "The Y component of the vector.",
+                    "type": "number"
+                },
+                "Z": {
+                    "description": "The Z component of the vector.",
+                    "type": "number"
+                }
+            },
+            "additionalProperties": false,
+            "description": "A 3D vector.",
+            "$id": "Vector3",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "discriminator": "discriminator",
+            "type": [
+                "object",
+                "null"
+            ],
+            "title": "Vector3"
+        },
+        "NonNullableColor": {
+            "x-namespace": "Elements.Geometry",
+            "required": [],
+            "type": "object",
+            "properties": {
+                "Red": {
+                    "type": "number"
+                },
+                "Green": {
+                    "type": "number"
+                },
+                "Blue": {
+                    "type": "number"
+                },
+                "Alpha": {
+                    "type": "number"
+                }
+            },
+            "additionalProperties": false,
+            "$id": "Color",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "discriminator": "discriminator",
+            "title": "Color"
+        },
+        "NullableColor": {
+            "$ref": "https://schemas.hypar.io/Color.json"
+        }
+    }
+}

--- a/Elements.CodeGeneration/test/TypeGeneratorTests.cs
+++ b/Elements.CodeGeneration/test/TypeGeneratorTests.cs
@@ -175,7 +175,21 @@ namespace Elements.Tests
             await TypeGenerator.GenerateUserElementTypesFromUrisAsync(new[] { relEmbeddedSchemaTestPath, relEmbeddedSchemaTestPath2, "https://raw.githubusercontent.com/hypar-io/Schemas/master/FacadePanel.json" }, tmpPath);
             // Ensure that there is only one beam.g.cs in the output.
             Assert.Equal(3, Directory.GetFiles(tmpPath, "*.g.cs").Length);
+        }
 
+        [Fact]
+        public async Task CodeGenerationOfNullableVectorAndColorProperties()
+        {
+            var schemaPath = "../../TestData/NullableAndNonNullableTypesSchema.json";
+
+            var tmpPath = Path.GetTempPath();            
+            var relPath = Path.GetRelativePath(Assembly.GetExecutingAssembly().Location, schemaPath);
+            await TypeGenerator.GenerateUserElementTypeFromUriAsync(relPath, tmpPath);
+            var code = File.ReadAllText(Path.Combine(tmpPath, "NullableAndNonNullableTypes.g.cs"));
+            Assert.Contains("public Vector3 NonNullableVector", code);
+            Assert.Contains("public Vector3? NullableVector", code);
+            Assert.Contains("public Color NonNullableColor", code);
+            Assert.Contains("public Color? NullableColor", code);
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
- In the Hypar CLI, we have supported nullable `Color` and `Vector3` values for a while, as of https://github.com/hypar-io/Hypar/pull/403 and https://github.com/hypar-io/Hypar/pull/492. However, we never brought these improvements over to Elements, meaning that it was supported in `input_schema` / `overrides` but not in element schemas. 

DESCRIPTION:
- Moves the Type Generator from `hypar` to `Elements`

TESTING:
- I tested this in tandem w/ `hypar init`, and I also wrote a test to ensure that the correct types are generated. 
  
FUTURE WORK:
- Once this is in, we should update `Hypar` to use it instead of having duplicated code. 

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1011)
<!-- Reviewable:end -->
