### PR TITLE
call update representations on child elements as well

### DIFF
--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -37,9 +37,8 @@ namespace Elements
 
         /// <summary>
         /// Collection of subelements from shared objects or RepresentationInstances (e.g. SolidRepresentation.Profile or RepresentationInstance.Material).
-        /// 
         /// We do not serialize shared objects to json, but we do include them in other formats like gltf.
-        /// This collection contains all elements referenced directly by RepresentationInstances, such as Materials and Profiles. 
+        /// This collection contains all elements referenced directly by RepresentationInstances, such as Materials and Profiles.
         /// These objects affect representation appearance and may be used at glTF creation time.
         /// </summary>
         [JsonIgnore]
@@ -136,6 +135,10 @@ namespace Elements
                 {
                     if (!this.Elements.ContainsKey(e.Id))
                     {
+                        if (updateElementRepresentations && e is GeometricElement geoE)
+                        {
+                            geoE.UpdateRepresentations();
+                        }
                         this.Elements.Add(e.Id, e);
                     }
                 }

--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -110,14 +110,7 @@ namespace Elements
                 return;
             }
 
-            // Some elements compute profiles and transforms
-            // during UpdateRepresentation. Call UpdateRepresentation
-            // here to ensure these values are correct in the JSON.
-
-            // TODO: This is really expensive. This should be removed
-            // when all internal types have been updated to not create elements
-            // during UpdateRepresentation. This is now possible because
-            // geometry operations are reactive to changes in their properties.
+            // Function wrapper code no longer calls UpdateRepresentations, so we need to do it here.
             if (updateElementRepresentations && element is GeometricElement geo)
             {
                 geo.UpdateRepresentations();
@@ -135,6 +128,8 @@ namespace Elements
                 {
                     if (!this.Elements.ContainsKey(e.Id))
                     {
+                        // Because function wrapper code doesn't called UpdateRepresentations any more
+                        // we need to call it her for all nested elements while they are added.
                         if (updateElementRepresentations && e is GeometricElement geoE)
                         {
                             geoE.UpdateRepresentations();

--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -128,8 +128,8 @@ namespace Elements
                 {
                     if (!this.Elements.ContainsKey(e.Id))
                     {
-                        // Because function wrapper code doesn't called UpdateRepresentations any more
-                        // we need to call it her for all nested elements while they are added.
+                        // Because function wrapper code doesn't call UpdateRepresentations any more
+                        // we need to call it here for all nested elements while they are added.
                         if (updateElementRepresentations && e is GeometricElement geoE)
                         {
                             geoE.UpdateRepresentations();

--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -270,8 +270,10 @@ namespace Elements
         /// </summary>
         public string ToJson()
         {
-            // The arguments here are meant to match the default arguments of the ToJson(bool, bool) method above.
-            return ToJson(false, true);
+            // By default we don't want to update representations because the UpdateRepresentation
+            // method is called during function adding.  Setting this to false makes the behavior
+            // match our function wrapping code behavior.
+            return ToJson(false, true, false);
         }
 
         /// <summary>


### PR DESCRIPTION
BACKGROUND:
- Content elements didn't show up with latest elements release, problem starting at this PR #1017 where we stopped calling UpdateRepresentations a second time.  This meant content elements didn't have representations, which means they don't have an object in the threeJS scene, which means we can't replace them with the glb mesh.

DESCRIPTION:
- Call update representation on all sub elements that are automatically added that are geometric elements.

TESTING:
- use this alpha with a function that makes content.
  
FUTURE WORK:
- Some content was mysteriously appearing still in the SpaceTypes function, knowing why this happened might reveal other inconsistencies in when representations exist or don't

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1052)
<!-- Reviewable:end -->
