### PR TITLE
SharedObject concept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - `Bezier.Intersects(Ellipse ellipse, out List<Vector3> results)`
 - `Bezier.Intersects(Bezier other, out List<Vector3> results)`
 - `Elements.Geometry.ThickenedPolyline`
+- `Elements.SharedObject`
 
 ### Fixed
 

--- a/Elements/src/CoreModels/SharedObject.cs
+++ b/Elements/src/CoreModels/SharedObject.cs
@@ -1,0 +1,40 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Elements
+{
+    /// <summary>
+    /// An object which is identified with a unique identifier.
+    /// </summary>
+    [JsonConverter(typeof(Serialization.JSON.JsonInheritanceConverter), "discriminator")]
+    public class SharedObject
+    {
+        private Guid _id;
+
+        /// <summary>
+        /// Initializes a new instance of SharedObject.
+        /// </summary>
+        /// <param name="id">The unique id of the object.</param> 
+        [JsonConstructor]
+        public SharedObject(Guid id = default)
+        {
+            _id = id;
+
+            if (_id == default)
+            {
+                _id = Guid.NewGuid();
+            }
+        }
+
+        /// <summary>
+        /// A unique object id.
+        /// </summary>
+        [JsonProperty("Id", Required = Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public Guid Id
+        {
+            get => _id;
+            set { _id = value; }
+        }
+    }
+}

--- a/Elements/src/Utilities/ReflectionUtils.cs
+++ b/Elements/src/Utilities/ReflectionUtils.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Elements.Utilities
+{
+    /// <summary>
+    /// Helpfull reflection methods
+    /// </summary>
+    internal static class ReflectionUtils
+    {
+        /// <summary>
+        /// Try to fin property by path inside an object (e.g. RepresentationInstances[0].Material)
+        /// </summary>
+        /// <param name="element">The object that potentially has the property by the path</param>
+        /// <param name="path">The property path</param>
+        /// <param name="objectInstanceWithProperty">The object instance with the property.
+        ///  (e.g. Materil instance if the path is RepresentationInstances[0].Material)</param>
+        /// <param name="propertyInfo">The property info</param>
+        /// <returns></returns>
+        public static bool TryFindPropertyByPath(object element, string path, out object objectInstanceWithProperty, out PropertyInfo propertyInfo)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException("value");
+            }
+            if (path == null)
+            {
+                throw new ArgumentNullException("path");
+            }
+
+            Type currentType = element.GetType();
+            propertyInfo = null;
+            objectInstanceWithProperty = element;
+            object propertyValue = element;
+
+            foreach (string propertyName in path.Split('.'))
+            {
+                if (currentType != null)
+                {
+                    objectInstanceWithProperty = propertyValue;
+                    propertyInfo = null;
+                    int brackStart = propertyName.IndexOf("[");
+                    int brackEnd = propertyName.IndexOf("]");
+
+                    propertyInfo = currentType.GetProperty(brackStart > 0 ? propertyName.Substring(0, brackStart) : propertyName);
+                    propertyValue = propertyInfo.GetValue(objectInstanceWithProperty, null);
+
+                    if (propertyInfo == null)
+                    {
+                        return false;
+                    }
+
+                    if (brackStart > 0 && propertyValue != null)
+                    {
+                        string index = propertyName.Substring(brackStart + 1, brackEnd - brackStart - 1);
+                        foreach (Type iType in propertyValue.GetType().GetInterfaces())
+                        {
+                            if (iType.IsGenericType && iType.GetGenericTypeDefinition() == typeof(IDictionary<,>))
+                            {
+                                propertyValue = typeof(ReflectionUtils).GetMethod("GetDictionaryElement")
+                                                     .MakeGenericMethod(iType.GetGenericArguments())
+                                                     .Invoke(null, new object[] { propertyValue, index });
+                                break;
+                            }
+                            if (iType.IsGenericType && iType.GetGenericTypeDefinition() == typeof(IList<>))
+                            {
+                                propertyValue = typeof(ReflectionUtils).GetMethod("GetListElement")
+                                                     .MakeGenericMethod(iType.GetGenericArguments())
+                                                     .Invoke(null, new object[] { propertyValue, index });
+                                break;
+                            }
+                        }
+                    }
+
+                    currentType = propertyValue?.GetType(); //property.PropertyType;
+
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public static TValue GetDictionaryElement<TKey, TValue>(IDictionary<TKey, TValue> dictionary, object index)
+        {
+            TKey key = (TKey)Convert.ChangeType(index, typeof(TKey), null);
+            return dictionary[key];
+        }
+
+        public static T GetListElement<T>(IList<T> list, object index)
+        {
+            return list[Convert.ToInt32(index)];
+        }
+    }
+}

--- a/Elements/src/Utilities/ReflectionUtils.cs
+++ b/Elements/src/Utilities/ReflectionUtils.cs
@@ -73,8 +73,7 @@ namespace Elements.Utilities
                         }
                     }
 
-                    currentType = propertyValue?.GetType(); //property.PropertyType;
-
+                    currentType = propertyValue?.GetType();
                 }
                 else
                 {

--- a/Elements/src/Utilities/SolidOperationUtils.cs
+++ b/Elements/src/Utilities/SolidOperationUtils.cs
@@ -26,7 +26,7 @@ namespace Elements.Utilities
                 return solidOperation._solid.ToCsg();
             }
 
-            // Transform the solid operatioon by the the local transform AND the
+            // Transform the solid operation  by the the local transform AND the
             // element's transform, or just by the element's transform.
             var transformedOp = solidOperation.LocalTransform != null
                         ? solidOperation._solid.ToCsg().Transform(element.Transform.Concatenated(solidOperation.LocalTransform).ToMatrix4x4())
@@ -36,7 +36,7 @@ namespace Elements.Utilities
                 return transformedOp;
             }
 
-            // If an addition transform was proovided, don't forget
+            // If an additional transform was provided, don't forget
             // to apply that as well.
             return transformedOp.Transform(addTransform.ToMatrix4x4());
         }


### PR DESCRIPTION
BACKGROUND:
It's a part of the PRs that will help to introduce multiple representations concept.

DESCRIPTION:
SharedObject - is object with id.  
During deserialization SharetdObject has the same behavior as Element.
If Element has SharedObject property, it will be replaced with GUID and shared object will be saved inside Model.SharedObjects list,  So now we have two lists: Elements and SharedObjects.

SharedObject can be deserialized after Element, so I added WaitList that keep track of giuds that were not replaced with deserialized objects. Once element is deserialized, it will  replace the pending guid.  

TESTING:
I tested it with multiple representations, but it can be tested by adding shared object to the Element. 
 
REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1023)
<!-- Reviewable:end -->
