### PR TITLE
Added ContentRepresentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - `Profile.ThickenedEdgePolygons`
 - `Elements.MEP`
 - `GeometricElement.RepresentationInstances`
+- `ContentRepresentation`
 
 ### Fixed
 

--- a/Elements/src/CoreModels/ElementRepresentation.cs
+++ b/Elements/src/CoreModels/ElementRepresentation.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using Elements;
 using Elements.Geometry;
 using glTFLoader.Schema;
-using System;
+using Elements.Serialization.glTF;
 
 /// <summary>
 /// The element's representation
@@ -13,13 +13,18 @@ public abstract class ElementRepresentation : SharedObject
     /// Get graphics buffers and other metadata required to modify a GLB.
     /// </summary>
     /// <param name="element">The element with this representation.</param>
-    /// <param name="graphicsBuffers">The list of graphc buffers.</param>
+    /// <param name="graphicsBuffers">The list of graphic buffers.</param>
     /// <param name="id">The buffer id. It will be used as a primitive name.</param>
     /// <param name="mode">The gltf primitive mode</param>
     /// <returns>
-    /// True if there is graphicsbuffers data applicable to add, false otherwise.
+    /// True if there is graphics buffers data applicable to add, false otherwise.
     /// Out variables should be ignored if the return value is false.
     /// </returns>
     public abstract bool TryToGraphicsBuffers(GeometricElement element, out List<GraphicsBuffers> graphicsBuffers,
         out string id, out MeshPrimitive.ModeEnum? mode);
+
+    internal virtual List<NodeExtension> GetNodeExtensions(GeometricElement element)
+    {
+        return new List<NodeExtension>();
+    }
 }

--- a/Elements/src/Representations/ContentRepresentation.cs
+++ b/Elements/src/Representations/ContentRepresentation.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using Elements.Geometry;
+using Elements.Geometry.Solids;
+using Elements.Serialization.glTF;
+using Elements.Utilities;
+using glTFLoader.Schema;
+
+namespace Elements
+{
+    /// <summary>
+    /// Represents an element as a reference to a GLB file location within the content catalog.
+    /// </summary>
+    public class ContentRepresentation : ElementRepresentation
+    {
+        /// <summary>The URI of the glb for this element.</summary>
+        public string GlbLocation { get; set; }
+
+        /// <summary>The bounding box of the content.</summary>
+        public BBox3 BoundingBox { get; set; }
+
+        /// <summary>The scale needed to convert the glb to meters.</summary>
+        public double GlbScaleToMeters { get; set; }
+
+        /// <summary>A vector indicating the direction the source object was originally facing.</summary>
+        public Vector3 SourceDirection { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of ContentRepresentation class
+        /// </summary>
+        /// <param name="boundingBox">The bounding box of the content.</param>
+        /// <param name="glbLocation">The URI of the glb for this element.</param>
+        /// <param name="glbScaleToMeters">The scale needed to convert the glb to meters.</param>
+        /// <param name="sourceDirection">A vector indicating the direction the source object was originally facing.</param>
+        public ContentRepresentation(BBox3 boundingBox, string glbLocation, double glbScaleToMeters, Vector3 sourceDirection)
+        {
+            GlbLocation = glbLocation;
+            BoundingBox = boundingBox;
+            GlbScaleToMeters = glbScaleToMeters;
+            SourceDirection = sourceDirection;
+        }
+
+        /// <inheritdoc/>
+        public override bool TryToGraphicsBuffers(GeometricElement element, out List<GraphicsBuffers> graphicsBuffers, out string id, out MeshPrimitive.ModeEnum? mode)
+        {
+            id = element.Id + "_mesh";
+
+            graphicsBuffers = new List<GraphicsBuffers>();
+            mode = MeshPrimitive.ModeEnum.TRIANGLES;
+
+            if (!BoundingBox.IsValid() || BoundingBox.IsDegenerate())
+            {
+                return false;
+            }
+
+            var bottomProfile = new Geometry.Polygon(new List<Vector3>{
+                            new Vector3(BoundingBox.Min.X - 2, BoundingBox.Min.Y, BoundingBox.Min.Z + 3),
+                            new Vector3(BoundingBox.Min.X - 2, BoundingBox.Max.Y, BoundingBox.Min.Z + 3),
+                            new Vector3(BoundingBox.Max.X - 2, BoundingBox.Max.Y, BoundingBox.Min.Z + 3),
+                            new Vector3(BoundingBox.Max.X - 2, BoundingBox.Min.Y, BoundingBox.Min.Z + 3),
+                        });
+
+            var height = BoundingBox.Max.Z - BoundingBox.Min.Z;
+            var boxSolid = new Extrude(bottomProfile, height, Vector3.ZAxis, false);
+
+            var csg = SolidOperationUtils.GetFinalCsgFromSolids(new List<SolidOperation>() { boxSolid }, element, false);
+
+            if (csg == null)
+            {
+                return false;
+            }
+
+            GraphicsBuffers buffers = null;
+            buffers = csg.Tessellate();
+
+            if (buffers.Vertices.Count == 0)
+            {
+                return false;
+            }
+
+            graphicsBuffers.Add(buffers);
+            return true;
+        }
+
+        internal override List<NodeExtension> GetNodeExtensions(GeometricElement element)
+        {
+            var extensions = base.GetNodeExtensions(element);
+            extensions.Add(new NodeExtension("HYPAR_referenced_content", "contentUrl", GlbLocation));
+            return extensions;
+        }
+    }
+}

--- a/Elements/src/Representations/ContentRepresentation.cs
+++ b/Elements/src/Representations/ContentRepresentation.cs
@@ -18,26 +18,22 @@ namespace Elements
         /// <summary>The bounding box of the content.</summary>
         public BBox3 BoundingBox { get; set; }
 
-        /// <summary>The scale needed to convert the glb to meters.</summary>
-        public double GlbScaleToMeters { get; set; }
-
-        /// <summary>A vector indicating the direction the source object was originally facing.</summary>
-        public Vector3 SourceDirection { get; set; }
+        /// <summary>
+        /// Initializes a new instance of ContentRepresentation class
+        /// </summary>
+        /// <param name="glbLocation">The URI of the glb for this element.</param>
+        /// <param name="boundingBox">The bounding box of the content.</param>
+        public ContentRepresentation(string glbLocation, BBox3 boundingBox)
+        {
+            GlbLocation = glbLocation;
+            BoundingBox = boundingBox;
+        }
 
         /// <summary>
         /// Initializes a new instance of ContentRepresentation class
         /// </summary>
-        /// <param name="boundingBox">The bounding box of the content.</param>
         /// <param name="glbLocation">The URI of the glb for this element.</param>
-        /// <param name="glbScaleToMeters">The scale needed to convert the glb to meters.</param>
-        /// <param name="sourceDirection">A vector indicating the direction the source object was originally facing.</param>
-        public ContentRepresentation(BBox3 boundingBox, string glbLocation, double glbScaleToMeters, Vector3 sourceDirection)
-        {
-            GlbLocation = glbLocation;
-            BoundingBox = boundingBox;
-            GlbScaleToMeters = glbScaleToMeters;
-            SourceDirection = sourceDirection;
-        }
+        public ContentRepresentation(string glbLocation) : this(glbLocation, default) { }
 
         /// <inheritdoc/>
         public override bool TryToGraphicsBuffers(GeometricElement element, out List<GraphicsBuffers> graphicsBuffers, out string id, out MeshPrimitive.ModeEnum? mode)
@@ -49,14 +45,14 @@ namespace Elements
 
             if (!BoundingBox.IsValid() || BoundingBox.IsDegenerate())
             {
-                return false;
+                return true;
             }
 
             var bottomProfile = new Geometry.Polygon(new List<Vector3>{
-                            new Vector3(BoundingBox.Min.X - 2, BoundingBox.Min.Y, BoundingBox.Min.Z + 3),
-                            new Vector3(BoundingBox.Min.X - 2, BoundingBox.Max.Y, BoundingBox.Min.Z + 3),
-                            new Vector3(BoundingBox.Max.X - 2, BoundingBox.Max.Y, BoundingBox.Min.Z + 3),
-                            new Vector3(BoundingBox.Max.X - 2, BoundingBox.Min.Y, BoundingBox.Min.Z + 3),
+                            new Vector3(BoundingBox.Min.X, BoundingBox.Min.Y, BoundingBox.Min.Z),
+                            new Vector3(BoundingBox.Min.X, BoundingBox.Max.Y, BoundingBox.Min.Z),
+                            new Vector3(BoundingBox.Max.X, BoundingBox.Max.Y, BoundingBox.Min.Z),
+                            new Vector3(BoundingBox.Max.X, BoundingBox.Min.Y, BoundingBox.Min.Z),
                         });
 
             var height = BoundingBox.Max.Z - BoundingBox.Min.Z;

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -1292,7 +1292,7 @@ namespace Elements.Serialization.glTF
                         var elementNodeId = NodeUtilities.AddInstanceNode(nodes, element.Transform, element.Id);
                         foreach (var representation in element.RepresentationInstances)
                         {
-                            // get the unique id that contains representation Id and opening Ids 
+                            // get the unique id that contains representation Id and opening Ids
                             int combinedId = representation.GetHashCode(element);
 
                             if (representationsMap.TryGetValue(combinedId, out var mesh))
@@ -1302,6 +1302,10 @@ namespace Elements.Serialization.glTF
                                 {
                                     NodeUtilities.SetRepresentationInfo(nodes[index], representation);
                                     NodeUtilities.SetElementInfo(nodes[index], element.Id);
+                                    foreach (var nodeExtension in representation.Representation.GetNodeExtensions(element))
+                                    {
+                                        AddExtension(gltf, nodes[index], nodeExtension.Name, nodeExtension.Attributes);
+                                    }
                                 }
                             }
                             else if (representation.Representation.TryToGraphicsBuffers(geometricElement, out var graphicsBuffers,
@@ -1327,6 +1331,10 @@ namespace Elements.Serialization.glTF
                                     {
                                         NodeUtilities.SetRepresentationInfo(nodes[index], representation);
                                         NodeUtilities.SetElementInfo(nodes[index], element.Id);
+                                        foreach (var nodeExtension in representation.Representation.GetNodeExtensions(element))
+                                        {
+                                            AddExtension(gltf, nodes[index], nodeExtension.Name, nodeExtension.Attributes);
+                                        }
                                     }
                                 }
                             }

--- a/Elements/src/Serialization/glTF/NodeExtension.cs
+++ b/Elements/src/Serialization/glTF/NodeExtension.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace Elements.Serialization.glTF
+{
+    internal class NodeExtension
+    {
+        public NodeExtension(string name, Dictionary<string, object> attributes)
+        {
+            Name = name;
+            Attributes = attributes;
+        }
+
+        public NodeExtension(string name)
+        {
+            Name = name;
+        }
+
+        public NodeExtension(string name, string attributeName, object attributeValue)
+        {
+            Name = name;
+            Attributes.Add(attributeName, attributeValue);
+        }
+
+        public string Name { get; set; }
+
+        public Dictionary<string, object> Attributes { get; } = new Dictionary<string, object>();
+    }
+}

--- a/Elements/src/Serialization/glTF/NodeUtilities.cs
+++ b/Elements/src/Serialization/glTF/NodeUtilities.cs
@@ -156,6 +156,11 @@ namespace Elements.Serialization.glTF
             return AddNode(nodes, newNode, 0);
         }
 
+        internal static int AddEmptyNode(List<glTFLoader.Schema.Node> nodes, int parentId)
+        {
+            return AddNode(nodes, new Node(), parentId);
+        }
+
         internal static int[] AddInstanceNode(
                                             List<glTFLoader.Schema.Node> nodes,
                                             List<int> meshIds,


### PR DESCRIPTION
BACKGROUND:
ContentElement doesn't work with RepresentationIstances. Explore rewrites Object3D geometry with data from content url. And at this moment it overrides all children nodes

DESCRIPTION:
- ContentRepresentation contains almost all ContentElement properties. The GlbLocation is stored inside glb node as user extension. No Explore changes needed. 

TESTING:
- https://hypar.io/workflows/1b9f4e24-01d4-4ccc-a4f8-460ebeee27b9
- The unicorn function contains Content representation. It's a first content element from the Catalog input
![image](https://github.com/hypar-io/Elements/assets/88673491/1eb253dc-e5f9-4baa-ad0e-fab27fc373eb)

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1044)
<!-- Reviewable:end -->
