### PR TITLE
fix some bugs in the notebook viewer

### DIFF
--- a/Elements/src/extension.dib
+++ b/Elements/src/extension.dib
@@ -92,10 +92,9 @@ const fitCameraToObject = function (scene, offset = 1.25) {
         camera.position.copy(center.clone().add(size.clone().multiplyScalar(offset)))
     }
 
-    const minZ = boundingBox.min.y;
-    const cameraToFarEdge = (minZ < 0) ? -minZ + cameraZ : cameraZ - minZ;
+    const cameraToFarEdge = camera.position.distanceTo(center) + maxDim;
 
-    camera.far = cameraToFarEdge * 30;
+    camera.far = cameraToFarEdge * 5;
     camera.updateProjectionMatrix();
 
     if (controls) {

--- a/Elements/src/extension.dib
+++ b/Elements/src/extension.dib
@@ -25,7 +25,7 @@ using System;
 using System.IO;
 
 var viewerSrc = @"
-<div id=""main_DIV_ID"" style=""height:WIDTH_VAR;width:HEIGHT_VARpx;""></div>
+<div id=""main_DIV_ID"" style=""height:HEIGHT_VARpx;width:WIDTH_VARpx;""></div>
 </div>
 <script type=""module"">
 import * as THREE from 'https://unpkg.com/three@0.126.0/build/three.module.js';
@@ -92,10 +92,10 @@ const fitCameraToObject = function (scene, offset = 1.25) {
         camera.position.copy(center.clone().add(size.clone().multiplyScalar(offset)))
     }
 
-    const minZ = boundingBox.min.z;
+    const minZ = boundingBox.min.y;
     const cameraToFarEdge = (minZ < 0) ? -minZ + cameraZ : cameraZ - minZ;
 
-    camera.far = cameraToFarEdge * 10;
+    camera.far = cameraToFarEdge * 30;
     camera.updateProjectionMatrix();
 
     if (controls) {


### PR DESCRIPTION
BACKGROUND:
- Fixes https://github.com/hypar-io/Elements/issues/1083

DESCRIPTION:
- There were a couple minor bugs in the 3d viewer code which resulted in the far plane calculation being wrong, which would cause models not centered on the origin to be clipped / invisible. There were also a couple other little syntax issues.

TESTING:
- I loaded this model into a notebook and returned it in a cell. (Scratch.dib is a good place to test this out against the local version of extension.dib)
[bad-model.json](https://github.com/hypar-io/Elements/files/15142356/bad-model.json)

![image](https://github.com/hypar-io/Elements/assets/31935763/7ea9398f-5ea5-4de1-8c25-0f4d41cae41b)
  
FUTURE WORK:
- We should find a way to upgrade the version of threejs in our notebook, so we can support setting DEFAULT_UP to `z` instead of `y`, but the recommended CDN approach for three these days requires `importMaps`, which I couldn't get to work in a notebook context.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1084)
<!-- Reviewable:end -->
