### PR TITLE
reset space configuration cache when setting catalog path

### DIFF
--- a/Elements.Components/src/ContentCatalogRetrieval.cs
+++ b/Elements.Components/src/ContentCatalogRetrieval.cs
@@ -18,7 +18,7 @@ namespace Elements.Components
         private static string catalogFilePath = null;
 
         /// <summary>
-        /// If you're using a different location for the catalog file, you can 
+        /// If you're using a different location for the catalog file, you can
         /// set it here.
         /// </summary>
         /// <param name="path"></param>
@@ -27,6 +27,7 @@ namespace Elements.Components
             catalogFilePath = path;
             // if we already have a catalog loaded, clear it out.
             catalog = null;
+            SpaceConfiguration.ResetContentCache();
         }
 
         /// <summary>

--- a/Elements.Components/src/SpaceConfiguration.cs
+++ b/Elements.Components/src/SpaceConfiguration.cs
@@ -14,6 +14,14 @@ namespace Elements.Components
     public class SpaceConfiguration : Dictionary<string, ContentConfiguration>
     {
         internal static Dictionary<string, ContentElement> contentDict = new Dictionary<string, ContentElement>();
+
+        /// <summary>
+        /// Clear the internal content cache.  Do this if content catalogs have changed.
+        /// </summary>
+        public static void ResetContentCache()
+        {
+            contentDict.Clear();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
BACKGROUND:
- We noticed that when a space type was updated in the content catalog that old values for the instance parameters on ContentElements would persists across multiple executions.  

DESCRIPTION:
- When a catalog path is set we want to be sure that the `SpaceConfiguration` class will use that new catalog, so we have to clear the catalog that is used for ContentElement retrieval inside `SpaceConfiguration`

TESTING:
- I've tested this with the `function-SpaceType` function and this resolves the stale instance parameter values
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
~- [ ] All changes are up to date in `CHANGELOG.md`.~

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1080)
<!-- Reviewable:end -->
