### PR TITLE
project line orthogonally onto another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - `ContentConfiguration.AllowRotatation`
 - `AdaptiveGrid.Clone`
 - `AdditionalProperties` to ContentConfiguration.
+- `Line.Projected(Line line)`
 
 ### Fixed
 

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1214,13 +1214,36 @@ namespace Elements.Geometry
         /// <summary>
         /// Projects current line onto a plane
         /// </summary>
-        /// <param name="plane">Plane to project</param>
+        /// <param name="plane">Plane to project on</param>
         /// <returns>New line on a plane</returns>
         public Line Projected(Plane plane)
         {
             var start = Start.Project(plane);
             var end = End.Project(plane);
             return new Line(start, end);
+        }
+
+        /// <summary>
+        /// Projects current line orthogonally onto another line
+        /// </summary>
+        /// <param name="line">Line to project on</param>
+        /// <returns>New line on a line</returns>
+        public Line Projected(Line line)
+        {
+            var lineDirection = line.Direction();
+            var normalizedDirection = new Vector3(lineDirection.X, lineDirection.Y, lineDirection.Z);
+
+            Vector3 ProjectPoint(Vector3 point, Vector3 lineStart)
+            {
+                var toPoint = point - lineStart;
+                var projectionLength = toPoint.Dot(normalizedDirection);
+                return lineStart + normalizedDirection.Scale(projectionLength);
+            }
+
+            var newLineStart = ProjectPoint(Start, line.Start);
+            var newLineEnd = ProjectPoint(End, line.Start);
+
+            return new Line(newLineStart, newLineEnd);
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1224,7 +1224,7 @@ namespace Elements.Geometry
         }
 
         /// <summary>
-        /// Projects current line orthogonally onto another line
+        /// Projects current line onto another line
         /// </summary>
         /// <param name="line">Line to project on</param>
         /// <returns>New line on a line</returns>
@@ -1232,15 +1232,8 @@ namespace Elements.Geometry
         {
             var lineDirection = line.Direction();
 
-            Vector3 ProjectPoint(Vector3 point, Vector3 lineStart)
-            {
-                var toPoint = point - lineStart;
-                var projectionLength = toPoint.Dot(lineDirection);
-                return lineStart + lineDirection.Scale(projectionLength);
-            }
-
-            var newLineStart = ProjectPoint(Start, line.Start);
-            var newLineEnd = ProjectPoint(End, line.Start);
+            var newLineStart = Start.Project(line.Start, lineDirection);
+            var newLineEnd = End.Project(line.End, lineDirection);
 
             return new Line(newLineStart, newLineEnd);
         }

--- a/Elements/src/Geometry/Line.cs
+++ b/Elements/src/Geometry/Line.cs
@@ -1231,13 +1231,12 @@ namespace Elements.Geometry
         public Line Projected(Line line)
         {
             var lineDirection = line.Direction();
-            var normalizedDirection = new Vector3(lineDirection.X, lineDirection.Y, lineDirection.Z);
 
             Vector3 ProjectPoint(Vector3 point, Vector3 lineStart)
             {
                 var toPoint = point - lineStart;
-                var projectionLength = toPoint.Dot(normalizedDirection);
-                return lineStart + normalizedDirection.Scale(projectionLength);
+                var projectionLength = toPoint.Dot(lineDirection);
+                return lineStart + lineDirection.Scale(projectionLength);
             }
 
             var newLineStart = ProjectPoint(Start, line.Start);

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -281,6 +281,16 @@ namespace Elements.Geometry
         }
 
         /// <summary>
+        /// Scales the vector by a given scalar value.
+        /// </summary>
+        /// <param name="scalar">The scalar value to multiply each component by.</param>
+        /// <returns>A new vector where each component is scaled by the given scalar.</returns>
+        public Vector3 Scale(double scalar)
+        {
+            return new Vector3(X * scalar, Y * scalar, Z * scalar);
+        }
+
+        /// <summary>
         /// The angle in degrees from this vector to the provided vector.
         /// Note that for angles in the plane that can be greater than 180 degrees,
         /// you should use Vector3.PlaneAngleTo.
@@ -992,7 +1002,7 @@ namespace Elements.Geometry
             // within tolerance of each other. If all points are within
             // tolerance/2 of some point, then they must all be within tolerance
             // of each other.
-            return points.All(p => p.IsAlmostEqualTo(average, tolerance / 2.0)); 
+            return points.All(p => p.IsAlmostEqualTo(average, tolerance / 2.0));
         }
 
         /// <summary>

--- a/Elements/src/Geometry/Vector3.cs
+++ b/Elements/src/Geometry/Vector3.cs
@@ -405,8 +405,31 @@ namespace Elements.Geometry
             {
                 return double.PositiveInfinity;
             }
-            var closestPointOnRay = ray.Origin + t * ray.Direction;
+            var closestPointOnRay = Project(ray);
             return closestPointOnRay.DistanceTo(this);
+        }
+
+        /// <summary>
+        /// Project a point onto a ray.
+        /// The ray is treated as being infinitely long.
+        /// </summary>
+        /// <param name="ray">The target ray.</param>
+        public Vector3 Project(Ray ray)
+        {
+            var toPoint = this - ray.Origin;
+            var projectionLength = toPoint.Dot(ray.Direction);
+            return ray.Origin + ray.Direction.Scale(projectionLength);
+        }
+
+        /// <summary>
+        /// Project a point onto a constructed ray.
+        /// The ray is treated as being infinitely long.
+        /// </summary>
+        /// <param name="origin">The origin of the line.</param>
+        /// <param name="direction">The direction of the line.</param>
+        public Vector3 Project(Vector3 origin, Vector3 direction)
+        {
+            return Project(new Ray(origin, direction));
         }
 
         internal double ProjectedParameterOn(Ray ray)

--- a/Elements/test/LineTests.cs
+++ b/Elements/test/LineTests.cs
@@ -141,7 +141,7 @@ namespace Elements.Geometry.Tests
         public void IntersectsCircle()
         {
             Circle c = new Circle(new Vector3(5, 5, 5), 5);
-            
+
             // Intersects circle at one point and touches at other.
             Line l = new Line(new Vector3(0, 5, 5), new Vector3(15, 5, 5));
             Assert.True(l.Intersects(c, out var results));
@@ -599,6 +599,72 @@ namespace Elements.Geometry.Tests
             var l1 = new Line(a, b);
             var l2 = new Line(b, a);
             Assert.NotEqual(l1.GetHashCode(), l2.GetHashCode());
+        }
+
+        [Fact]
+        public void ProjectedLine()
+        {
+            // Identical Line Projection
+            var line = new Line(new Vector3(0, 0, 0), new Vector3(1, 1, 1));
+            var result = line.Projected(line);
+
+            Assert.Equal(line.Start, result.Start);
+            Assert.Equal(line.End, result.End);
+
+            // Parallel Line Projection
+            var lineA = new Line(new Vector3(0, 0, 0), new Vector3(1, 0, 0));
+            var parallelLine = new Line(new Vector3(1, 0, 0), new Vector3(2, 0, 0));
+            var resultA = parallelLine.Projected(lineA);
+
+            var expectedStartA = new Vector3(1, 0, 0);
+            var expectedEndA = new Vector3(2, 0, 0);
+
+            Assert.Equal(expectedStartA, resultA.Start);
+            Assert.Equal(expectedEndA, resultA.End);
+
+            // Diagnol Line Projection
+            var lineB = new Line(new Vector3(0, 0, 0), new Vector3(1, 1, 0));
+            var diagonalLine = new Line(new Vector3(1, 1, 1), new Vector3(2, 2, 1));
+            var resultB = diagonalLine.Projected(lineB);
+
+            var expectedStartB = new Vector3(1, 1, 0);
+            var expectedEndB = new Vector3(2, 2, 0);
+
+            Assert.Equal(expectedStartB, resultB.Start);
+            Assert.Equal(expectedEndB, resultB.End);
+
+            // Perpendicular Line Projection
+            var lineC = new Line(new Vector3(0, 0, 0), new Vector3(1, 0, 0));
+            var perpendicularLine = new Line(new Vector3(0, 1, 0), new Vector3(1, 1, 0));
+            var resultC = perpendicularLine.Projected(lineC);
+
+            var expectedStartC = new Vector3(0, 0, 0);
+            var expectedEndC = new Vector3(1, 0, 0);
+
+            Assert.Equal(expectedStartC, resultC.Start);
+            Assert.Equal(expectedEndC, resultC.End);
+
+            // Negative Line Projection
+            var lineD = new Line(new Vector3(-1, -1, -1), new Vector3(-2, -2, -2));
+            var otherLineD = new Line(new Vector3(-3, -3, -3), new Vector3(-4, -4, -4));
+            var resultD = otherLineD.Projected(lineD);
+
+            var expectedStartD = new Vector3(-3, -3, -3);
+            var expectedEndD = new Vector3(-4, -4, -4);
+
+            Assert.Equal(expectedStartD, resultD.Start);
+            Assert.Equal(expectedEndD, resultD.End);
+
+            // Arbitrary Line Projection
+            var lineE = new Line(new Vector3(0, 0, 0), new Vector3(1, 2, 3));
+            var otherLineE = new Line(new Vector3(1, 1, 1), new Vector3(2, 3, 4));
+            var resultE = otherLineE.Projected(lineE);
+
+            var expectedStartE = new Vector3(0.42857, 0.85714, 1.28571); // approximate expected values
+            var expectedEndE = new Vector3(1.42857, 2.85714, 4.28571); // approximate expected values
+
+            Assert.True(resultE.Start.IsAlmostEqualTo(expectedStartE));
+            Assert.True(resultE.End.IsAlmostEqualTo(expectedEndE));
         }
 
         [Fact]
@@ -1209,7 +1275,7 @@ namespace Elements.Geometry.Tests
             Assert.Equal(delta.Length(), (new Line(pt12, pt11)).DistanceTo(new Line(pt21, pt22)), 12);
             Assert.Equal(delta.Length(), (new Line(pt12, pt11)).DistanceTo(new Line(pt22, pt21)), 12);
             //The segments (pt12, pt13) and (pt21, pt22) does not intersect.
-            //The shortest distance is from an endpoint to another segment - difference between lines plus between endpoints. 
+            //The shortest distance is from an endpoint to another segment - difference between lines plus between endpoints.
             var expected = (q12 * v1).DistanceTo(new Line(delta + q21 * v2, delta + q22 * v2));
             Assert.Equal(expected, (new Line(pt12, pt13)).DistanceTo(new Line(pt21, pt22)), 12);
             Assert.Equal(expected, (new Line(pt12, pt13)).DistanceTo(new Line(pt22, pt21)), 12);


### PR DESCRIPTION
BACKGROUND:
- Some hy-ccups indicated that while we allowed tolerance within our Walls LOD 200 function, we we're not successfully merging these lines which fell out of tolerance for the merge collinear function

DESCRIPTION:
- Adds a method to orthogonally project a line onto another

TESTING:
- Project line A onto line B and observe line A projected orthogonally onto line B.
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1086)
<!-- Reviewable:end -->
