### PR TITLE
Thickened polylines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2.0.1
 
+### Added
+- `Elements.Geometry.ThickenedPolyline`
+
 ### Fixed
 
 - `Polygon.Contains3D` passed wrong `out Containment containment` parameter in some cases.

--- a/Elements/src/Geometry/ThickenedPolyline.cs
+++ b/Elements/src/Geometry/ThickenedPolyline.cs
@@ -75,36 +75,29 @@ namespace Elements.Geometry
             public bool PointingAway;
         }
 
-        /// <summary>
-        /// Construct the thickened geometry for a collection of thickened
-        /// polylines.
-        /// </summary>
-        /// <param name="polylines">The polylines to thicken.</param>
-        /// <param name="normal">The normal of the plane in which to thicken. Z+ by default.</param>
-        /// <returns>A collection of thickened geometry. Polylines with
-        /// thickness > 0 will yield `offsetPolygon`s, those with thickness = 0
-        /// will yield `offsetLine` segments.</returns>
-        /// <remarks>This is a direct translation of the corresponding javascript method on the Hypar front end. It is important that this code match the behavior, so that the "thickened polyline" preview shows the same thing as will be generated here.</remarks>
-        public static List<(Polygon offsetPolygon, Line offsetLine)> GetPolygons(IEnumerable<ThickenedPolyline> polylines, Vector3? normal = null)
+        private class ThickenedPolylineGraph
         {
-            var normalDir = normal ?? Vector3.ZAxis;
-            if (!polylines.Any())
+            public PointOctree<int?> PointToNodeIndexMap;
+            public List<(Vector3 position, List<EdgeInfo> edges, Dictionary<int, Vector3[]> offsetVertexMap)> Nodes;
+            public List<(int a, int b, int origPlIndex)> Edges;
+        }
+
+        /// <summary>
+        /// Construct a graph of the supplied thickened polylines, where each node is a point
+        /// </summary>
+        private static ThickenedPolylineGraph ConstructThickenedPolylineGraph(IEnumerable<ThickenedPolyline> polylines)
+        {
+            var graph = new ThickenedPolylineGraph
             {
-                return new List<(Polygon offsetPolygon, Line offsetLine)>();
-            }
-            var resultList = new Dictionary<int, (Polygon offsetPolygon, Line offsetLine)>();
-            // Initialize a graph to manage nodes and edges of the thickened polylines
-            var graph = new
-            {
-                nodes = new List<(
+                // Initialize a point set for efficient spatial queries and build a collection of segments from the polylines
+                PointToNodeIndexMap = new PointOctree<int?>(10, polylines.First().Polyline.Vertices.First(), Vector3.EPSILON),
+                Nodes = new List<(
                     Vector3 position,
                     List<EdgeInfo> edges,
                         Dictionary<int, Vector3[]> offsetVertexMap
                     )>(),
-                edges = new List<(int a, int b, int origPlIndex)>()
+                Edges = new List<(int a, int b, int origPlIndex)>()
             };
-            // Initialize a point set for efficient spatial queries and build a collection of segments from the polylines
-            var pointSet = new PointOctree<int?>(10, polylines.First().Polyline.Vertices.First(), Vector3.EPSILON);
             // Deconstruct all polylines into individual thickened segments. Each segment will be an edge in the graph.
             var segments = polylines.SelectMany((polyline) => polyline.Polyline.Segments().Select(s => (Line: s, polyline.LeftWidth, polyline.RightWidth))).ToArray();
             // build up the graph, finding existing nodes or creating new ones as needed
@@ -114,13 +107,13 @@ namespace Elements.Geometry
                 var ptA = segment.Line.Start;
                 var ptB = segment.Line.End;
 
-                var indexA = pointSet.GetNearby(ptA, Vector3.EPSILON).FirstOrDefault();
-                var indexB = pointSet.GetNearby(ptB, Vector3.EPSILON).FirstOrDefault();
+                var indexA = graph.PointToNodeIndexMap.GetNearby(ptA, Vector3.EPSILON).FirstOrDefault();
+                var indexB = graph.PointToNodeIndexMap.GetNearby(ptB, Vector3.EPSILON).FirstOrDefault();
                 if (indexA == null)
                 {
-                    indexA = graph.nodes.Count;
-                    pointSet.Add(indexA, ptA);
-                    graph.nodes.Add((
+                    indexA = graph.Nodes.Count;
+                    graph.PointToNodeIndexMap.Add(indexA, ptA);
+                    graph.Nodes.Add((
                         ptA,
                         new List<EdgeInfo>(),
                         new Dictionary<int, Vector3[]>()
@@ -128,23 +121,23 @@ namespace Elements.Geometry
                 }
                 if (indexB == null)
                 {
-                    indexB = graph.nodes.Count;
-                    pointSet.Add(indexB, ptB);
-                    graph.nodes.Add((
+                    indexB = graph.Nodes.Count;
+                    graph.PointToNodeIndexMap.Add(indexB, ptB);
+                    graph.Nodes.Add((
                         ptB,
                         new List<EdgeInfo>(),
                         new Dictionary<int, Vector3[]>()
                         ));
                 }
 
-                graph.edges.Add((indexA.Value, indexB.Value, i));
-                graph.nodes[indexA.Value].edges.Add(new EdgeInfo(
+                graph.Edges.Add((indexA.Value, indexB.Value, i));
+                graph.Nodes[indexA.Value].edges.Add(new EdgeInfo(
                     indexB.Value,
                     ptB,
                     segment.LeftWidth,
                     segment.RightWidth,
                     true));
-                graph.nodes[indexB.Value].edges.Add(new EdgeInfo(
+                graph.Nodes[indexB.Value].edges.Add(new EdgeInfo(
                     indexA.Value,
                     ptA,
                     segment.LeftWidth,
@@ -152,10 +145,18 @@ namespace Elements.Geometry
                     false
                     ));
             }
+            return graph;
+        }
+
+        /// <summary>
+        /// Populate the offset vertex map for each node in the graph. These points can be used to construct the thickened geometry.
+        /// </summary>
+        private static void PopulateOffsetVertexMap(ThickenedPolylineGraph graph, Vector3 normalDir)
+        {
             // Walk all nodes, building up the offset vertex map for each node.
             // These vertices will ultimately become the vertices from which we
             // construct our polygons.
-            foreach (var (position, edges, offsetVertexMap) in graph.nodes)
+            foreach (var (position, edges, offsetVertexMap) in graph.Nodes)
             {
                 var projectionPlane = new Plane(position, normalDir);
                 // for each edge, compute all the info we'll need for it: its left
@@ -273,14 +274,39 @@ namespace Elements.Geometry
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Construct the thickened geometry for a collection of thickened
+        /// polylines.
+        /// </summary>
+        /// <param name="polylines">The polylines to thicken.</param>
+        /// <param name="normal">The normal of the plane in which to thicken. Z+ by default.</param>
+        /// <returns>A collection of thickened geometry. Polylines with
+        /// thickness > 0 will yield `offsetPolygon`s, those with thickness = 0
+        /// will yield `offsetLine` segments.</returns>
+        /// <remarks>This is a direct translation of the corresponding javascript method on the Hypar front end. It is important that this code match the behavior, so that the "thickened polyline" preview shows the same thing as will be generated here.</remarks>
+        public static List<(Polygon offsetPolygon, Line offsetLine)> GetPolygons(IEnumerable<ThickenedPolyline> polylines, Vector3? normal = null)
+        {
+            var normalDir = normal ?? Vector3.ZAxis;
+            if (!polylines.Any())
+            {
+                return new List<(Polygon offsetPolygon, Line offsetLine)>();
+            }
+            var resultList = new Dictionary<int, (Polygon offsetPolygon, Line offsetLine)>();
+            // Initialize a graph to manage nodes and edges of the thickened polylines
+            var graph = ConstructThickenedPolylineGraph(polylines);
+            // Populate the offset vertex map for each node in the graph. These points can be used to construct the thickened geometry.
+            PopulateOffsetVertexMap(graph, normalDir);
+
             var polygons = new List<Polygon>();
             var lines = new List<Line>();
             // For each edge in the graph, construct a new polygon from the points in the offset vertex map.
-            foreach (var (a, b, origPlIndex) in graph.edges)
+            foreach (var (a, b, origPlIndex) in graph.Edges)
             {
 
-                var abc = graph.nodes[a].offsetVertexMap[b];
-                var def = graph.nodes[b].offsetVertexMap[a];
+                var abc = graph.Nodes[a].offsetVertexMap[b];
+                var def = graph.Nodes[b].offsetVertexMap[a];
                 try
                 {
                     var pgonOutput = new Polygon(abc.Concat(def).ToArray());

--- a/Elements/src/Geometry/ThickenedPolyline.cs
+++ b/Elements/src/Geometry/ThickenedPolyline.cs
@@ -1,0 +1,232 @@
+namespace Elements.Geometry
+{
+    public class ThickenedPolyline
+    {
+        /// <summary>
+        /// Construct a thickened polyline.
+        /// </summary>
+        /// <param name="polyline">The polyline to thicken.</param>
+        /// <param name="leftWidth">The amount to thicken the polyline on its "left" side, imagining that the polyline is extending away from you. That is, if the polyline starts at (0,0,0) and follows the +Z axis, the left side extends into the -X quadrant.</param>
+        /// <param name="rightWidth">The amount to thicken the polyline on its "right" side, imagining that the polyline is extending away from you. That is, if the polyline starts at (0,0,0) and follows the +Z axis, the right side extends into the +X quadrant.</param>
+        [JsonConstructor]
+        public ThickenedPolyline(Polyline polyline, double leftWidth, double rightWidth)
+        {
+            this.Polyline = polyline;
+            this.LeftWidth = leftWidth;
+            this.RightWidth = rightWidth;
+        }
+
+        /// <summary>The base polyline to thicken.</summary>
+        [Newtonsoft.Json.JsonProperty("polyline", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Polyline Polyline { get; set; }
+
+        /// <summary>The amount to thicken the polyline on its "left" side, imagining that the polyline is extending away from you. That is, if the polyline starts at (0,0,0) and follows the +Z axis, the left side extends into the -X quadrant.</summary>
+        [Newtonsoft.Json.JsonProperty("leftWidth", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double LeftWidth { get; set; }
+
+        /// <summary>The amount to thicken the polyline on its "right" side, imagining that the polyline is extending away from you. That is, if the polyline starts at (0,0,0) and follows the +Z axis, the right side extends into the +X quadrant.</summary>
+        [Newtonsoft.Json.JsonProperty("rightWidth", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double RightWidth { get; set; }
+
+        /// <summary>
+        /// Construct the thickened geometry for a collection of thickened
+        /// polylines.
+        /// </summary>
+        /// <param name="polylines">The polylines to thicken.</param>
+        /// <param name="normal">The normal of the plane in which to thicken. Z+ by default.</param>
+        /// <returns>A collection of thickened geometry. Polylines with
+        /// thickness > 0 will yield `offsetPolygon`s, those with thickness = 0
+        /// will yield `offsetLine` segments.</returns>
+        /// <remarks>This is a direct translation of the corresponding javascript method on the Hypar front end. It is important that this code match the behavior, so that the "thickened polyline" preview shows the same thing as will be generated here.</remarks>
+        public static List<(Polygon offsetPolygon, Line offsetLine)> GetPolygons(IEnumerable<ThickenedPolyline> polylines, Vector3? normal = null)
+        {
+            if (!polylines.Any())
+            {
+                return new();
+            }
+            var resultList = new Dictionary<int, (Polygon offsetPolygon, Line offsetLine)>();
+            // Initialize a graph to manage nodes and edges of the thickened polylines
+            var graph = new
+            {
+                nodes = new List<(
+                    Vector3 position,
+                    List<(
+                        int otherPointIndex,
+                        Vector3 otherPoint,
+                        double leftWidth,
+                        double rightWidth,
+                        bool pointingAway
+                        )> edges,
+                        Dictionary<int, Vector3[]> offsetVertexMap
+                    )>(),
+                edges = new List<(int a, int b, int origPlIndex)>()
+            };
+            // Initialize a point set for efficient spatial queries and build a collection of segments from the polylines
+            var pointSet = new PointOctree<int?>(10, polylines.First().Polyline.Vertices.First(), Vector3.EPSILON);
+            // Deconstruct all polylines into individual thickened segments. Each segment will be an edge in the graph.
+            var segments = polylines.SelectMany((polyline) => polyline.Polyline.Segments().Select(s => (Line: s, polyline.LeftWidth, polyline.RightWidth))).ToArray();
+            // build up the graph, finding existing nodes or creating new ones as needed
+            for (int i = 0; i < segments.Length; i++)
+            {
+                (Line Line, double LeftWidth, double RightWidth) segment = segments[i];
+                var ptA = segment.Line.Start;
+                var ptB = segment.Line.End;
+
+                var indexA = pointSet.GetNearby(ptA, Vector3.EPSILON).FirstOrDefault();
+                var indexB = pointSet.GetNearby(ptB, Vector3.EPSILON).FirstOrDefault();
+                if (indexA == null)
+                {
+                    indexA = graph.nodes.Count;
+                    pointSet.Add(indexA, ptA);
+                    graph.nodes.Add((
+                        ptA,
+                        new(),
+                        new()
+                        ));
+                }
+                if (indexB == null)
+                {
+                    indexB = graph.nodes.Count;
+                    pointSet.Add(indexB, ptB);
+                    graph.nodes.Add((
+                        ptB,
+                        new(),
+                        new()
+                        ));
+                }
+
+                graph.edges.Add((indexA.Value, indexB.Value, i));
+                graph.nodes[indexA.Value].edges.Add((
+                    indexB.Value,
+                    ptB,
+                    segment.LeftWidth,
+                    segment.RightWidth,
+                    true));
+                graph.nodes[indexB.Value].edges.Add((
+                    indexA.Value,
+                    ptA,
+                    segment.LeftWidth,
+                    segment.RightWidth,
+                    false
+                    ));
+            }
+            // Walk all nodes, building up the offset vertex map for each node.
+            // These vertices will ultimately become the vertices from which we
+            // construct our polygons.
+            foreach (var (position, edges, offsetVertexMap) in graph.nodes)
+            {
+                var projectionPlane = new Plane(position, normal ?? Vector3.ZAxis);
+                var edgesSorted = edges.Select((edge) =>
+                {
+                    var otherPoint = edge.otherPoint;
+                    var edgeVector = otherPoint - position;
+                    var edgeAngle = Vector3.XAxis.PlaneAngleTo(edgeVector, normal ?? Vector3.ZAxis);
+                    var edgeLength = edgeVector.Length();
+                    offsetVertexMap[edge.otherPointIndex] = new Vector3[3];
+                    offsetVertexMap[edge.otherPointIndex][1] = position;
+                    return (edge, edgeVector, edgeAngle, edgeLength);
+                }).OrderBy((edge) => edge.edgeAngle).ToArray();
+                for (int i = 0; i < edgesSorted.Length; i++)
+                {
+                    var edge = edgesSorted[i];
+                    var nextOffsetDist = edge.edge.pointingAway ? edge.edge.leftWidth : edge.edge.rightWidth;
+                    var consistentCenterLine = new[] { position, edge.edge.otherPoint };
+                    var awayDir = edge.edgeVector;
+                    var perpendicular = awayDir.Cross(normal ?? Vector3.ZAxis).Unitized();
+                    var leftOffsetLine = new Line(
+                        consistentCenterLine[0] + perpendicular * nextOffsetDist * -1,
+                        consistentCenterLine[1] + perpendicular * nextOffsetDist * -1
+                    ).Projected(projectionPlane);
+
+                    var nextEdge = edgesSorted[(i + 1) % edgesSorted.Length];
+                    var nextCenterLine = new[] { position, nextEdge.edge.otherPoint };
+                    var nextOffsetDist2 = nextEdge.edge.pointingAway ? nextEdge.edge.rightWidth : nextEdge.edge.leftWidth;
+                    var nextAwayDir = nextEdge.edgeVector;
+                    var nextPerpendicular = nextAwayDir.Cross(normal ?? Vector3.ZAxis).Unitized();
+                    var rightOffsetLine = new Line(
+                        nextCenterLine[0] + nextPerpendicular * nextOffsetDist2,
+                        nextCenterLine[1] + nextPerpendicular * nextOffsetDist2
+                    ).Projected(projectionPlane);
+                    var intersects = leftOffsetLine.Intersects(rightOffsetLine, out var intersection, true);
+                    var angleThreshold = 90;
+                    var angleDiff = (nextEdge.edgeAngle - edge.edgeAngle + 360) % 360;
+                    if (intersects)
+                    {
+                        var maxLength = Math.Min(edge.edgeLength, nextEdge.edgeLength);
+                        if (angleDiff < angleThreshold)
+                        {
+                            // acute angle
+                            var toIntersectionVec = intersection - position;
+                            if (toIntersectionVec.Length() > maxLength)
+                            {
+                                intersection = position + toIntersectionVec.Unitized() * maxLength;
+                            }
+                            offsetVertexMap[edge.edge.otherPointIndex][0] = intersection;
+                            offsetVertexMap[nextEdge.edge.otherPointIndex][2] = intersection;
+                        }
+                        else if (angleDiff > 360 - angleThreshold)
+                        {
+                            // reflex angle
+                            var squareEndLeft = leftOffsetLine.Start + awayDir.Unitized() * -1 * nextOffsetDist;
+                            var squareEndRight = rightOffsetLine.Start + nextAwayDir.Unitized() * -1 * nextOffsetDist;
+                            var newInt = (squareEndLeft + squareEndRight) * 0.5;
+                            offsetVertexMap[edge.edge.otherPointIndex][0] = squareEndLeft;
+                            offsetVertexMap[edge.edge.otherPointIndex][1] = newInt;
+                            offsetVertexMap[nextEdge.edge.otherPointIndex][1] = newInt;
+                            offsetVertexMap[nextEdge.edge.otherPointIndex][2] = squareEndRight;
+                        }
+                        else if (Math.Abs(360 - angleDiff) < angleThreshold / 2 && intersection.DistanceTo(position) > maxLength)
+                        {
+                            offsetVertexMap[edge.edge.otherPointIndex][0] = leftOffsetLine.Start;
+                            offsetVertexMap[nextEdge.edge.otherPointIndex][2] = rightOffsetLine.Start;
+                        }
+                        else
+                        {
+                            offsetVertexMap[edge.edge.otherPointIndex][0] = intersection;
+                            offsetVertexMap[nextEdge.edge.otherPointIndex][2] = intersection;
+                        }
+                    }
+                    else
+                    {
+                        offsetVertexMap[edge.edge.otherPointIndex][0] = leftOffsetLine.Start;
+                        offsetVertexMap[nextEdge.edge.otherPointIndex][2] = rightOffsetLine.Start;
+                    }
+                }
+            }
+            var polygons = new List<Polygon>();
+            var lines = new List<Line>();
+            // For each edge in the graph, construct a new polygon from the points in the offset vertex map.
+            foreach (var (a, b, origPlIndex) in graph.edges)
+            {
+
+                var abc = graph.nodes[a].offsetVertexMap[b];
+                var def = graph.nodes[b].offsetVertexMap[a];
+                try
+                {
+                    var pgonOutput = new Polygon(abc.Concat(def).ToArray());
+                    resultList[origPlIndex] = (offsetPolygon: pgonOutput, offsetLine: null);
+                }
+                catch
+                {
+                    try
+                    {
+                        // we may have a degenerate polygon.
+                        Elements.Validators.Validator.DisableValidationOnConstruction = true;
+                        var pgonOutput = new Polygon(abc.Concat(def).ToArray());
+                        var offsets = Profile.Offset(Profile.Offset(new Profile[] { pgonOutput }, -0.01), 0.01);
+                        // get largest offset
+                        var largestOffset = offsets.OrderByDescending((pgon) => Math.Abs(pgon.Area())).First();
+                        resultList[origPlIndex] = (offsetPolygon: largestOffset.Perimeter, offsetLine: null);
+                        Elements.Validators.Validator.DisableValidationOnConstruction = false;
+                    }
+                    catch
+                    {
+                        resultList[origPlIndex] = (offsetPolygon: null, offsetLine: new Line(abc[1], def[1]));
+                    }
+                }
+
+            }
+            return resultList.Values.ToList();
+        }
+    }
+}

--- a/Elements/src/Geometry/ThickenedPolyline.cs
+++ b/Elements/src/Geometry/ThickenedPolyline.cs
@@ -171,7 +171,7 @@ namespace Elements.Geometry
                     var edgeLength = edgeVector.Length();
                     offsetVertexMap[edge.OtherPointIndex] = new Vector3[3];
                     offsetVertexMap[edge.OtherPointIndex][1] = position;
-                    return (edge, edgeVector, edgeAngle, edgeLength);
+                    return new { edge, edgeVector, edgeAngle, edgeLength };
                 }).OrderBy((edge) => edge.edgeAngle).ToArray();
 
                 // for each edge in the sorted set, find the next edge, and compute the
@@ -239,13 +239,21 @@ namespace Elements.Geometry
                             var squareEndLeft = leftOffsetLine.Start + awayDir.Unitized() * -1 * nextOffsetDist;
                             var squareEndRight = rightOffsetLine.Start + nextAwayDir.Unitized() * -1 * nextOffsetDist;
                             var newInt = (squareEndLeft + squareEndRight) * 0.5;
-                            offsetVertexMap[edge.edge.OtherPointIndex][0] = squareEndLeft;
-                            offsetVertexMap[edge.edge.OtherPointIndex][1] = newInt;
-                            offsetVertexMap[nextEdge.edge.OtherPointIndex][1] = newInt;
-                            offsetVertexMap[nextEdge.edge.OtherPointIndex][2] = squareEndRight;
+                            if (newInt.DistanceTo(position) > intersection.DistanceTo(position))
+                            {
+                                offsetVertexMap[edge.edge.OtherPointIndex][0] = intersection;
+                                offsetVertexMap[nextEdge.edge.OtherPointIndex][2] = intersection;
+                            }
+                            else
+                            {
+                                offsetVertexMap[edge.edge.OtherPointIndex][0] = squareEndLeft;
+                                offsetVertexMap[edge.edge.OtherPointIndex][1] = newInt;
+                                offsetVertexMap[nextEdge.edge.OtherPointIndex][1] = newInt;
+                                offsetVertexMap[nextEdge.edge.OtherPointIndex][2] = squareEndRight;
+                            }
                         }
                         else if (Math.Abs(180 - angleDiff) < parallelThreshold && intersection.DistanceTo(position) > maxLength)
-                        { 
+                        {
                             // angle is nearly parallel. Use the perpendicular offset points.
                             offsetVertexMap[edge.edge.OtherPointIndex][0] = leftOffsetLine.Start;
                             offsetVertexMap[nextEdge.edge.OtherPointIndex][2] = rightOffsetLine.Start;

--- a/Elements/test/ThickenedPolylineTests.cs
+++ b/Elements/test/ThickenedPolylineTests.cs
@@ -74,5 +74,19 @@ namespace Elements.Geometry.Tests
                 }
             }
         }
+
+        [Fact]
+        public void DifferentAlignmentsAtCorners()
+        {
+            Name = nameof(DifferentAlignmentsAtCorners);
+            var a = new ThickenedPolyline(new Line((0, 0), (10, 0)), 0.5, 0.5);
+            var b = new ThickenedPolyline(new Line((10, 0), (9.9, 10)), 1, 0);
+            var c = new ThickenedPolyline(new Line((9.9, 10), (0, 10)), 0.5, 0.5);
+            var d = new ThickenedPolyline(new Line((0, 10), (0, 0)), 0.5, 0.5);
+            var abcd = new[] { a, b, c, d };
+            var polygons = ThickenedPolyline.GetPolygons(abcd);
+            Model.AddElements(polygons.Select(p => new ModelCurve(p.offsetPolygon, BuiltInMaterials.YAxis)));
+            Model.AddElements(abcd.Select(p => new ModelCurve(p.Polyline, BuiltInMaterials.XAxis, new Transform(0, 0, 0.1))));
+        }
     }
 }

--- a/Elements/test/ThickenedPolylineTests.cs
+++ b/Elements/test/ThickenedPolylineTests.cs
@@ -2,9 +2,6 @@ using Elements.Tests;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using Elements.Geometry;
-using Xunit.Sdk;
-using System;
 
 namespace Elements.Geometry.Tests
 {
@@ -127,13 +124,15 @@ namespace Elements.Geometry.Tests
             var tp4 = new ThickenedPolyline(new Polyline((0, 0, 0), (10, 0, 0), (0, 10, 0)), 0.5, 0.5);
             pgon = tp4.GetPolygons();
             Assert.Equal(2, pgon.Count);
-            var expectedVertices4 = new Vector3[] { (-0.35355339, 9.64644660), (0.35355339, 10.35355339), (11.20710678, -0.5), (8.7928932, 0.5), (0, -0.5), (0, 0.5) };
+            var expectedVertices4 = new Vector3[] { (0, 0.5), (0, 0), (0, -0.5), (10.5, -0.5), (10.603553, -0.25), (8.792893, 0.5), (8.792893, 0.5), (10.603553, -0.25), (10.707107, 0), (0.353553, 10.353553), (0, 10), (-0.353553, 9.646447) };
+            Assert.True(containsExpectedVertices(expectedVertices4, pgon.SelectMany(p => p.offsetPolygon.Vertices)));
 
             // Acute Angle with cap
             var tp5 = new ThickenedPolyline(new Polyline((0, 0, 0), (10, 0, 0), (0, 3, 0)), 0.5, 0.5);
             pgon = tp5.GetPolygons();
             Assert.Equal(2, pgon.Count);
-            var expectedVertices5 = new Vector3[] { (0, 0.5), (0, 0), (0, -0.5), (10.5, -0.5), (10.5613, -0.0824), (6.5933, 0.5), (6.5933, 0.5), (10.5613, -0.0824), (10.6226, 0.3352), (0.1437, 3.4789), (0, 3), (-0.1437, 2.5211) };
+            var expectedVertices5 = new Vector3[] { (0, 0.5), (0, 0), (0, -0.5), (10.5, -0.5), (10.561294, -0.08238), (6.593282, 0.5), (6.593282, 0.5), (10.561294, -0.08238), (10.622587, 0.335239), (0.143674, 3.478913), (0, 3), (-0.143674, 2.521087) };
+            Assert.True(containsExpectedVertices(expectedVertices5, pgon.SelectMany(p => p.offsetPolygon.Vertices)));
         }
     }
 }

--- a/Elements/test/ThickenedPolylineTests.cs
+++ b/Elements/test/ThickenedPolylineTests.cs
@@ -56,5 +56,23 @@ namespace Elements.Geometry.Tests
                 Model.AddElement(new ModelCurve(p.offsetPolygon, BuiltInMaterials.YAxis));
             }
         }
+
+        [Fact]
+        public void CorrectCornerConditions()
+        {
+            Name = nameof(CorrectCornerConditions);
+            for (double thickness = 0.1; thickness < 2.5; thickness += 0.25)
+            {
+                var segmentA = new ThickenedPolyline(new Line((0, 0), (-10, 0)), thickness / 2, thickness / 2);
+                for (double angle = 10; angle < 360; angle += 10)
+                {
+                    var rotation = new Transform().Rotated(Vector3.ZAxis, angle);
+                    var segmentB = new ThickenedPolyline(new Line((0, 0), (-10, 0)).TransformedLine(rotation), thickness / 2, thickness / 2);
+                    var polygons = ThickenedPolyline.GetPolygons(new[] { segmentA, segmentB });
+                    var displayTransform = new Transform(0, angle * 1.5, thickness);
+                    Model.AddElements(polygons.Select(p => new ModelCurve(p.offsetPolygon, BuiltInMaterials.XAxis, displayTransform)));
+                }
+            }
+        }
     }
 }

--- a/Elements/test/ThickenedPolylineTests.cs
+++ b/Elements/test/ThickenedPolylineTests.cs
@@ -1,0 +1,60 @@
+using Elements.Tests;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Elements.Geometry;
+
+namespace Elements.Geometry.Tests
+{
+    public class ThickenedPolylineTests : ModelTest
+    {
+        public ThickenedPolylineTests()
+        {
+            this.GenerateIfc = false;
+        }
+
+        [Fact, Trait("Category", "Examples")]
+        public void ThickenedPolylineExample()
+        {
+            this.Name = "Elements_Geometry_ThickenedPolyline";
+
+            // <example>
+            // Construct a single polyline and thicken it on both sides.
+            var a = new Vector3();
+            var b = new Vector3(10, 10);
+            var c = new Vector3(20, 5);
+            var d = new Vector3(25, 10);
+
+            var singleThickenedPolyline = new ThickenedPolyline(new[] { a, b, c, d }, 0.5, 0.5);
+            var polygons = singleThickenedPolyline.GetPolygons();
+
+            // Construct multiple thickened segments and compute their polygons.
+            var segmentsWithDifferentThickness = new[] {
+                new ThickenedPolyline(new Line((0, 15), (0, 25)), 0.5, 0),
+                new ThickenedPolyline(new Line((0, 25), (10, 35)), 0.5, 0.25),
+                new ThickenedPolyline(new Line((0, 25), (-10, 25)), 0.5, 0.5),
+                new ThickenedPolyline(new Line((0, 15), (-10, 15)), 0, 1),
+                new ThickenedPolyline(new Line((-10, 15), (-10, 25)), 1, 1),
+            };
+            var polygons2 = ThickenedPolyline.GetPolygons(segmentsWithDifferentThickness);
+
+            // </example>
+
+            Model.AddElement(new ModelCurve(singleThickenedPolyline.Polyline, BuiltInMaterials.XAxis, transform: new Transform(0, 0, 0.1)));
+            foreach (var p in polygons)
+            {
+                Model.AddElement(new ModelCurve(p.offsetPolygon, BuiltInMaterials.YAxis));
+            }
+
+            foreach (var s in segmentsWithDifferentThickness)
+            {
+                Model.AddElement(new ModelCurve(s.Polyline, BuiltInMaterials.XAxis, transform: new Transform(0, 0, 0.1)));
+            }
+
+            foreach (var p in polygons2)
+            {
+                Model.AddElement(new ModelCurve(p.offsetPolygon, BuiltInMaterials.YAxis));
+            }
+        }
+    }
+}

--- a/Elements/test/ThickenedPolylineTests.cs
+++ b/Elements/test/ThickenedPolylineTests.cs
@@ -70,7 +70,7 @@ namespace Elements.Geometry.Tests
                     var segmentB = new ThickenedPolyline(new Line((0, 0), (-10, 0)).TransformedLine(rotation), thickness / 2, thickness / 2);
                     var polygons = ThickenedPolyline.GetPolygons(new[] { segmentA, segmentB });
                     var displayTransform = new Transform(0, angle * 1.5, thickness);
-                    Model.AddElements(polygons.Select(p => new ModelCurve(p.offsetPolygon, BuiltInMaterials.XAxis, displayTransform)));
+                    Model.AddElements(polygons.Select(p => new ModelCurve(p.offsetPolygon, BuiltInMaterials.YAxis, displayTransform)));
                 }
             }
         }

--- a/Elements/test/ThickenedPolylineTests.cs
+++ b/Elements/test/ThickenedPolylineTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Elements.Geometry;
+using Xunit.Sdk;
+using System;
 
 namespace Elements.Geometry.Tests
 {
@@ -87,6 +89,51 @@ namespace Elements.Geometry.Tests
             var polygons = ThickenedPolyline.GetPolygons(abcd);
             Model.AddElements(polygons.Select(p => new ModelCurve(p.offsetPolygon, BuiltInMaterials.YAxis)));
             Model.AddElements(abcd.Select(p => new ModelCurve(p.Polyline, BuiltInMaterials.XAxis, new Transform(0, 0, 0.1))));
+        }
+
+        [Fact]
+        public void TestCorners()
+        {
+            var containsExpectedVertices = (Vector3[] expectedVertices, IEnumerable<Vector3> v) =>
+            {
+                // We want to make sure that all the vertices we expect are
+                // present in v. We don't care about cases where there are
+                // vertices in v that are not in expected vertices.
+                return expectedVertices.All(ev => v.Any(vv => vv.IsAlmostEqualTo(ev)));
+            };
+
+            // Single Line
+            var tp1 = new ThickenedPolyline(new Line((0, 0, 0), (10, 0, 0)), 0.5, 0.5);
+            var pgon = tp1.GetPolygons();
+            Assert.Equal(1, pgon.Count);
+            var expectedVertices = new Vector3[] { (0, 0.5), (10, 0.5), (10, -0.5), (0, -0.5) };
+            Assert.True(containsExpectedVertices(expectedVertices, pgon[0].offsetPolygon.Vertices));
+
+            // 90 degree L
+            var tp2 = new ThickenedPolyline(new Polyline((0, 0, 0), (10, 0, 0), (10, 10, 0)), 0.5, 0.5);
+            pgon = tp2.GetPolygons();
+            Assert.Equal(2, pgon.Count);
+            var expectedVertices2 = new Vector3[] { (9.5, 10.0), (10.5, 10.0), (9.5, 0.5), (10.5, -0.5), (0.0, -0.5), (0.0, 0.5) };
+            Assert.True(containsExpectedVertices(expectedVertices2, pgon.SelectMany(p => p.offsetPolygon.Vertices)));
+
+            // 90 degree L with different thicknesses
+            var tps3 = new[] { new ThickenedPolyline(new Line((0, 0), (10, 0)), 0.5, 0.5), new ThickenedPolyline(new Line((10, 0), (10, 10)), 1, 1) };
+            pgon = ThickenedPolyline.GetPolygons(tps3);
+            Assert.Equal(2, pgon.Count);
+            var expectedVertices3 = new Vector3[] { (11.0, 10.0), (9.0, 10.0), (11.0, -0.5), (9.0, 0.5), (0.0, -0.5), (0.0, 0.5) };
+            Assert.True(containsExpectedVertices(expectedVertices3, pgon.SelectMany(p => p.offsetPolygon.Vertices)));
+
+            // Acute Angle with no cap
+            var tp4 = new ThickenedPolyline(new Polyline((0, 0, 0), (10, 0, 0), (0, 10, 0)), 0.5, 0.5);
+            pgon = tp4.GetPolygons();
+            Assert.Equal(2, pgon.Count);
+            var expectedVertices4 = new Vector3[] { (-0.35355339, 9.64644660), (0.35355339, 10.35355339), (11.20710678, -0.5), (8.7928932, 0.5), (0, -0.5), (0, 0.5) };
+
+            // Acute Angle with cap
+            var tp5 = new ThickenedPolyline(new Polyline((0, 0, 0), (10, 0, 0), (0, 3, 0)), 0.5, 0.5);
+            pgon = tp5.GetPolygons();
+            Assert.Equal(2, pgon.Count);
+            var expectedVertices5 = new Vector3[] { (0, 0.5), (0, 0), (0, -0.5), (10.5, -0.5), (10.5613, -0.0824), (6.5933, 0.5), (6.5933, 0.5), (10.5613, -0.0824), (10.6226, 0.3352), (0.1437, 3.4789), (0, 3), (-0.1437, 2.5211) };
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- The Hypar front end supports the concept of a "Thickened Polyline," which is used for wall + corridor drawing. Until now, we've relied on a schema type, and had to ship around a separate library to reproduce the "thickening" behavior that takes place on the client — but now that this type has settled into usefulness, it should get a place in Elements.

DESCRIPTION:
- Adds the `ThickenedPolyline` class. 

TESTING:
- Several tests were added, including an example for docs.
- I have also been using this code extensively in existing projects (https://github.com/hypar-io/function-Circulation/), so trust its behavior.

![image](https://github.com/hypar-io/Elements/assets/31935763/441ce777-938d-4ea0-a1e7-e171a6960ef7)


REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1013)
<!-- Reviewable:end -->
