### PR TITLE
Fix: ifc serialization was using ZAxis as extrusion direction

### DIFF
--- a/Elements.Serialization.IFC/src/Serialization/IFC/IFCElementExtensions.cs
+++ b/Elements.Serialization.IFC/src/Serialization/IFC/IFCElementExtensions.cs
@@ -227,7 +227,7 @@ namespace Elements.Serialization.IFC
 
             var extrudeDepth = extrude.Height;
             var extrudeProfile = extrude.Profile.Perimeter.ToIfcArbitraryClosedProfileDef(doc);
-            var extrudeDirection = Vector3.ZAxis.ToIfcDirection(); ;
+            var extrudeDirection = extrude.Direction.ToIfcDirection(); ;
 
             var solid = new IfcExtrudedAreaSolid(extrudeProfile, position,
                 extrudeDirection, new IfcPositiveLengthMeasure(extrude.Height));


### PR DESCRIPTION
BACKGROUND:
- I was trying to export windows as IFC and found that the geometry didn't look the way I expected:
![image](https://github.com/hypar-io/Elements/assets/88673491/117e2429-6c18-4c7e-a20f-f091bfbf31f3)


DESCRIPTION:
- The issue was in extrusion creation logic. We were using Z axis as extrusion direction even if the element had extrusion direction Y axis:
![image](https://github.com/hypar-io/Elements/assets/88673491/d771f87a-438b-4f0a-b732-1d377417bbf7)

TESTING:
- I tried it locally on my local Windows test model. I can give you access to it. But you can simply create model with extrusion by Y axis, create test and add ToIFC method call.
  
REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1018)
<!-- Reviewable:end -->
