### PR TITLE
don't process solid if no csg

### DIFF
--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -1623,7 +1623,7 @@ namespace Elements.Serialization.glTF
                 return -1;
             }
 
-            if (geometricElement.Representation != null)
+            if (geometricElement.Representation != null && geometricElement._csg != null)
             {
                 meshId = ProcessSolidsAsCSG(geometricElement,
                                     e.Id.ToString(),


### PR DESCRIPTION
BACKGROUND:
- I wasn't getting any stuff when making elbows because I had a non-null representation that was empty. this caused errors during the code for getting render data for element.  we previously wouldn't notice these errors because we wouldn't expect to see any geometry, but now with the alternative path of RepresentationInstances we might expect to see geometry in these cases.

DESCRIPTION:
- add a _csg==null check

TESTING:
- no behavior change.
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1055)
<!-- Reviewable:end -->
