### PR TITLE
rename and make properties accessible

### DIFF
--- a/Elements.Serialization.IFC/src/IFCElementExtensions.cs
+++ b/Elements.Serialization.IFC/src/IFCElementExtensions.cs
@@ -274,8 +274,8 @@ namespace Elements.Serialization.IFC
                 localPlacement,
                 shape,
                 null,
-                new IfcPositiveLengthMeasure(new IfcLengthMeasure(door.ClearHeight)),
-                new IfcPositiveLengthMeasure(new IfcLengthMeasure(door.ClearWidth)),
+                new IfcPositiveLengthMeasure(new IfcLengthMeasure(door.DoorHeight)),
+                new IfcPositiveLengthMeasure(new IfcLengthMeasure(door.DoorWidth)),
                 IfcDoorTypeEnum.DOOR,
                 door.GetIfcDoorTypeOperation(),
                 null

--- a/Elements.Serialization.IFC/src/IFCToHypar/Converters/FromIfcDoorConverter.cs
+++ b/Elements.Serialization.IFC/src/IFCToHypar/Converters/FromIfcDoorConverter.cs
@@ -37,7 +37,7 @@ namespace Elements.Serialization.IFC.IFCToHypar.Converters
             //var wall = GetWallFromDoor(ifcDoor, allWalls);
             var doorWidth = (IfcLengthMeasure)ifcDoor.OverallWidth;
             var doorHeight = (IfcLengthMeasure)ifcDoor.OverallHeight;
-            var doorThickness = 2 * 0.0254;
+            var doorThickness = Door.DEFAULT_DOOR_THICKNESS;
 
             var result = new Door(doorWidth,
                                   doorHeight,

--- a/Elements.Serialization.IFC/src/IFCToHypar/Converters/FromIfcDoorConverter.cs
+++ b/Elements.Serialization.IFC/src/IFCToHypar/Converters/FromIfcDoorConverter.cs
@@ -37,10 +37,11 @@ namespace Elements.Serialization.IFC.IFCToHypar.Converters
             //var wall = GetWallFromDoor(ifcDoor, allWalls);
             var doorWidth = (IfcLengthMeasure)ifcDoor.OverallWidth;
             var doorHeight = (IfcLengthMeasure)ifcDoor.OverallHeight;
+            var doorThickness = 2 * 0.0254;
 
             var result = new Door(doorWidth,
                                   doorHeight,
-                                  Door.DOOR_THICKNESS,
+                                  doorThickness,
                                   openingSide,
                                   openingType,
                                   repData.Transform,

--- a/Elements.Serialization.IFC/test/IFCTests.cs
+++ b/Elements.Serialization.IFC/test/IFCTests.cs
@@ -138,8 +138,8 @@ namespace Elements.IFC.Tests
             var wall1 = new StandardWall(wallLine1, 0.2, 3, name: "Wall1");
             var wall2 = new StandardWall(wallLine2, 0.2, 2, name: "Wall2");
 
-            var door1 = new Door(wallLine1, 0.5, 1.5, 2.0, 2 * 0.0254, DoorOpeningSide.LeftHand, DoorOpeningType.DoubleSwing);
-            var door2 = new Door(wallLine2, 0.5, 1.5, 1.8, 2 * 0.0254, DoorOpeningSide.LeftHand, DoorOpeningType.DoubleSwing);
+            var door1 = new Door(wallLine1, 0.5, 1.5, 2.0, Door.DEFAULT_DOOR_THICKNESS, DoorOpeningSide.LeftHand, DoorOpeningType.DoubleSwing);
+            var door2 = new Door(wallLine2, 0.5, 1.5, 1.8, Door.DEFAULT_DOOR_THICKNESS, DoorOpeningSide.LeftHand, DoorOpeningType.DoubleSwing);
 
             wall1.AddDoorOpening(door1);
             wall2.AddDoorOpening(door2);

--- a/Elements.Serialization.IFC/test/IFCTests.cs
+++ b/Elements.Serialization.IFC/test/IFCTests.cs
@@ -138,8 +138,8 @@ namespace Elements.IFC.Tests
             var wall1 = new StandardWall(wallLine1, 0.2, 3, name: "Wall1");
             var wall2 = new StandardWall(wallLine2, 0.2, 2, name: "Wall2");
 
-            var door1 = new Door(wallLine1, 0.5, 1.5, 2.0, Door.DOOR_THICKNESS, DoorOpeningSide.LeftHand, DoorOpeningType.DoubleSwing);
-            var door2 = new Door(wallLine2, 0.5, 1.5, 1.8, Door.DOOR_THICKNESS, DoorOpeningSide.LeftHand, DoorOpeningType.DoubleSwing);
+            var door1 = new Door(wallLine1, 0.5, 1.5, 2.0, 2 * 0.0254, DoorOpeningSide.LeftHand, DoorOpeningType.DoubleSwing);
+            var door2 = new Door(wallLine2, 0.5, 1.5, 1.8, 2 * 0.0254, DoorOpeningSide.LeftHand, DoorOpeningType.DoubleSwing);
 
             wall1.AddDoorOpening(door1);
             wall2.AddDoorOpening(door2);

--- a/Elements.Serialization.IFC/test/IFCTests.cs
+++ b/Elements.Serialization.IFC/test/IFCTests.cs
@@ -39,7 +39,7 @@ namespace Elements.IFC.Tests
         // TODO: The entrance door has an incorrect representation. It happens because during
         // the UpdateRepresentation the default representation of a door is created instead of
         // the extracted one.
-        [InlineData("AC20-Institute-Var-2", "../../../models/IFC4/AC20-Institute-Var-2.ifc", 1506, 5, 570, 121, 7, 82, 0, 21)]
+        [InlineData("AC20-Institute-Var-2", "../../../models/IFC4/AC20-Institute-Var-2.ifc", 1513, 5, 570, 121, 7, 82, 0, 21)]
         // [InlineData("20160125WestRiverSide Hospital - IFC4-Autodesk_Hospital_Sprinkle", "../../../models/IFC4/20160125WestRiverSide Hospital - IFC4-Autodesk_Hospital_Sprinkle.ifc")]
         public void FromIFC4(string name,
                          string ifcPath,

--- a/Elements.Serialization.IFC/test/IFCTests.cs
+++ b/Elements.Serialization.IFC/test/IFCTests.cs
@@ -29,7 +29,7 @@ namespace Elements.IFC.Tests
         // [InlineData("rac_sample", "../../../models/IFC4/rac_advanced_sample_project.ifc")]
         // [InlineData("rme_sample", "../../../models/IFC4/rme_advanced_sample_project.ifc")]
         // [InlineData("rst_sample", "../../../models/IFC4/rst_advanced_sample_project.ifc")]
-        [InlineData("AC-20-Smiley-West-10-Bldg", "../../../models/IFC4/AC-20-Smiley-West-10-Bldg.ifc", 1963, 120, 530, 270, 9, 140, 10, 2)]
+        [InlineData("AC-20-Smiley-West-10-Bldg", "../../../models/IFC4/AC-20-Smiley-West-10-Bldg.ifc", 1972, 120, 530, 270, 9, 140, 10, 2)]
         // TODO: Some walls are extracted incorrectly and intersecting the roof. It happens because
         // IfcBooleanClippingResultParser doesn't handle the boolean clipping operation.
         // In order to fix it surface support is required.

--- a/Elements/src/BIM/Door/Door.cs
+++ b/Elements/src/BIM/Door/Door.cs
@@ -23,8 +23,10 @@ namespace Elements
                 public double DoorWidth { get; set; }
                 /// <summary>Height of a door without a frame.</summary>
                 public double DoorHeight { get; set; }
+                /// <summary>Default door thickness.</summary>
+                public static double DEFAULT_DOOR_THICKNESS = 2 * 0.0254;
                 /// <summary>Door thickness.</summary>
-                public double DoorThickness { get; set; }
+                public double DoorThickness { get; set; } = DEFAULT_DOOR_THICKNESS;
                 /// <summary>Default thickness of a door frame.</summary>
                 public double FrameDepth { get; set; } = 4 * 0.0254;
                 /// <summary>Default width of a door frame.</summary>
@@ -84,7 +86,7 @@ namespace Elements
                         DoorHeight = clearHeight;
                         DoorWidth = clearWidth;
                         DoorThickness = thickness;
-                        Material = material;
+                        Material = material ?? BuiltInMaterials.Default;
                 }
 
                 /// <summary>
@@ -126,7 +128,7 @@ namespace Elements
                         DoorWidth = clearWidth;
                         DoorHeight = clearHeight;
                         DoorThickness = thickness;
-                        Material = material;
+                        Material = material ?? BuiltInMaterials.Default;
                         Transform = GetDoorTransform(line.PointAtNormalized(tPos), line);
                 }
 
@@ -175,7 +177,7 @@ namespace Elements
                 /// </summary>
                 public string GetRepresentationHash()
                 {
-                        return $"{this.GetType().Name}-{this.DoorWidth}-{this.DoorHeight}-{this.DoorThickness}-{this.FrameDepth}-{this.FrameWidth}{this.FrameMaterial}-{this.OpeningType}-{this.OpeningSide}-{this.Material.Name}";
+                        return $"{this.GetType().Name}-{this.DoorWidth}-{this.DoorHeight}-{this.DoorThickness}-{this.FrameDepth}-{this.FrameWidth}{this.FrameMaterial.Name}-{this.OpeningType}-{this.OpeningSide}-{this.Material.Name}";
                 }
 
                 public List<RepresentationInstance> GetInstances()

--- a/Elements/src/BIM/Door/DoorRepresentationStorage.cs
+++ b/Elements/src/BIM/Door/DoorRepresentationStorage.cs
@@ -4,7 +4,7 @@ using Elements.Geometry.Solids;
 
 namespace Elements
 {
-    static class DoorRepresentationStorage
+    public static class DoorRepresentationStorage
     {
         private static readonly Dictionary<string, List<RepresentationInstance>> _doors = new Dictionary<string, List<RepresentationInstance>>();
         public static Dictionary<string, List<RepresentationInstance>> Doors => _doors;

--- a/Elements/test/DoorTest.cs
+++ b/Elements/test/DoorTest.cs
@@ -14,7 +14,7 @@ namespace Elements
 
             var line = new Line(new Vector3(0, 0, 0), new Vector3(10, 10, 0));
             var wall = new StandardWall(line, 0.1, 3.0);
-            var door = new Door(wall.CenterLine, 0.5, 2.0, 2.0, Door.DOOR_THICKNESS, DoorOpeningSide.LeftHand, DoorOpeningType.SingleSwing);
+            var door = new Door(wall.CenterLine, 0.5, 2.0, 2.0, 2 * 0.0254, DoorOpeningSide.LeftHand, DoorOpeningType.SingleSwing);
             wall.AddDoorOpening(door);
 
             Assert.Single(wall.Openings);

--- a/Elements/test/DoorTest.cs
+++ b/Elements/test/DoorTest.cs
@@ -14,7 +14,7 @@ namespace Elements
 
             var line = new Line(new Vector3(0, 0, 0), new Vector3(10, 10, 0));
             var wall = new StandardWall(line, 0.1, 3.0);
-            var door = new Door(wall.CenterLine, 0.5, 2.0, 2.0, 2 * 0.0254, DoorOpeningSide.LeftHand, DoorOpeningType.SingleSwing);
+            var door = new Door(wall.CenterLine, 0.5, 2.0, 2.0, Door.DEFAULT_DOOR_THICKNESS, DoorOpeningSide.LeftHand, DoorOpeningType.SingleSwing);
             wall.AddDoorOpening(door);
 
             Assert.Single(wall.Openings);


### PR DESCRIPTION
BACKGROUND:
- Doors needed some properties exposed for functions... This way doors can be adapted depending on context (e.g. wall thickness)

DESCRIPTION:
- Makes properties public so users can define these in their function as needed

TESTING:
- These are being used in the updated `Doors` and `Interior Partitions` functions
  
FUTURE WORK:
- Possibly more refactoring as we make this cleaner

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1063)
<!-- Reviewable:end -->
