### PR TITLE
Update ToPolyline function in BoundedCurve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - `IndexedPolycurve.GetSubdivisionParameters` now works correctly with `startSetbackDistance` and `endSetbackDistance` parameters.
 - `Polyline.Frames` now works correctly with `startSetbackDistance` and `endSetbackDistance` parameters.
 - `Polygon.Frames` now works correctly with `startSetbackDistance` and `endSetbackDistance` parameters.
+- `BoundedCurve.ToPolyline` now works correctly for `EllipticalArc` class.
 
 
 ### Changed

--- a/Elements/src/Geometry/Arc.cs
+++ b/Elements/src/Geometry/Arc.cs
@@ -485,29 +485,6 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Create a polyline through a set of points along the curve.
-        /// </summary>
-        /// <param name="divisions">The number of divisions of the curve.</param>
-        /// <returns>A polyline.</returns>
-        public override Polyline ToPolyline(int divisions = 10)
-        {
-            var pts = new List<Vector3>(divisions + 1);
-            var step = this.Domain.Length / divisions;
-            for (var t = this.Domain.Min; t < this.Domain.Max; t += step)
-            {
-                pts.Add(PointAt(t));
-            }
-
-            // We don't go all the way to the end parameter, and
-            // add it here explicitly because rounding errors can
-            // cause small imprecision which accumulates to make
-            // the final parameter slightly more/less than the actual
-            // end parameter.
-            pts.Add(PointAt(this.Domain.Max));
-            return new Polyline(pts);
-        }
-
-        /// <summary>
         /// Get the parameter at a distance from the start parameter along the curve.
         /// </summary>
         /// <param name="distance">The distance from the start parameter.</param>

--- a/Elements/src/Geometry/BoundedCurve.cs
+++ b/Elements/src/Geometry/BoundedCurve.cs
@@ -93,10 +93,17 @@ namespace Elements.Geometry
         {
             var pts = new List<Vector3>(divisions + 1);
             var step = this.Domain.Length / divisions;
-            for (var t = 0; t <= divisions; t++)
+            for (var t = this.Domain.Min; t < this.Domain.Max; t += step)
             {
-                pts.Add(PointAt(t * step));
+                pts.Add(PointAt(t));
             }
+
+            // We don't go all the way to the end parameter, and
+            // add it here explicitly because rounding errors can
+            // cause small imprecision which accumulates to make
+            // the final parameter slightly more/less than the actual
+            // end parameter.
+            pts.Add(PointAt(this.Domain.Max));
             return new Polyline(pts);
         }
 

--- a/Elements/test/EllipticalArcTests.cs
+++ b/Elements/test/EllipticalArcTests.cs
@@ -29,5 +29,15 @@ namespace Elements.Geometry.Tests
             }
             this.Model.AddElement(new ModelCurve(ellipticalArc, BuiltInMaterials.ZAxis));
         }
+
+        [Fact]
+        public void ToPolyline()
+        {
+            var arc = new EllipticalArc(Vector3.Origin, 1, 2, 10, 20);
+            var p = arc.ToPolyline(10);
+            Assert.Equal(10, p.Segments().Length);
+            Assert.Equal(arc.Start, p.Vertices[0]);
+            Assert.Equal(arc.End, p.Vertices[p.Vertices.Count - 1]);
+        }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- ToPolyline() function doesn't work for EllipticalArc

DESCRIPTION:
- This PR fixes the ToPolyline() function inside the BoundedCurve class so that inheriting classes don't get errors. Including EllipticalArc

TESTING:
- Call the new test Elements.Geometry.Tests.EllipticalArcTests.ToPolyline() or call the ToPolyline() method on any class that inherits BoundedCurve
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1041)
<!-- Reviewable:end -->
