### PR TITLE
Use representation instances for reducers

### DIFF
--- a/Elements.MEP/src/Fittings/FittingRepresentationStorage.cs
+++ b/Elements.MEP/src/Fittings/FittingRepresentationStorage.cs
@@ -11,17 +11,32 @@ namespace Elements.Fittings
         private static readonly Dictionary<string, List<RepresentationInstance>> _fittings = new Dictionary<string, List<RepresentationInstance>>();
         public static Dictionary<string, List<RepresentationInstance>> Fittings => _fittings;
 
-        public static void SetFittingRepresentation(Fitting fitting, Func<IList<SolidOperation>> makeSolids)
+        public static void SetFittingRepresentation(Fitting fitting, Func<IList<SolidOperation>> makeSolids, Boolean unioned = true, Boolean updateTransform = true)
         {
             var hash = fitting.GetRepresentationHash();
             if (!_fittings.ContainsKey(hash))
             {
                 var solids = makeSolids();
-                _fittings.Add(hash, new List<RepresentationInstance> { new RepresentationInstance(new SolidRepresentation(solids), fitting.Material) });
+                var representationInstances = new List<RepresentationInstance>();
+                if (unioned)
+                {
+                    representationInstances = new List<RepresentationInstance> { new RepresentationInstance(new SolidRepresentation(solids), fitting.Material) };
+                }
+                else
+                {
+                    foreach (var solid in solids)
+                    {
+                        representationInstances.Add(new RepresentationInstance(new SolidRepresentation(solid), fitting.Material));
+                    }
+                }
+                _fittings.Add(hash, representationInstances);
             }
             fitting.RepresentationInstances = _fittings[hash];
 
-            fitting.Transform = fitting.GetRotatedTransform().Concatenated(new Transform(fitting.Transform.Origin));
+            if (updateTransform)
+            {
+                fitting.Transform = fitting.GetRotatedTransform().Concatenated(new Transform(fitting.Transform.Origin));
+            }
         }
     }
 }

--- a/Elements.MEP/src/Fittings/FittingRepresentationStorage.cs
+++ b/Elements.MEP/src/Fittings/FittingRepresentationStorage.cs
@@ -11,32 +11,17 @@ namespace Elements.Fittings
         private static readonly Dictionary<string, List<RepresentationInstance>> _fittings = new Dictionary<string, List<RepresentationInstance>>();
         public static Dictionary<string, List<RepresentationInstance>> Fittings => _fittings;
 
-        public static void SetFittingRepresentation(Fitting fitting, Func<IList<SolidOperation>> makeSolids, Boolean unioned = true, Boolean updateTransform = true)
+        public static void SetFittingRepresentation(Fitting fitting, Func<IList<SolidOperation>> makeSolids)
         {
             var hash = fitting.GetRepresentationHash();
             if (!_fittings.ContainsKey(hash))
             {
                 var solids = makeSolids();
-                var representationInstances = new List<RepresentationInstance>();
-                if (unioned)
-                {
-                    representationInstances = new List<RepresentationInstance> { new RepresentationInstance(new SolidRepresentation(solids), fitting.Material) };
-                }
-                else
-                {
-                    foreach (var solid in solids)
-                    {
-                        representationInstances.Add(new RepresentationInstance(new SolidRepresentation(solid), fitting.Material));
-                    }
-                }
-                _fittings.Add(hash, representationInstances);
+                _fittings.Add(hash, new List<RepresentationInstance> { new RepresentationInstance(new SolidRepresentation(solids), fitting.Material) });
             }
             fitting.RepresentationInstances = _fittings[hash];
 
-            if (updateTransform)
-            {
-                fitting.Transform = fitting.GetRotatedTransform().Concatenated(new Transform(fitting.Transform.Origin));
-            }
+            fitting.Transform = fitting.GetRotatedTransform().Concatenated(new Transform(fitting.Transform.Origin));
         }
     }
 }

--- a/Elements.MEP/src/Fittings/Reducer.cs
+++ b/Elements.MEP/src/Fittings/Reducer.cs
@@ -72,7 +72,12 @@ namespace Elements.Fittings
             var arrows = this.Start.GetArrow(branchSideTransformInverted.OfPoint(startNodeTransform.Origin))
                  .Concat(this.End.GetArrow(endNodeTransform.Origin)).Concat(GetExtensions());
 
-            this.Representation = new Representation(new List<SolidOperation> { sweep1, sweep2 }.Concat(arrows).ToList());
+            this.RepresentationInstances.Add(new RepresentationInstance(new SolidRepresentation(sweep1), this.Material));
+            this.RepresentationInstances.Add(new RepresentationInstance(new SolidRepresentation(sweep2), this.Material));
+            foreach (var arrow in arrows)
+            {
+                this.RepresentationInstances.Add(new RepresentationInstance(new SolidRepresentation(arrow), this.Material));
+            }
         }
 
         public override void ApplyAdditionalTransform()

--- a/Elements.MEP/src/Fittings/Reducer.cs
+++ b/Elements.MEP/src/Fittings/Reducer.cs
@@ -76,7 +76,10 @@ namespace Elements.Fittings
             // It would also be ideal to fully understand the geometry artifacts seen with certain Reducers that result in
             // bad boolean graphics which result in invisible or fractured geometry.
             var solidOperations = new List<SolidOperation> { sweep1, sweep2 }.Concat(arrows).ToList();
-            FittingRepresentationStorage.SetFittingRepresentation(this, () => solidOperations, false, false);
+            foreach (var solidOperation in solidOperations)
+            {
+                this.RepresentationInstances.Add(new RepresentationInstance(new SolidRepresentation(solidOperation), this.Material));
+            }
         }
 
         public override void ApplyAdditionalTransform()

--- a/Elements.MEP/src/Fittings/Reducer.cs
+++ b/Elements.MEP/src/Fittings/Reducer.cs
@@ -72,12 +72,11 @@ namespace Elements.Fittings
             var arrows = this.Start.GetArrow(branchSideTransformInverted.OfPoint(startNodeTransform.Origin))
                  .Concat(this.End.GetArrow(endNodeTransform.Origin)).Concat(GetExtensions());
 
-            this.RepresentationInstances.Add(new RepresentationInstance(new SolidRepresentation(sweep1), this.Material));
-            this.RepresentationInstances.Add(new RepresentationInstance(new SolidRepresentation(sweep2), this.Material));
-            foreach (var arrow in arrows)
-            {
-                this.RepresentationInstances.Add(new RepresentationInstance(new SolidRepresentation(arrow), this.Material));
-            }
+            // TODO: Update the Factory pattern for setting representationInstances to work with Reducer transforms.
+            // It would also be ideal to fully understand the geometry artifacts seen with certain Reducers that result in
+            // bad boolean graphics which result in invisible or fractured geometry.
+            var solidOperations = new List<SolidOperation> { sweep1, sweep2 }.Concat(arrows).ToList();
+            FittingRepresentationStorage.SetFittingRepresentation(this, () => solidOperations, false, false);
         }
 
         public override void ApplyAdditionalTransform()


### PR DESCRIPTION
BACKGROUND:
- Reducers were not being rendered properly do to (presumably) geometry conflicts from 2 sweeps intersecting.

DESCRIPTION:
- Switches from using `this.Representation` to `this.RepresentationInstances` for Reducer representations.

TESTING:
- Load up a workflow with reducers of various sizes and see them no longer missing.
  
<img width="375" alt="Screenshot 2024-12-24 at 4 40 12 PM" src="https://github.com/user-attachments/assets/7370bca0-08fa-4869-8285-b966725e4c5e" />

<img width="348" alt="Screenshot 2024-12-24 at 4 39 38 PM" src="https://github.com/user-attachments/assets/8d0b136b-c345-4548-b2cb-ed4b417d656a" />

FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1089)
<!-- Reviewable:end -->
