### PR TITLE
Fix setting a different catalog

### DIFF
--- a/Elements.Components/src/ContentCatalogRetrieval.cs
+++ b/Elements.Components/src/ContentCatalogRetrieval.cs
@@ -25,6 +25,8 @@ namespace Elements.Components
         public static void SetCatalogFilePath(string path)
         {
             catalogFilePath = path;
+            // if we already have a catalog loaded, clear it out.
+            catalog = null;
         }
 
         /// <summary>


### PR DESCRIPTION
BACKGROUND:
- Ancient catalog retrieval code assumed only a single catalog could exist. Setting a second catalog (as the Space Type function does) would fail — we would see we already had a catalog, and just use that, rather than reading the new one.
- This meant that in cases where more than one space type was specified, all but the first one would be missing all properties. 

DESCRIPTION:
- Resets the catalog to null when setting a new path.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1079)
<!-- Reviewable:end -->
