### PR TITLE
`AdaptiveGrid.AddEdge` no longer delete edges in case where new edge partially overlaps old edges without intersections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - `BoundedCurve.ToPolyline` now works correctly for `EllipticalArc` class.
 - `Ray.Intersects(Topography)` and `Ray.Intersects(Mesh)` would sometimes return a different intersection than the closest one.
 - `Ray.Intersects(Topography)` now considers the topography's transform.
+- `AdaptiveGrid.AddEdge` no longer delete edges in case where new edge partially overlaps old edges without intersections.
 
 ### Changed
 

--- a/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
+++ b/Elements/src/Spatial/AdaptiveGrid/AdaptiveGrid.cs
@@ -936,12 +936,14 @@ namespace Elements.Spatial.AdaptiveGrid
                             AddEdgeOverlappingExisting(edgeV0, edgeV1, startVertex, endVertex, true))
                         {
                             edgesToRemove.Add(edge);
+                            intersectionPoints.Add(oldEdgeLine.End);
                         }
 
                         if (isOldEdgeStartOnNewEdge &&
                             AddEdgeOverlappingExisting(edgeV0, edgeV1, startVertex, endVertex, false))
                         {
                             edgesToRemove.Add(edge);
+                            intersectionPoints.Add(oldEdgeLine.Start);
                         }
                     }
                     // old edge is inside new edge

--- a/Elements/test/AdaptiveGridTests.cs
+++ b/Elements/test/AdaptiveGridTests.cs
@@ -990,6 +990,41 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void AdaptiveGridAddCutWithOverlap()
+        {
+            var grid = new AdaptiveGrid();
+            //Create single edges, so cut operation process only overlaps and not intersections.
+            grid.AddEdge(new Vector3(0, 0), new Vector3(0, 10));
+
+            //Start point of new edge is outside, end is inside.
+            var v0 = grid.AddVertex(new Vector3(0, -5));
+            var v1 = grid.AddVertex(new Vector3(0, 3));
+            var edges = grid.AddEdge(v0.Id, v1.Id);
+            Assert.Equal(2, edges.Count);
+            Assert.Single(v0.Edges);
+            Assert.Equal(2, v1.Edges.Count);
+            var middle = edges.First().OtherVertexId(v0.Id);
+            var middleVertex = grid.GetVertex(middle);
+            Assert.Equal(new Vector3(0, 0), middleVertex.Point);
+            Assert.Equal(2, middleVertex.Edges.Count);
+
+            //End point of new edge is outside, start is inside.
+            v0 = grid.AddVertex(new Vector3(0, 7));
+            v1 = grid.AddVertex(new Vector3(0, 15));
+            edges = grid.AddEdge(v0.Id, v1.Id);
+            Assert.Equal(2, edges.Count);
+            Assert.Equal(2, v0.Edges.Count);
+            Assert.Single(v1.Edges);
+            middle = edges.Last().OtherVertexId(v1.Id);
+            middleVertex = grid.GetVertex(middle);
+            Assert.Equal(new Vector3(0, 10), middleVertex.Point);
+            Assert.Equal(2, middleVertex.Edges.Count);
+
+            // Result should be strip of 6 vertices.
+            Assert.Equal(6, grid.GetVertices().Count);
+        }
+
+        [Fact]
         public void AdaptiveGridAddVertexWithAngle()
         {
             var grid = new AdaptiveGrid();


### PR DESCRIPTION
BACKGROUND:
- When creating grid from a set of circulation objects I found that some edges disappear.
- After investigation I found a bug in partial overlap of two edges: when one end is outside and one is inside.  

DESCRIPTION:
- Register missing intersection points in `AddCutEdge`.  
- It's not an issue if some of them will appear in the list several times since the list is later ordered and checked for duplicates.

TESTING:
- Added AdaptiveGridAddCutWithOverlap to cover problematic case.
 
REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1070)
<!-- Reviewable:end -->
