### PR TITLE
Polygon: delete last vertex if it equals the first one

### DIFF
--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -77,6 +77,12 @@ namespace Elements.Geometry
 
             this.Vertices = Vector3.RemoveSequentialDuplicates(this.Vertices, true);
             DeleteVerticesForOverlappingEdges();
+
+            if (Vertices.Count > 3 && Vertices[Vertices.Count - 1].IsAlmostEqualTo(Vertices[0]))
+            {
+                Vertices.RemoveAt(Vertices.Count - 1);
+            }
+
             if (this.Vertices.Count < 3)
             {
                 throw new ArgumentException("The polygon could not be created. At least 3 vertices are required.");


### PR DESCRIPTION
BACKGROUND:
In drywall function the data exported from Revit and then proceed by transformation/union etc. can cause the creation of polygon where the last vertex duplicated the first one. "Edges" method tries to create a segment from this two points and fails (the line is too short) 

DESCRIPTION:
- Delete the last vertex if it equals the first one as part of polygon validation

TESTING:
- I published Drywall function with this change. It might be worth creating a test

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1026)
<!-- Reviewable:end -->
