### PR TITLE
Make-deserialization-thread-safe

### DIFF
--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -442,7 +442,6 @@ namespace Elements
                     args.ErrorContext.Handled = true;
                 }
             });
-
             deserializationErrors.AddRange(JsonInheritanceConverter.GetAndClearDeserializationWarnings());
             errors = deserializationErrors;
             JsonInheritanceConverter.Elements.Clear();

--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -442,6 +442,7 @@ namespace Elements
                     args.ErrorContext.Handled = true;
                 }
             });
+
             deserializationErrors.AddRange(JsonInheritanceConverter.GetAndClearDeserializationWarnings());
             errors = deserializationErrors;
             JsonInheritanceConverter.Elements.Clear();

--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -50,7 +50,20 @@ namespace Elements.Serialization.JSON
             }
         }
 
-        private static List<string> _deserializationWarnings = new List<string>();
+        [System.ThreadStatic]
+        private static List<string> _deserializationWarnings;
+
+        public static List<string> DeserializationWarnings
+        {
+            get
+            {
+                if (_deserializationWarnings == null)
+                {
+                    _deserializationWarnings = new List<string>();
+                }
+                return _deserializationWarnings;
+            }
+        }
 
         public JsonInheritanceConverter()
         {
@@ -247,8 +260,8 @@ namespace Elements.Serialization.JSON
 
         public static List<string> GetAndClearDeserializationWarnings()
         {
-            var warnings = _deserializationWarnings.ToList();
-            _deserializationWarnings.Clear();
+            var warnings = DeserializationWarnings.ToList();
+            DeserializationWarnings.Clear();
             return warnings;
         }
 
@@ -261,7 +274,7 @@ namespace Elements.Serialization.JSON
                 var id = Guid.Parse(reader.Value.ToString());
                 if (!Elements.ContainsKey(id))
                 {
-                    _deserializationWarnings.Add($"Element {id} was not found during deserialization. Check for other deserialization errors.");
+                    DeserializationWarnings.Add($"Element {id} was not found during deserialization. Check for other deserialization errors.");
                     return null;
                 }
                 return Elements[id];
@@ -318,7 +331,7 @@ namespace Elements.Serialization.JSON
 
                 if (discriminator != null)
                 {
-                    _deserializationWarnings.Add($"An object with the discriminator, {discriminator}, could not be deserialized. {baseMessage}");
+                    DeserializationWarnings.Add($"An object with the discriminator, {discriminator}, could not be deserialized. {baseMessage}");
                     return null;
 
                 }


### PR DESCRIPTION
BACKGROUND:
- Had an issue with deserialization warnings where they were being accessed in different threads

DESCRIPTION:
- Adds the `ThreadStatic` to ensure that this will not be accessed from other threads

TESTING:
- Deserialization should work running in a published function (I tested with `Doors` function)
  
FUTURE WORK:
- Make sure we are being thread safe!

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1074)
<!-- Reviewable:end -->
