### PR TITLE
Allow rotation of the ContentConfigurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - `ContentRepresentation`
 - `Elements.Door`
 - `ComponentBase.UseRepresentationInstances` - an option flag to make generating fitting models faster/smaller.
+- `ContentConfiguration.AllowRotatation`
 
 ### Fixed
 

--- a/Elements.Components/src/SpaceConfiguration.cs
+++ b/Elements.Components/src/SpaceConfiguration.cs
@@ -135,6 +135,11 @@ namespace Elements.Components
         public double Depth => this.CellBoundary.Depth;
 
         /// <summary>
+        /// Allow rotation of the configuration
+        /// </summary>
+        public bool AllowRotatation { get; set; }
+
+        /// <summary>
         /// Create a set of element instances from this configuration.
         /// </summary>
         /// <param name="t">The transform to apply to the configuration.</param>


### PR DESCRIPTION
BACKGROUND:
- Configurations could not be rotated, so they were not selected unless they clearly fell within the width and length dimensions of the room

DESCRIPTION:
- This PR adds the AllowRotatation property to the ContentConfiguration class. This will allow to understand that the configuration can be rotated if needed

TESTING:
- To fill the room with furniture, use the "Space Type" function. When filling the rooms, the version of the configuration rotated by 90 degrees should be taken into account (depends on the PR: https://github.com/hypar-io/HyparSpace/pull/73)
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1060)
<!-- Reviewable:end -->
