### PR TITLE
fix mesh / topo intersection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - `Polyline.TransformAt` returns correct transformations when parameter on domain is provided.
 - `IndexedPolycurve` constructor that takes list of `BoundedCurve` now produces `CurveIndices` that share vertices and are withing index range. This means `IndexedPolyline.TransformedPolyline` preserves `CurveIndicies` on new `IndexedPolyline`.
 - `BoundedCurve.ToPolyline` now works correctly for `EllipticalArc` class.
+- `Ray.Intersects(Topography)` and `Ray.Intersects(Mesh)` would sometimes return a different intersection than the closest one.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - `IndexedPolycurve` constructor that takes list of `BoundedCurve` now produces `CurveIndices` that share vertices and are withing index range. This means `IndexedPolyline.TransformedPolyline` preserves `CurveIndicies` on new `IndexedPolyline`.
 - `BoundedCurve.ToPolyline` now works correctly for `EllipticalArc` class.
 - `Ray.Intersects(Topography)` and `Ray.Intersects(Mesh)` would sometimes return a different intersection than the closest one.
+- `Ray.Intersects(Topography)` now considers the topography's transform.
 
 ### Changed
 

--- a/Elements/src/Geometry/Mesh.cs
+++ b/Elements/src/Geometry/Mesh.cs
@@ -259,7 +259,8 @@ Triangles:{Triangles.Count}";
         public void RemoveTriangle(Triangle face)
         {
             this.Triangles.Remove(face);
-            foreach(var vert in face.Vertices) {
+            foreach (var vert in face.Vertices)
+            {
                 vert.Triangles.Remove(face);
             }
         }
@@ -450,10 +451,10 @@ Triangles:{Triangles.Count}";
         }
 
         /// <summary>
-        /// Does the provided ray intersect this mesh mesh?
+        /// Does the provided ray intersect this mesh?
         /// </summary>
         /// <param name="ray">The Ray to intersect.</param>
-        /// <param name="intersection">The location of intersection.</param>
+        /// <param name="intersection">The location of the closest intersection.</param>
         /// <returns>True if an intersection result occurs.
         /// False if no intersection occurs.</returns>
         public bool Intersects(Ray ray, out Vector3 intersection)
@@ -461,14 +462,20 @@ Triangles:{Triangles.Count}";
             var nearbyVertices = GetOctree().GetNearby(ray, _maxTriangleSize).ToList();
             var nearbyTriangles = nearbyVertices.SelectMany(v => v.Triangles).Distinct();
             intersection = default;
+            var closest = double.MaxValue;
             foreach (var t in nearbyTriangles)
             {
-                if (ray.Intersects(t, out intersection))
+                if (ray.Intersects(t, out var triangleIntersection))
                 {
-                    return true;
+                    var d = triangleIntersection.DistanceTo(ray.Origin);
+                    if (d < closest)
+                    {
+                        intersection = triangleIntersection;
+                        closest = d;
+                    }
                 }
             }
-            return false;
+            return closest < double.MaxValue;
         }
 
         private double SignedVolumeOfTriangle(Triangle t)

--- a/Elements/src/Geometry/Ray.cs
+++ b/Elements/src/Geometry/Ray.cs
@@ -236,7 +236,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Does this ray intersect the provided topography? Note that the Topography's transform is not considered. 
+        /// Does this ray intersect the provided topography?
         /// </summary>
         /// <param name="topo">The topography.</param>
         /// <param name="result">The location of intersection.</param>
@@ -244,7 +244,15 @@ namespace Elements.Geometry
         /// False if no intersection occurs.</returns>
         public bool Intersects(Topography topo, out Vector3 result)
         {
-            return Intersects(topo.Mesh, out result);
+            var transform = topo.Transform;
+            var inverse = transform.Inverted();
+            var transformedRay = new Ray(inverse.OfPoint(Origin), Direction);
+            var intersects = transformedRay.Intersects(topo.Mesh, out result);
+            if (intersects)
+            {
+                result = transform.OfPoint(result);
+            }
+            return intersects;
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Ray.cs
+++ b/Elements/src/Geometry/Ray.cs
@@ -236,7 +236,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Does this ray intersect the provided topography?
+        /// Does this ray intersect the provided topography? Note that the Topography's transform is not considered. 
         /// </summary>
         /// <param name="topo">The topography.</param>
         /// <param name="result">The location of intersection.</param>

--- a/Elements/test/RayTests.cs
+++ b/Elements/test/RayTests.cs
@@ -63,43 +63,34 @@ namespace Elements.Tests
         {
             this.Name = "RayIntersectTopo";
 
-            var elevations = new double[25];
+            var elevations = new double[100];
 
             int e = 0;
-            for (var x = 0; x < 5; x++)
+            for (var x = 0; x < 10; x++)
             {
-                for (var y = 0; y < 5; y++)
+                for (var y = 0; y < 10; y++)
                 {
-                    elevations[e] = Math.Sin(((double)x / 5.0) * Math.PI) * 10;
+                    elevations[e] = Math.Sin(((double)x / 10.0) * Math.PI) * 5;
                     e++;
                 }
             }
-            var topo = new Topography(Vector3.Origin, 4, elevations);
+            var topo = new Topography(Vector3.Origin, 10, elevations);
+            topo.Material = new Material("topo", new Color(0.5, 0.5, 0.5, 0.5));
             this.Model.AddElement(topo);
 
-            var modelPoints = new ModelPoints(new List<Vector3>(), new Material("begin", Colors.Blue));
-            this.Model.AddElement(modelPoints);
-            foreach (var t in topo.Mesh.Triangles)
+            var ray = new Ray(Vector3.Origin, Vector3.ZAxis);
+            this.Model.AddElement(ModelCurveFromRay(ray));
+            Assert.True(ray.Intersects(topo.Mesh, out var result));
+            for (int i = 1; i < 9; i++)
             {
-                var c = Center(t);
-                var o = new Vector3(c.X, c.Y);
-                modelPoints.Locations.Add(o);
-
-                var ray = new Ray(o, Vector3.ZAxis);
-
-                Vector3 xsect;
-                if (ray.Intersects(t, out xsect))
+                for (int j = 1; j < 9; j++)
                 {
-                    try
-                    {
-                        var l = new Line(o, xsect);
-                        var ml = new ModelCurve(l);
-                        this.Model.AddElement(ml);
-                    }
-                    catch
-                    {
-                        continue;
-                    }
+                    var newRay = new Ray(new Vector3(i, j, 40), Vector3.ZAxis.Negate());
+                    var intersect = newRay.Intersects(topo.Mesh, out var result2);
+                    Assert.True(intersect);
+                    var line = new Line(result2, newRay.Origin);
+                    Model.AddElement(new ModelCurve(line, BuiltInMaterials.XAxis));
+                    Assert.True(result2.Z > 0 && result2.Z < 40);
                 }
             }
         }

--- a/Elements/test/RayTests.cs
+++ b/Elements/test/RayTests.cs
@@ -7,6 +7,8 @@ using Xunit;
 using Xunit.Abstractions;
 using System.Diagnostics;
 using Vertex = Elements.Geometry.Vertex;
+using Xunit.Sdk;
+using System.Linq;
 
 namespace Elements.Tests
 {
@@ -74,23 +76,23 @@ namespace Elements.Tests
                     e++;
                 }
             }
-            var topo = new Topography(Vector3.Origin, 10, elevations);
-            topo.Material = new Material("topo", new Color(0.5, 0.5, 0.5, 0.5));
+            var topo = new Topography(Vector3.Origin, 10, elevations)
+            {
+                Material = new Material("topo", new Color(0.5, 0.5, 0.5, 0.5)),
+                Transform = new Transform(0, 0, 2)
+            };
             this.Model.AddElement(topo);
-
-            var ray = new Ray(Vector3.Origin, Vector3.ZAxis);
-            this.Model.AddElement(ModelCurveFromRay(ray));
-            Assert.True(ray.Intersects(topo.Mesh, out var result));
+            this.Model.AddElements(new Transform().ToModelCurves());
             for (int i = 1; i < 9; i++)
             {
                 for (int j = 1; j < 9; j++)
                 {
                     var newRay = new Ray(new Vector3(i, j, 40), Vector3.ZAxis.Negate());
-                    var intersect = newRay.Intersects(topo.Mesh, out var result2);
+                    var intersect = newRay.Intersects(topo, out var result2);
                     Assert.True(intersect);
                     var line = new Line(result2, newRay.Origin);
                     Model.AddElement(new ModelCurve(line, BuiltInMaterials.XAxis));
-                    Assert.True(result2.Z > 0 && result2.Z < 40);
+                    Assert.True(result2.Z > elevations.Min() + 2 && result2.Z < elevations.Max() + 2);
                 }
             }
         }


### PR DESCRIPTION
BACKGROUND:
- Mesh/Ray and Topo/Ray intersection would return the wrong point for closed volumes — it was only returning the first intersection, rather than the nearest, so it was impossible to (e.g.) project a ray down onto a topography and get the location of the intersection. 
- The `RayIntersectTopo` test got blown away by [this PR](https://github.com/hypar-io/Elements/pull/212) with what appears to be some temporary code — it switched from testing `Ray.Intersects(Topography)` to testing `Ray.Intersects(Triangle)`.
![image](https://github.com/hypar-io/Elements/assets/31935763/1ed2a6d5-5597-458b-a845-0ca0fd0606c9)

DESCRIPTION:
- Checks all near triangles, rather than aborting after the first one.
- Fixes the `RayIntersectsTopo` test

REQUIRED:
- [X] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1062)
<!-- Reviewable:end -->
