### PR TITLE
Fix: GeometrisElement.Intersection method

### DIFF
--- a/Elements/src/GeometricElement.cs
+++ b/Elements/src/GeometricElement.cs
@@ -213,7 +213,6 @@ namespace Elements
             var graphVertices = new List<Vector3>();
             var graphEdges = new List<List<(int from, int to, int? tag)>>();
 
-            var intersectionPoints = new List<Vector3>();
             var beyondPolygonsList = new List<Polygon>();
 
             if (Representation != null && _csg != null)
@@ -252,7 +251,7 @@ namespace Elements
 
                     var d = csgNormal.Cross(plane.Normal).Unitized();
                     edgeResults.Sort(new DirectionComparer(d));
-                    intersectionPoints.AddRange(edgeResults);
+                    AddToGraph(edgeResults, graphVertices, graphEdges);
                 }
             }
 
@@ -268,42 +267,14 @@ namespace Elements
 
                     if (instance.Representation is SolidRepresentation solidRepresentation)
                     {
-                        intersectionPoints.AddRange(solidRepresentation.CalculateIntersectionPoints(this, plane,
-                            out var beyondPolygonsLocal));
-                        beyondPolygonsList.AddRange(beyondPolygonsLocal);
+                        foreach (var intersection in solidRepresentation.CalculateIntersectionPoints(this, plane,
+                            out var beyondPolygonsLocal))
+                        {
+                            AddToGraph(intersection, graphVertices, graphEdges);
+                        }
                     }
                 }
             }
-
-            if (!intersectionPoints.Any())
-            {
-                return false;
-            }
-
-            // Draw segments through the results and add to the 
-            // half edge graph.
-            for (var j = 0; j < intersectionPoints.Count - 1; j += 2)
-            {
-                // Don't create zero-length edges.
-                if (intersectionPoints[j].IsAlmostEqualTo(intersectionPoints[j + 1]))
-                {
-                    continue;
-                }
-
-                var a = Solid.FindOrCreateGraphVertex(intersectionPoints[j], graphVertices, graphEdges);
-                var b = Solid.FindOrCreateGraphVertex(intersectionPoints[j + 1], graphVertices, graphEdges);
-                var e1 = (a, b, 0);
-                var e2 = (b, a, 0);
-                if (graphEdges[a].Contains(e1) || graphEdges[b].Contains(e2))
-                {
-                    continue;
-                }
-                else
-                {
-                    graphEdges[a].Add(e1);
-                }
-            }
-            // }
 
             var heg = new HalfEdgeGraph2d()
             {
@@ -361,6 +332,33 @@ namespace Elements
             {
                 Debug.WriteLine(ex.Message);
                 return false;
+            }
+        }
+
+        private static void AddToGraph(List<Vector3> intersectionPoints, List<Vector3> graphVertices, List<List<(int from, int to, int? tag)>> graphEdges)
+        {
+            // Draw segments through the results and add to the
+            // half edge graph.
+            for (var j = 0; j < intersectionPoints.Count - 1; j += 2)
+            {
+                // Don't create zero-length edges.
+                if (intersectionPoints[j].IsAlmostEqualTo(intersectionPoints[j + 1]))
+                {
+                    continue;
+                }
+
+                var a = Solid.FindOrCreateGraphVertex(intersectionPoints[j], graphVertices, graphEdges);
+                var b = Solid.FindOrCreateGraphVertex(intersectionPoints[j + 1], graphVertices, graphEdges);
+                var e1 = (a, b, 0);
+                var e2 = (b, a, 0);
+                if (graphEdges[a].Contains(e1) || graphEdges[b].Contains(e2))
+                {
+                    continue;
+                }
+                else
+                {
+                    graphEdges[a].Add(e1);
+                }
             }
         }
 

--- a/Elements/src/Representations/SolidRepresentation.cs
+++ b/Elements/src/Representations/SolidRepresentation.cs
@@ -147,9 +147,9 @@ namespace Elements
         /// <param name="plane">The intersecting plane.</param>
         /// <param name="beyondPolygons">The output collection of the polygons beyond the input plane.</param>
         /// <returns>Returns the collection of intersection points.</returns>
-        public List<Vector3> CalculateIntersectionPoints(GeometricElement element, Plane plane, out List<Polygon> beyondPolygons)
+        public List<List<Vector3>> CalculateIntersectionPoints(GeometricElement element, Plane plane, out List<Polygon> beyondPolygons)
         {
-            var intersectionPoints = new List<Vector3>();
+            var intersectionPoints = new List<List<Vector3>>();
             beyondPolygons = new List<Polygon>();
 
             var csg = SolidOperationUtils.GetFinalCsgFromSolids(SolidOperations, element, true);
@@ -186,7 +186,7 @@ namespace Elements
 
                 var d = csgNormal.Cross(plane.Normal).Unitized();
                 edgeResults.Sort(new DirectionComparer(d));
-                intersectionPoints.AddRange(edgeResults);
+                intersectionPoints.Add(edgeResults);
             }
 
             return intersectionPoints;


### PR DESCRIPTION
BACKGROUND:
I changed the GeometricElement.Intersection method to support RepresentationInstances. I playing with Stocking Plan Exporter and noticed that sometimes pdf contains wrong geometry:
![image](https://github.com/hypar-io/Elements/assets/88673491/6cc5956d-c600-4b8a-86da-fe101cc216d8)


DESCRIPTION:
- The issue was that I have changed prev. this method to collect intersection points and only after that add them to the graph. And for the case below it doesn't work:
![image](https://github.com/hypar-io/Elements/assets/88673491/da6c7a93-4728-462f-86c6-517f6cbbe11e)

I changed method to add points like it was before

TESTING:
![image](https://github.com/hypar-io/Elements/assets/88673491/699a153b-d145-4552-98bb-1f17ce2b4cd2)

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Change log contains data that Intersection method was changed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1042)
<!-- Reviewable:end -->
