### PR TITLE
handle folders which look like elemetns but aren't

### DIFF
--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -358,7 +358,7 @@ namespace Elements.Serialization.JSON
                 return typeof(GeometricElement);
             }
             // If nothing else has worked, see if it has an ID and treat it as a generic element
-            if (jObject.TryGetValue("Id", out _))
+            if (jObject.TryGetValue("Id", out _) && DoesNotLookLikeFolder(objectType))
             {
                 return typeof(Element);
             }
@@ -366,6 +366,11 @@ namespace Elements.Serialization.JSON
             // The default behavior for this converter, as provided by nJSONSchema
             // is to return the base objectType if a derived type can't be found.
             return objectType;
+        }
+
+        private static bool DoesNotLookLikeFolder(Type objectType)
+        {
+            return objectType.GetProperty("Files") == null;
         }
     }
 }

--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -353,12 +353,12 @@ namespace Elements.Serialization.JSON
 
             // If it's not in the type cache see if it's got a representation.
             // Import it as a GeometricElement.
-            if (jObject.TryGetValue("Representation", out _))
+            if (jObject.TryGetValue("Representation", out _) && discriminator != null)
             {
                 return typeof(GeometricElement);
             }
             // If nothing else has worked, see if it has an ID and treat it as a generic element
-            if (jObject.TryGetValue("Id", out _) && DoesNotLookLikeFolder(objectType))
+            if (jObject.TryGetValue("Id", out _) && discriminator != null)
             {
                 return typeof(Element);
             }
@@ -366,11 +366,6 @@ namespace Elements.Serialization.JSON
             // The default behavior for this converter, as provided by nJSONSchema
             // is to return the base objectType if a derived type can't be found.
             return objectType;
-        }
-
-        private static bool DoesNotLookLikeFolder(Type objectType)
-        {
-            return objectType.GetProperty("Files") == null;
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- De-serializing folders in tests broke recently because we started falling back to elements if something has an "Id" property, which folders do, but they are not Elements

DESCRIPTION:
- Check if there is a discriminator before falling back to Element or GeometricElement.  non-elements can't fallback to these types even if they have an Id or Representation property.

TESTING:
- try to make/run a function that as a folder as an input.  You will get a de serialization error on de serializing the input, then try with this change.
  
FUTURE WORK:
- NA

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1073)
<!-- Reviewable:end -->
