### PR TITLE
Fix Vector3.DistanceTo(Polygon). Add custom implementations of ToPolyline (issue #495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - `Polyline.Frames` now works correctly with `startSetbackDistance` and `endSetbackDistance` parameters.
 - `Polygon.Frames` now works correctly with `startSetbackDistance` and `endSetbackDistance` parameters.
 - `BoundedCurve.ToPolyline` now works correctly for `EllipticalArc` class.
+- `Vector3.DistanceToDistanceTo(Polygon polygon, out Vector3 closestPoint)` now also checks the last edge of the polygon.
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - `Profile.ThickenedEdgePolygons`
 - `Elements.MEP`
 - `GeometricElement.RepresentationInstances`
+- Custom implementations of `ToPolyline` for `IndexedPolycurve`, `Polyline` and `Polygon`.
 
 ### Fixed
 

--- a/Elements/src/Geometry/BoundedCurve.cs
+++ b/Elements/src/Geometry/BoundedCurve.cs
@@ -87,9 +87,18 @@ namespace Elements.Geometry
         /// <summary>
         /// Create a polyline through a set of points along the curve.
         /// </summary>
+        /// <returns>A polyline.</returns>
+        public virtual Polyline ToPolyline()
+        {
+            return ToPolyline(10);
+        }
+
+        /// <summary>
+        /// Create a polyline through a set of points along the curve.
+        /// </summary>
         /// <param name="divisions">The number of divisions of the curve.</param>
         /// <returns>A polyline.</returns>
-        public virtual Polyline ToPolyline(int divisions = 10)
+        public virtual Polyline ToPolyline(int divisions)
         {
             var pts = new List<Vector3>(divisions + 1);
             var step = this.Domain.Length / divisions;

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -699,7 +699,6 @@ namespace Elements.Geometry
         /// This can lead to highly distorted result.</param>
         /// <returns>A polyline.</returns>
         public override Polyline ToPolyline(int divisions = 10)
-        public override Polyline ToPolyline(int divisions = 10)
         {
             //
             if (divisions < _curves.Count)

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -692,11 +692,13 @@ namespace Elements.Geometry
         /// <summary>
         /// Create a polyline through a set of points along the curve.
         /// End points of curves are added first and then non straight curves are divided uniformly.
-        /// If number of divisions is less than number of curves - points are uniformly distributed though whole domain.
+        /// If number of divisions is less than number of curves - points are uniformly distributed
+        /// though whole domain, deviating heavily from original shape.
         /// </summary>
         /// <param name="divisions">The number of divisions of the curve. 
         /// This can lead to highly distorted result.</param>
         /// <returns>A polyline.</returns>
+        public override Polyline ToPolyline(int divisions = 10)
         public override Polyline ToPolyline(int divisions = 10)
         {
             //
@@ -710,6 +712,8 @@ namespace Elements.Geometry
             var numArcs = _curves.Count(c => !(c is Line));
             if (numArcs > 0)
             {
+                // If polycurve consists of lines and curves - excess divisions are uniformly distributed
+                // among curves as dividing the lines wont add any new details in Polyline.
                 foreach (var curve in _curves)
                 {
                     if (!(curve is Line))
@@ -730,7 +734,7 @@ namespace Elements.Geometry
             }
             else
             {
-                //If polycurve consists only of lines - divisions are distributed uniformly among them.
+                // If polycurve consists only of lines - divisions are distributed uniformly among them.
                 var linesLeft = _curves.Count;
                 foreach (var curve in _curves)
                 {

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -670,7 +670,7 @@ namespace Elements.Geometry
         /// Create a polyline through curves of IndexedPolycurve, interpolating any curves that are not lines.
         /// </summary>
         /// <returns>A polyline.</returns>
-        public virtual Polyline ToPolyline()
+        public override Polyline ToPolyline()
         {
             List<Vector3> vertices = new List<Vector3>();
             foreach (var curve in _curves)
@@ -698,7 +698,7 @@ namespace Elements.Geometry
         /// <param name="divisions">The number of divisions of the curve. 
         /// This can lead to highly distorted result.</param>
         /// <returns>A polyline.</returns>
-        public override Polyline ToPolyline(int divisions = 10)
+        public override Polyline ToPolyline(int divisions)
         {
             //
             if (divisions < _curves.Count)

--- a/Elements/src/Geometry/IndexedPolycurve.cs
+++ b/Elements/src/Geometry/IndexedPolycurve.cs
@@ -667,6 +667,91 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Create a polyline through curves of IndexedPolycurve, interpolating any curves that are not lines.
+        /// </summary>
+        /// <returns>A polyline.</returns>
+        public virtual Polyline ToPolyline()
+        {
+            List<Vector3> vertices = new List<Vector3>();
+            foreach (var curve in _curves)
+            {
+                if (curve is Line)
+                {
+                    vertices.Add(curve.Start);
+                }
+                else
+                {
+                    var pl = curve.ToPolyline();
+                    vertices.AddRange(pl.Vertices.Take(pl.Vertices.Count - 1));
+                }
+            }
+            vertices.Add(End);
+            return new Polyline(vertices);
+        }
+
+        /// <summary>
+        /// Create a polyline through a set of points along the curve.
+        /// End points of curves are added first and then non straight curves are divided uniformly.
+        /// If number of divisions is less than number of curves - points are uniformly distributed though whole domain.
+        /// </summary>
+        /// <param name="divisions">The number of divisions of the curve. 
+        /// This can lead to highly distorted result.</param>
+        /// <returns>A polyline.</returns>
+        public override Polyline ToPolyline(int divisions = 10)
+        {
+            //
+            if (divisions < _curves.Count)
+            {
+                return base.ToPolyline(divisions);
+            }
+
+            double extraSplits = divisions - _curves.Count;
+            List<Vector3> vertices = new List<Vector3>(divisions + 1) { Start };
+            var numArcs = _curves.Count(c => !(c is Line));
+            if (numArcs > 0)
+            {
+                foreach (var curve in _curves)
+                {
+                    if (!(curve is Line))
+                    {
+                        var splitsPerArc = Math.Ceiling(1.0d * extraSplits / numArcs);
+                        var splits = Math.Min(splitsPerArc, extraSplits);
+                        var step = curve.Domain.Length / (splitsPerArc + 1);
+                        for (int i = 1; i <= splitsPerArc; i++)
+                        {
+                            var t = curve.Domain.Min + i * step;
+                            vertices.Add(curve.PointAt(t));
+                        }
+                        extraSplits -= splitsPerArc;
+                        numArcs--;
+                    }
+                    vertices.Add(curve.End);
+                }
+            }
+            else
+            {
+                //If polycurve consists only of lines - divisions are distributed uniformly among them.
+                var linesLeft = _curves.Count;
+                foreach (var curve in _curves)
+                {
+                    var splitsPerLine = Math.Ceiling(1.0d * extraSplits / linesLeft);
+                    var splits = Math.Min(splitsPerLine, extraSplits);
+                    var step = curve.Domain.Length / (splitsPerLine + 1);
+                    for (int i = 1; i <= splitsPerLine; i++)
+                    {
+                        var t = curve.Domain.Min + i * step;
+                        vertices.Add(curve.PointAt(t));
+                    }
+                    vertices.Add(curve.End);
+                    extraSplits -= splitsPerLine;
+                    linesLeft--;
+                }
+            }
+            vertices.Add(End);
+            return new Polyline(vertices);
+        }
+
+        /// <summary>
         /// Get the enumerator for this indexed polycurve.
         /// </summary>
         /// <returns>An enumerator of bounded curves.</returns>

--- a/Elements/src/Geometry/Polygon.cs
+++ b/Elements/src/Geometry/Polygon.cs
@@ -1824,6 +1824,18 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Create a polyline through vertices of a polygon.
+        /// </summary>
+        /// <returns>A polyline.</returns>
+        public override Polyline ToPolyline()
+        {
+            var vertices = new List<Vector3>(Vertices.Count + 1);
+            vertices.AddRange(Vertices);
+            vertices.Add(End);
+            return new Polyline(vertices);
+        }
+
+        /// <summary>
         /// Reverse the direction of a polygon.
         /// </summary>
         /// <returns>Returns a new Polygon whose vertices are reversed.</returns>

--- a/Elements/src/Geometry/Polyline.cs
+++ b/Elements/src/Geometry/Polyline.cs
@@ -85,6 +85,15 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Create a copy of a polyline.
+        /// </summary>
+        /// <returns>A polyline.</returns>
+        public override Polyline ToPolyline()
+        {
+            return new Polyline(Vertices.ToList());
+        }
+
+        /// <summary>
         /// Get the transform at the specified parameter along the polyline.
         /// </summary>
         /// <param name="u">The parameter on the polygon between 0.0 and length.</param>

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -523,7 +523,7 @@ namespace Elements.Geometry
             }
             else
             {
-                return this.DistanceTo(new Polyline(polygon.Vertices), out closestPoint);
+                return this.DistanceTo(polygon as Polyline, out closestPoint);
             }
         }
 

--- a/Elements/test/IndexedPolyCurveTests.cs
+++ b/Elements/test/IndexedPolyCurveTests.cs
@@ -227,5 +227,64 @@ namespace Elements.Tests
             Assert.Equal(1.25, parameters[0]);
             Assert.Equal(1.75, parameters[1]);
         }
+
+        [Fact]
+        public void ToPolyyline()
+        {
+            var arc0 = new Arc(new Vector3(2.5, 5), 2.5, 0, 180);
+            var arc1 = new Arc(new Vector3(-2.5, 0), 2.5, 360, 180);
+            var a = new Vector3(5, 0, 0);
+            var b = new Vector3(5, 5, 0);
+            var c = arc0.Mid();
+            var d = new Vector3(0, 5, 0);
+            var e = Vector3.Origin;
+            var f = arc1.Mid();
+            var g = new Vector3(-5, 0, 0);
+            var vertices = new[] { a, b, c, d, e, f, g };
+            var indices = new[]{
+                new[]{0,1},
+                new[]{1,2,3},
+                new[]{3,4},
+                new[]{4,5,6}
+            };
+            var pc = new IndexedPolycurve(vertices, indices);
+
+            var pl = pc.ToPolyline(indices.Count());
+            Assert.Equal(5, pl.Vertices.Count);
+            Assert.True(a.IsAlmostEqualTo(pl.Vertices[0]));
+            Assert.True(b.IsAlmostEqualTo(pl.Vertices[1]));
+            Assert.True(d.IsAlmostEqualTo(pl.Vertices[2]));
+            Assert.True(e.IsAlmostEqualTo(pl.Vertices[3]));
+            Assert.True(g.IsAlmostEqualTo(pl.Vertices.Last()));
+
+            pl = pc.ToPolyline();
+            Assert.Equal(arc0.ToPolyline().Vertices.Count + arc1.ToPolyline().Vertices.Count + 1,
+                         pl.Vertices.Count);
+            Assert.True(a.IsAlmostEqualTo(pl.Vertices[0]));
+            Assert.True(b.IsAlmostEqualTo(pl.Vertices[1]));
+            Assert.True(g.IsAlmostEqualTo(pl.Vertices.Last()));
+
+            pl = pc.ToPolyline(9);
+            Assert.Equal(10, pl.Vertices.Count);
+            Assert.True(a.IsAlmostEqualTo(pl.Vertices[0]));
+            Assert.True(b.IsAlmostEqualTo(pl.Vertices[1]));
+            Assert.True(arc0.PointAtNormalized(0.25).IsAlmostEqualTo(pl.Vertices[2]));
+            Assert.True(arc0.PointAtNormalized(0.50).IsAlmostEqualTo(pl.Vertices[3]));
+            Assert.True(arc0.PointAtNormalized(0.75).IsAlmostEqualTo(pl.Vertices[4]));
+            Assert.True(d.IsAlmostEqualTo(pl.Vertices[5]));
+            Assert.True(e.IsAlmostEqualTo(pl.Vertices[6]));
+            Assert.True(arc1.PointAtNormalized(1.0 / 3).IsAlmostEqualTo(pl.Vertices[7]));
+            Assert.True(arc1.PointAtNormalized(2.0 / 3).IsAlmostEqualTo(pl.Vertices[8]));
+            Assert.True(g.IsAlmostEqualTo(pl.Vertices[9]));
+
+            pl = pc.ToPolyline(5);
+            Assert.Equal(6, pl.Vertices.Count);
+            Assert.True(a.IsAlmostEqualTo(pl.Vertices[0]));
+            Assert.True(b.IsAlmostEqualTo(pl.Vertices[1]));
+            Assert.True(arc0.PointAtNormalized(0.50).IsAlmostEqualTo(pl.Vertices[2]));
+            Assert.True(d.IsAlmostEqualTo(pl.Vertices[3]));
+            Assert.True(e.IsAlmostEqualTo(pl.Vertices[4]));
+            Assert.True(g.IsAlmostEqualTo(pl.Vertices[5]));
+        }
     }
 }

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -2391,5 +2391,46 @@ namespace Elements.Geometry.Tests
             Assert.Equal((1, 2), frames[3].Origin);
             Assert.True(Vector3.XAxis.IsParallelTo(frames[3].ZAxis));
         }
+
+        [Fact]
+        public void ToPolyline()
+        {
+            var L = Polygon.L(10, 15, 5);
+            var pl = L.ToPolyline();
+            Assert.Equal(L.Vertices.Count + 1, pl.Vertices.Count);
+            for (int i = 0; i < L.Vertices.Count; i++)
+            {
+                Assert.True(L.Vertices[i].IsAlmostEqualTo(pl.Vertices[i]));
+            }
+            Assert.True(pl.Vertices.Last().IsAlmostEqualTo(L.End));
+
+            pl = L.ToPolyline(4);
+            var segments = L.Segments();
+            Assert.Equal(5, pl.Vertices.Count);
+            Assert.True(L.Start.IsAlmostEqualTo(pl.Vertices[0]));
+            Assert.True(segments[1].Mid().IsAlmostEqualTo(pl.Vertices[1]));
+            Assert.True(L.Vertices[3].IsAlmostEqualTo(pl.Vertices[2]));
+            Assert.True(segments[4].Mid().IsAlmostEqualTo(pl.Vertices[3]));
+            Assert.True(L.End.IsAlmostEqualTo(pl.Vertices[4]));
+
+            pl = L.ToPolyline(13);
+            segments = L.Segments();
+            Assert.Equal(pl.Length(), L.Length());
+            Assert.Equal(14, pl.Vertices.Count);
+            Assert.True(L.Start.IsAlmostEqualTo(pl.Vertices[0]));
+            Assert.True(segments[0].PointAtNormalized(1.0 / 3).IsAlmostEqualTo(pl.Vertices[1]));
+            Assert.True(segments[0].PointAtNormalized(2.0 / 3).IsAlmostEqualTo(pl.Vertices[2]));
+            Assert.True(segments[1].Start.IsAlmostEqualTo(pl.Vertices[3]));
+            Assert.True(segments[1].Mid().IsAlmostEqualTo(pl.Vertices[4]));
+            Assert.True(segments[2].Start.IsAlmostEqualTo(pl.Vertices[5]));
+            Assert.True(segments[2].Mid().IsAlmostEqualTo(pl.Vertices[6]));
+            Assert.True(segments[3].Start.IsAlmostEqualTo(pl.Vertices[7]));
+            Assert.True(segments[3].Mid().IsAlmostEqualTo(pl.Vertices[8]));
+            Assert.True(segments[4].Start.IsAlmostEqualTo(pl.Vertices[9]));
+            Assert.True(segments[4].Mid().IsAlmostEqualTo(pl.Vertices[10]));
+            Assert.True(segments[5].Start.IsAlmostEqualTo(pl.Vertices[11]));
+            Assert.True(segments[5].Mid().IsAlmostEqualTo(pl.Vertices[12]));
+            Assert.True(L.End.IsAlmostEqualTo(pl.Vertices[13]));
+        }
     }
 }

--- a/Elements/test/VectorTests.cs
+++ b/Elements/test/VectorTests.cs
@@ -596,6 +596,19 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void DistanceToL()
+        {
+            var L = Polygon.L(10, 15, 5);
+            var position = new Vector3(-1, 3);
+            var distance = position.DistanceTo(L.ToPolyline(), out var closestA);
+            var distancePolygon = position.DistanceTo(L, out var closestB);
+            Assert.Equal(1, distance);
+            Assert.Equal(1, distancePolygon);
+            Assert.Equal(new Vector3(0, 3), closestA);
+            Assert.Equal(new Vector3(0, 3), closestB);
+        }
+
+        [Fact]
         public void PointsAreCoplanarWithinTolerance()
         {
             // Test with three points that are collinear.


### PR DESCRIPTION
BACKGROUND:
- This is fix for the issue https://github.com/hypar-io/Elements/issues/945
- Distance function was not including closing edge of Polygon.
- ToPolyline function by default interpolates Polygon by 10 uniformly placed segments (11 vertices) cutting edges in the process.

DESCRIPTION:
- Fixed DisntanceTo function by casting Polygon to Polyline instead of creating new Polyline.
- Created set of default implementations for `ToPolyline` function for `IndexedPolycurve`, `Polyline` and `Polygon`.
a) In `Polyline` and `Polygon` they produce Polyline with the same points as original object instead of dividing by 10 segments.
b) In `IndexedPolycurve` lines are always  represented by 2 points, curve are interpolated by their corresponding ToPolyline function.
- Created custom implementation for  `IndexedPolycurve` with divisions parameter. End points of curves are added first and then non straight curves are divided uniformly. If number of divisions is less than number of curves - points are uniformly distributed though whole domain, deviating heavily from original shape.

TESTING:
- Added new tests for DistanceTo and ToPolyline.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.