### PR TITLE
Added methods to set and get snap points

### DIFF
--- a/Elements/src/BIM/Door/Door.cs
+++ b/Elements/src/BIM/Door/Door.cs
@@ -221,6 +221,7 @@ namespace Elements
                         var points = CollectPointsForSchematicVisualization();
                         var curve = new IndexedPolycurve(points);
                         var curveRep = new CurveRepresentation(curve, false);
+                        curveRep.SetSnappingPoints(new List<SnappingPoints>());
                         var repInstance = new RepresentationInstance(curveRep, BuiltInMaterials.Black);
 
                         return repInstance;
@@ -251,6 +252,7 @@ namespace Elements
                         var doorFrameExtrude = new Extrude(new Profile(doorFramePolygon), this.FrameDepth, Vector3.YAxis);
 
                         var solidRep = new SolidRepresentation(doorFrameExtrude);
+                        solidRep.SetSnappingPoints(new List<SnappingPoints>());
                         var repInstance = new RepresentationInstance(solidRep, FrameMaterial, true);
                         return repInstance;
                 }
@@ -286,6 +288,7 @@ namespace Elements
                         }
 
                         var solidRep = new SolidRepresentation(doorExtrusions);
+                        solidRep.SetSnappingPoints(new List<SnappingPoints>(new SnappingPoints[] { new SnappingPoints(new[] { left, Vector3.Origin, right }, SnappingEdgeMode.LineStrip) }));
                         var repInstance = new RepresentationInstance(solidRep, this.Material, true);
                         return repInstance;
                 }
@@ -416,6 +419,7 @@ namespace Elements
                         }
 
                         var solidRep = new SolidRepresentation(solidOperationsList);
+                        solidRep.SetSnappingPoints(new List<SnappingPoints>());
                         var repInst = new RepresentationInstance(solidRep, FrameMaterial);
                         return repInst;
                 }

--- a/Elements/src/CoreModels/ElementRepresentation.cs
+++ b/Elements/src/CoreModels/ElementRepresentation.cs
@@ -9,6 +9,8 @@ using Elements.Serialization.glTF;
 /// </summary>
 public abstract class ElementRepresentation : SharedObject
 {
+    protected List<SnappingPoints> _snapPoints;
+
     /// <summary>
     /// Get graphics buffers and other metadata required to modify a GLB.
     /// </summary>
@@ -29,11 +31,29 @@ public abstract class ElementRepresentation : SharedObject
     }
 
     /// <summary>
+    /// Set the snapping points for this representation.
+    /// </summary>
+    public void SetSnappingPoints(List<SnappingPoints> snapPoints)
+    {
+        _snapPoints = snapPoints;
+    }
+
+    /// <summary>
+    /// Get the snapping points for this representation. Uses CreateSnappingPoints if _snapPoints is null.
+    /// </summary>
+    public List<SnappingPoints> GetSnappingPoints(GeometricElement element)
+    {
+        if (_snapPoints == null) return CreateSnappingPoints(element);
+        return _snapPoints;
+    }
+
+
+    /// <summary>
     ///Creates the set of snapping points
     /// </summary>
     /// <param name="element">The element with this representation.</param>
     /// <returns></returns>
-    public virtual List<SnappingPoints> CreateSnappingPoints(GeometricElement element)
+    protected virtual List<SnappingPoints> CreateSnappingPoints(GeometricElement element)
     {
         return new List<SnappingPoints>();
     }

--- a/Elements/src/Representations/CurveRepresentation.cs
+++ b/Elements/src/Representations/CurveRepresentation.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Elements.Geometry;
 using glTFLoader.Schema;
 
@@ -47,7 +48,7 @@ namespace Elements
         }
 
         /// <inheritdoc/>
-        public override List<SnappingPoints> CreateSnappingPoints(GeometricElement element)
+        protected override List<SnappingPoints> CreateSnappingPoints(GeometricElement element)
         {
             var snappingPoints = new List<SnappingPoints>();
             var curvePoints = _curve.RenderVertices();

--- a/Elements/src/Representations/SolidRepresentation.cs
+++ b/Elements/src/Representations/SolidRepresentation.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json;
 namespace Elements
 {
     /// <summary>
-    /// 
+    /// A solid representation of an element.
     /// </summary>
     public class SolidRepresentation : ElementRepresentation
     {
@@ -193,7 +193,7 @@ namespace Elements
         }
 
         /// <inheritdoc/>
-        public override List<SnappingPoints> CreateSnappingPoints(GeometricElement element)
+        protected override List<SnappingPoints> CreateSnappingPoints(GeometricElement element)
         {
             var snappingPoints = new List<SnappingPoints>();
 

--- a/Elements/src/Serialization/glTF/GltfExtensions.cs
+++ b/Elements/src/Serialization/glTF/GltfExtensions.cs
@@ -1341,8 +1341,9 @@ namespace Elements.Serialization.glTF
                                         var meshIdList = new List<int> { meshId };
                                         representationsMap.Add(combinedId, meshIdList);
                                         addedNodes.AddRange(NodeUtilities.AddNodes(nodes, meshIdList, elementNodeId));
-                                        var snappingPoints = representation.Representation.CreateSnappingPoints(element);
-                                        if (snappingPoints.Any())
+                                        var snappingPoints = representation.Representation.GetSnappingPoints(element);
+
+                                        if (snappingPoints != null)
                                         {
                                             AddExtension(gltf, meshes[meshId], "HYPAR_snapping_points", new Dictionary<string, object>() { { "points", snappingPoints } });
                                         }


### PR DESCRIPTION
BACKGROUND:
- Snap points are automatically created from representions, which can create too many snap points available for Elements.

DESCRIPTION:
- Adds Set and Get methods to the ElementRepresentation which checks if a developer has specified their own snap points.

TESTING:
- This workflow features a Doors function which is published using snap points at the ends and middle of the door object. Drag it around and see the snapping.
http://localhost:8080/workflows/818a4543-ce03-4688-bf15-d555407abcdb?view=b09eebe9-9857-4fcf-92e4-e4173e928289
  
FUTURE WORK:
- There may also be Explore changes required to handle null or empty lists of snap points... but it seems to work just fine.

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1065)
<!-- Reviewable:end -->
