### PR TITLE
Add edge intersection test to Contains3D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 - `Polyline.Frames` now works correctly with `startSetbackDistance` and `endSetbackDistance` parameters.
 - `Polygon.Frames` now works correctly with `startSetbackDistance` and `endSetbackDistance` parameters.
 - `BoundedCurve.ToPolyline` now works correctly for `EllipticalArc` class.
-
+- `Polygon.Contains3D` now performs edge intersection test.
 
 ### Changed
 - `GltfExtensions.UseReferencedContentExtension` is now true by default.

--- a/Elements/test/PolygonTests.cs
+++ b/Elements/test/PolygonTests.cs
@@ -241,6 +241,32 @@ namespace Elements.Geometry.Tests
         }
 
         [Fact]
+        public void Contains3d()
+        {
+            var p0 = new Polygon(new Vector3[]
+            {
+                (0, 0, 2),
+                (0, 0, 10),
+                (2, 0, 10),
+                (2, 0, 2),
+                (8, 0, 2),
+                (8, 0, 10),
+                (10, 0, 10),
+                (10, 0, 0)
+            });
+
+            var p1 = new Polygon(new Vector3[]
+            {
+                (1, 0, 6),
+                (1, 0, 8),
+                (9.5, 0, 7.5),
+                (9, 0, 6)
+            });
+
+            Assert.False(p0.Contains3D(p1));
+        }
+
+        [Fact]
         public void Disjoint()
         {
             var v1 = new Vector3();


### PR DESCRIPTION
BACKGROUND:
- This PR fixes issue https://github.com/hypar-io/Elements/issues/767

DESCRIPTION:
- Covers function already had needed logic implemented. Since the only difference between them is how they treat containment, this logic is reused for Contains3D.
- Implementation of Cover is moved into shared static Contains function.

TESTING:
- Added Contains3d test to PolygonTests.

FUTURE WORK:
- There are inconsistency between different Covers and Contains functions described in the issue. New issue will be created to address this. 

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.
