### PR TITLE
Small refactoring before adding multiple representations

### DIFF
--- a/Elements.Serialization.IFC/src/Serialization/IFC/IFCElementExtensions.cs
+++ b/Elements.Serialization.IFC/src/Serialization/IFC/IFCElementExtensions.cs
@@ -227,7 +227,7 @@ namespace Elements.Serialization.IFC
 
             var extrudeDepth = extrude.Height;
             var extrudeProfile = extrude.Profile.Perimeter.ToIfcArbitraryClosedProfileDef(doc);
-            var extrudeDirection = Vector3.ZAxis.ToIfcDirection(); ;
+            var extrudeDirection = extrude.Direction.ToIfcDirection(); ;
 
             var solid = new IfcExtrudedAreaSolid(extrudeProfile, position,
                 extrudeDirection, new IfcPositiveLengthMeasure(extrude.Height));

--- a/Elements/src/GeometricElement.cs
+++ b/Elements/src/GeometricElement.cs
@@ -321,20 +321,13 @@ namespace Elements
                 return null;
             }
 
-            if (this is IHasOpenings openingContainer)
-            {
-                return SolidOperationUtils.GetFinalCsgFromSolids(Representation.SolidOperations, openingContainer.Openings, transformed ? Transform : null);
-            }
-            else
-            {
-                return SolidOperationUtils.GetFinalCsgFromSolids(Representation.SolidOperations, null, transformed ? Transform : null);
-            }
+            return SolidOperationUtils.GetFinalCsgFromSolids(Representation.SolidOperations, this, transformed);
         }
 
         internal Csg.Solid[] GetCsgSolids(bool transformed = false)
         {
             var solids = Representation.SolidOperations.Where(op => op.IsVoid == false)
-                                                       .Select(op => SolidOperationUtils.TransformedSolidOperation(op, Transform))
+                                                       .Select(op => SolidOperationUtils.TransformedSolidOperation(op, this))
                                                        .ToArray();
             if (Transform == null || transformed)
             {

--- a/Elements/src/Utilities/SolidOperationUtils.cs
+++ b/Elements/src/Utilities/SolidOperationUtils.cs
@@ -26,7 +26,7 @@ namespace Elements.Utilities
                 return solidOperation._solid.ToCsg();
             }
 
-            // Transform the solid operatioon by the the local transform AND the
+            // Transform the solid operation  by the the local transform AND the
             // element's transform, or just by the element's transform.
             var transformedOp = solidOperation.LocalTransform != null
                         ? solidOperation._solid.ToCsg().Transform(element.Transform.Concatenated(solidOperation.LocalTransform).ToMatrix4x4())
@@ -36,7 +36,7 @@ namespace Elements.Utilities
                 return transformedOp;
             }
 
-            // If an addition transform was proovided, don't forget
+            // If an additional transform was provided, don't forget
             // to apply that as well.
             return transformedOp.Transform(addTransform.ToMatrix4x4());
         }

--- a/Elements/src/Utilities/SolidOperationUtils.cs
+++ b/Elements/src/Utilities/SolidOperationUtils.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using System.Linq;
+using Elements.Geometry;
+using Elements.Geometry.Solids;
+
+namespace Elements.Utilities
+{
+    /// <summary>
+    /// The helpful methods for work with SolidOperations.
+    /// </summary>
+    internal static class SolidOperationUtils
+    {
+        /// <summary>
+        /// Get the computed csg solid.
+        /// </summary>
+        /// <param name="solidOperation">The solid operation.</param>
+        /// <param name="elementTransform">The element transform.</param>
+        /// <param name="addTransform">The additional transform to apply.</param>
+        /// <returns></returns>
+        public static Csg.Solid TransformedSolidOperation(SolidOperation solidOperation, Transform elementTransform = null,
+            Transform addTransform = null)
+        {
+            // TODO: call this code from ElementRepresentation? or Element itself
+            if (elementTransform == null)
+            {
+                return solidOperation._solid.ToCsg();
+            }
+
+            // Transform the solid operatioon by the the local transform AND the
+            // element's transform, or just by the element's transform.
+            var transformedOp = solidOperation.LocalTransform != null
+                        ? solidOperation._solid.ToCsg().Transform(elementTransform.Concatenated(solidOperation.LocalTransform).ToMatrix4x4())
+                        : solidOperation._solid.ToCsg().Transform(elementTransform.ToMatrix4x4());
+            if (addTransform == null)
+            {
+                return transformedOp;
+            }
+
+            // If an addition transform was proovided, don't forget
+            // to apply that as well.
+            return transformedOp.Transform(addTransform.ToMatrix4x4());
+        }
+
+        /// <summary>
+        /// Get the computed csg solid.
+        /// The csg is centered on the origin by default.
+        /// </summary>
+        /// <param name="solidOperations">The list of solid operations.</param>
+        /// <param name="openings">The list of openings. This parameter can be null.</param>
+        /// <param name="transform">The element transformation. This parameter can be null.</param>
+        public static Csg.Solid GetFinalCsgFromSolids(IList<SolidOperation> solidOperations, IList<Opening> openings,
+            Transform transform = null)
+        {
+            if (solidOperations.Count == 0)
+            {
+                return null;
+            }
+
+            // To properly compute csgs, all solid operation csgs need
+            // to be transformed into their final position. Then the csgs
+            // can be computed and by default the final csg will have the inverse of the
+            // geometric element's transform applied to "reset" it.
+            // The transforms applied to each node in the glTF will then
+            // ensure that the elements are correctly transformed.
+            Csg.Solid csg = new Csg.Solid();
+
+            var solids = new List<Csg.Solid>();
+            var voids = new List<Csg.Solid>();
+
+            foreach (var op in solidOperations)
+            {
+                if (op.IsVoid)
+                {
+                    voids.Add(TransformedSolidOperation(op));
+                }
+                else
+                {
+                    solids.Add(TransformedSolidOperation(op));
+                }
+            }
+
+            if (openings != null)
+            {
+                foreach (var opening in openings)
+                {
+                    foreach (var op in opening.Representation.SolidOperations)
+                    {
+                        if (op.IsVoid)
+                        {
+                            voids.Add(TransformedSolidOperation(op, null, opening.Transform));
+                        }
+                    }
+                }
+            }
+
+            var solidItems = solids.ToArray();
+            var voidItems = voids.ToArray();
+
+            // Don't try CSG booleans if we only have one one solid.
+            if (solids.Count() == 1)
+            {
+                csg = solids.First();
+            }
+            else if (solids.Count() > 0)
+            {
+                csg = csg.Union(solidItems);
+            }
+
+
+            if (voids.Count() > 0)
+            {
+                csg = csg.Subtract(voidItems);
+            }
+
+            if (transform == null)
+            {
+                return csg;
+            }
+            else
+            {
+                csg = csg.Transform(transform.ToMatrix4x4());
+                return csg;
+            }
+        }
+    }
+}


### PR DESCRIPTION
BACKGROUND:
I'm planning to re-use code that creates Csg.Solid from SolidOperation

DESCRIPTION:
Solid creation is moved to a separate class

TESTING:
- I tested it on a few functions. I can share them with you. 

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1022)
<!-- Reviewable:end -->
