### PR TITLE
remove all instances of Required.AllowNull

### DIFF
--- a/Elements/src/CoreModels/RepresentationInstance.cs
+++ b/Elements/src/CoreModels/RepresentationInstance.cs
@@ -43,7 +43,7 @@ namespace Elements
         /// <summary>
         /// The representation's material.
         /// </summary>
-        [JsonProperty("Material", Required = Required.AllowNull)]
+        [JsonProperty("Material")]
         public Material Material { get; set; }
 
         /// <summary>

--- a/Elements/src/GeometricElement.cs
+++ b/Elements/src/GeometricElement.cs
@@ -39,15 +39,15 @@ namespace Elements
         public BBox3 Bounds => _bounds;
 
         /// <summary>The element's transform.</summary>
-        [JsonProperty("Transform", Required = Required.AllowNull)]
+        [JsonProperty("Transform")]
         public Transform Transform { get; set; }
 
         /// <summary>The element's material.</summary>
-        [JsonProperty("Material", Required = Required.AllowNull)]
+        [JsonProperty("Material")]
         public Material Material { get; set; }
 
         /// <summary>The element's representation.</summary>
-        [JsonProperty("Representation", Required = Required.AllowNull)]
+        [JsonProperty("Representation")]
         public Representation Representation { get; set; }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Elements
         public List<RepresentationInstance> RepresentationInstances { get; set; } = new List<RepresentationInstance>();
 
         /// <summary>When true, this element will act as the base definition for element instances, and will not appear in visual output.</summary>
-        [JsonProperty("IsElementDefinition", Required = Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("IsElementDefinition", NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool IsElementDefinition { get; set; } = false;
 
         /// <summary>

--- a/Elements/src/Geometry/Circle.cs
+++ b/Elements/src/Geometry/Circle.cs
@@ -13,7 +13,7 @@ namespace Elements.Geometry
     public class Circle : Curve, IConic
     {
         /// <summary>The center of the circle.</summary>
-        [JsonProperty("Center", Required = Required.AllowNull)]
+        [JsonProperty("Center", Required = Required.Always)]
         public Vector3 Center
         {
             get

--- a/Elements/src/Geometry/Plane.cs
+++ b/Elements/src/Geometry/Plane.cs
@@ -11,11 +11,11 @@ namespace Elements.Geometry
     public partial class Plane : IEquatable<Plane>
     {
         /// <summary>The origin of the plane.</summary>
-        [JsonProperty("Origin", Required = Required.AllowNull)]
+        [JsonProperty("Origin", Required = Required.Always)]
         public Vector3 Origin { get; set; }
 
         /// <summary>The normal of the plane.</summary>
-        [JsonProperty("Normal", Required = Required.AllowNull)]
+        [JsonProperty("Normal", Required = Required.Always)]
         public Vector3 Normal { get; set; }
 
         /// <summary>

--- a/Elements/src/Geometry/Profile.cs
+++ b/Elements/src/Geometry/Profile.cs
@@ -13,11 +13,11 @@ namespace Elements.Geometry
     public class Profile : Element, IEquatable<Profile>
     {
         /// <summary>The perimeter of the profile.</summary>
-        [JsonProperty("Perimeter", Required = Required.AllowNull)]
+        [JsonProperty("Perimeter", Required = Required.Always)]
         public Polygon Perimeter { get; set; }
 
         /// <summary>A collection of Polygons representing voids in the profile.</summary>
-        [JsonProperty("Voids", Required = Required.AllowNull)]
+        [JsonProperty("Voids")]
         public IList<Polygon> Voids { get; set; }
 
         /// <summary>

--- a/Elements/src/Geometry/Solids/Extrude.cs
+++ b/Elements/src/Geometry/Solids/Extrude.cs
@@ -16,7 +16,7 @@ namespace Elements.Geometry.Solids
         private bool _reverseWinding;
 
         /// <summary>The id of the profile to extrude.</summary>
-        [JsonProperty("Profile", Required = Required.AllowNull)]
+        [JsonProperty("Profile", Required = Required.Always)]
         public Profile Profile
         {
             get { return _profile; }
@@ -47,7 +47,7 @@ namespace Elements.Geometry.Solids
         }
 
         /// <summary>The direction in which to extrude.</summary>
-        [JsonProperty("Direction", Required = Required.AllowNull)]
+        [JsonProperty("Direction", Required = Required.Always)]
         public Vector3 Direction
         {
             get { return _direction; }

--- a/Elements/src/Geometry/Solids/Lamina.cs
+++ b/Elements/src/Geometry/Solids/Lamina.cs
@@ -12,7 +12,7 @@ namespace Elements.Geometry.Solids
         private IList<Polygon> _voids;
 
         /// <summary>The perimeter.</summary>
-        [JsonProperty("Perimeter", Required = Required.AllowNull)]
+        [JsonProperty("Perimeter", Required = Required.Always)]
         public Polygon Perimeter
         {
             get { return _perimeter; }
@@ -29,7 +29,7 @@ namespace Elements.Geometry.Solids
         /// <summary>
         /// A collection of voids.
         /// </summary>
-        [JsonProperty("Voids", Required = Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("Voids", NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<Polygon> Voids
         {
             get { return _voids; }

--- a/Elements/src/Geometry/Triangle.cs
+++ b/Elements/src/Geometry/Triangle.cs
@@ -17,7 +17,7 @@ namespace Elements.Geometry
         public IList<Vertex> Vertices { get; set; } = new List<Vertex>();
 
         /// <summary>The triangle's normal.</summary>
-        [JsonProperty("Normal", Required = Required.AllowNull)]
+        [JsonProperty("Normal")]
         public Vector3 Normal { get; set; }
 
         /// <summary>

--- a/Elements/src/Geometry/Vertex.cs
+++ b/Elements/src/Geometry/Vertex.cs
@@ -9,11 +9,11 @@ namespace Elements.Geometry
     public class Vertex
     {
         /// <summary>The vertex's position.</summary>
-        [JsonProperty("Position", Required = Required.AllowNull)]
+        [JsonProperty("Position", Required = Required.Always)]
         public Vector3 Position { get; set; }
 
         /// <summary>The vertex's normal.</summary>
-        [JsonProperty("Normal", Required = Required.AllowNull)]
+        [JsonProperty("Normal")]
         public Vector3 Normal { get; set; }
 
         /// <summary>The vertex's color.</summary>

--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -22,12 +22,12 @@ namespace Elements
     public class Model
     {
         /// <summary>The origin of the model.</summary>
-        [JsonProperty("Origin", Required = Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("Origin", NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Obsolete("Use Transform instead.")]
         public Position Origin { get; set; }
 
         /// <summary>The transform of the model.</summary>
-        [JsonProperty("Transform", Required = Required.AllowNull)]
+        [JsonProperty("Transform")]
         public Transform Transform { get; set; }
 
         /// <summary>A collection of Elements keyed by their identifiers.</summary>


### PR DESCRIPTION
BACKGROUND:
- In a number of cases, our NJsonSchema-generated classes reflected an unintentional strange state: that of being `required` but possibly `null`. This is rarely practically useful: in nearly all cases we want a property to either be required or to permit null, but not both.  

DESCRIPTION:
- Adapts all usage of the `Required.AllowNull` attribute to be either `Required.Always`, or not required. Since these values could always be null anyway, the code is generally able to tolerate their "nullness" — the difference is just whether or not we get a serialization failure if a `null` is omitted from the json. For example:
```
{
   Perimeter: [...],
   Voids: null
}
``` 
is a valid `Profile`, but 

```
{
   Perimeter: [...],
}
```
will throw a deserialization error, even though the code can handle it. 

TESTING:
- All tests continue to pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1078)
<!-- Reviewable:end -->
