### PR TITLE
Optimize model serialization by using SharedObjects for reusable data

### DIFF
--- a/Elements/src/Element.cs
+++ b/Elements/src/Element.cs
@@ -96,6 +96,13 @@ namespace Elements
         internal Dictionary<string, MappingBase> Mappings { get; set; } = null;
 
         /// <summary>
+        ///  An optional shared object that can be used to share data between elements.
+        /// </summary>
+        /// <value></value>
+        [JsonProperty("SharedObject", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]
+        public SharedObject SharedObject { get; set; }
+
+        /// <summary>
         /// The method used to set a mapping for a given context.
         /// </summary>
         /// <param name="context"></param>

--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -34,7 +34,7 @@ namespace Elements
             /// List of elements collected from the shared object's properties.
             ///
             /// If shared object is marked as JsonIgnore (e.g. RepresentationInstance), it will not be
-            /// serialized to JSON, but it's properties will be collected here so they can be used
+            /// serialized to JSON, but its properties will be collected here so they can be used
             /// during gltf serialization.
             /// </summary>
             public List<Element> ElementsFromSharedObjectProperties { get; } = new List<Element>();

--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -50,6 +50,20 @@ namespace Elements.Serialization.JSON
             }
         }
 
+        private static Dictionary<Guid, SharedObject> _sharedObjects = null;
+
+        public static Dictionary<Guid, SharedObject> SharedObjects
+        {
+            get
+            {
+                if (_sharedObjects == null)
+                {
+                    _sharedObjects = new Dictionary<Guid, SharedObject>();
+                }
+                return _sharedObjects;
+            }
+        }
+
         [System.ThreadStatic]
         private static List<string> _deserializationWarnings;
 
@@ -170,9 +184,15 @@ namespace Elements.Serialization.JSON
 
                 // Operate on all identifiable Elements with a path less than Entities.xxxxx
                 // This will get all properties.
-                if (value is Element element && !WritingTopLevelElement(writer.Path) && !ElementwiseSerialization)
+                var element = value as Element;
+                if (element != null && !WritingTopLevelElement(writer.Path) && !ElementwiseSerialization)
                 {
                     var ident = element;
+                    writer.WriteValue(ident.Id);
+                }
+                else if (value is SharedObject sharedObject && !WritingTopLevelSharedObject(writer.Path) && !ElementwiseSerialization)
+                {
+                    var ident = sharedObject;
                     writer.WriteValue(ident.Id);
                 }
                 else
@@ -195,6 +215,13 @@ namespace Elements.Serialization.JSON
                     {
                         jObject.AddFirst(new Newtonsoft.Json.Linq.JProperty(_discriminator, discriminatorName));
                     }
+
+                    // Remove properties that are the same as in SharedObject
+                    if (element != null && element.SharedObject != null)
+                    {
+                        RemovePropertiesSameAsInSharedObject(element, jObject);
+
+                    }
                     writer.WriteToken(jObject.CreateReader());
                 }
             }
@@ -204,10 +231,64 @@ namespace Elements.Serialization.JSON
             }
         }
 
+        private void RemovePropertiesSameAsInSharedObject(Element element, JObject jObject)
+        {
+            var sharedProperties = element.SharedObject.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            var elementProperties = element.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+            foreach (var property in elementProperties)
+            {
+                // Check if property is in SharedObject
+                var sharedProperty = sharedProperties.FirstOrDefault(p => p.Name == property.Name);
+                if (sharedProperty != null)
+                {
+                    var sharedValue = sharedProperty.GetValue(element.SharedObject);
+                    var elementValue = property.GetValue(element);
+
+                    // If property value in SharedObject and Element are the same, remove property from jObject
+                    if (Equals(sharedValue, elementValue)) // Compare values
+                    {
+                        jObject.Remove(property.Name);
+                    }
+                    // If property has JsonExtensionDataAttribute (e.g. AdditionalProperties)
+                    // compare each value in the dictionary
+                    else if (Attribute.IsDefined(sharedProperty, typeof(JsonExtensionDataAttribute)))
+                    {
+                        if (sharedProperty.GetValue(element.SharedObject) is IDictionary<string, object> extraDataFromSharedObject
+                            && property.GetValue(element) is IDictionary<string, object> extraDataFromElement)
+                        {
+                            foreach (var extraDataFromSharedObjectKey in extraDataFromSharedObject.Keys)
+                            {
+                                if (string.Equals(extraDataFromSharedObjectKey, _discriminator))
+                                {
+                                    continue;
+                                }
+                                if (extraDataFromElement.ContainsKey(extraDataFromSharedObjectKey) &&
+                                Equals(extraDataFromSharedObject[extraDataFromSharedObjectKey], extraDataFromElement[extraDataFromSharedObjectKey]))
+                                {
+                                    jObject.Remove(extraDataFromSharedObjectKey);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         private static bool WritingTopLevelElement(string path)
         {
             var parts = path.Split('.');
             if (parts.Length == 2 && parts[0] == "Elements" && Guid.TryParse(parts[1], out var _))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        private static bool WritingTopLevelSharedObject(string path)
+        {
+            var parts = path.Split('.');
+            if (parts.Length == 2 && parts[0] == "SharedObjects" && Guid.TryParse(parts[1], out var _))
             {
                 return true;
             }
@@ -280,6 +361,17 @@ namespace Elements.Serialization.JSON
                 return Elements[id];
             }
 
+            if (typeof(SharedObject).IsAssignableFrom(objectType) && !WritingTopLevelSharedObject(reader.Path) && reader.Value != null)
+            {
+                var id = Guid.Parse(reader.Value.ToString());
+                if (!SharedObjects.ContainsKey(id))
+                {
+                    DeserializationWarnings.Add($"SharedObject {id} was not found during deserialization. Check for other deserialization errors.");
+                    return null;
+                }
+                return SharedObjects[id];
+            }
+
             var jObject = serializer.Deserialize<Newtonsoft.Json.Linq.JObject>(reader);
             if (jObject == null)
             {
@@ -319,6 +411,15 @@ namespace Elements.Serialization.JSON
                     if (!Elements.ContainsKey(ident.Id))
                     {
                         Elements.Add(ident.Id, ident);
+                    }
+                }
+
+                if (typeof(SharedObject).IsAssignableFrom(objectType) && WritingTopLevelSharedObject(reader.Path))
+                {
+                    var ident = (SharedObject)obj;
+                    if (!SharedObjects.ContainsKey(ident.Id))
+                    {
+                        SharedObjects.Add(ident.Id, ident);
                     }
                 }
 

--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -185,12 +185,12 @@ namespace Elements.Serialization.JSON
                 // Operate on all identifiable Elements with a path less than Entities.xxxxx
                 // This will get all properties.
                 var element = value as Element;
-                if (element != null && !WritingTopLevelElement(writer.Path) && !ElementwiseSerialization)
+                if (element != null && !PathIsTopLevel(writer.Path, "Elements") && !ElementwiseSerialization)
                 {
                     var ident = element;
                     writer.WriteValue(ident.Id);
                 }
-                else if (value is SharedObject sharedObject && !WritingTopLevelSharedObject(writer.Path) && !ElementwiseSerialization)
+                else if (value is SharedObject sharedObject && !PathIsTopLevel(writer.Path, "SharedObjects") && !ElementwiseSerialization)
                 {
                     var ident = sharedObject;
                     writer.WriteValue(ident.Id);
@@ -275,20 +275,10 @@ namespace Elements.Serialization.JSON
             }
         }
 
-        private static bool WritingTopLevelElement(string path)
+        private static bool PathIsTopLevel(string path, string propertyName)
         {
             var parts = path.Split('.');
-            if (parts.Length == 2 && parts[0] == "Elements" && Guid.TryParse(parts[1], out var _))
-            {
-                return true;
-            }
-            return false;
-        }
-
-        private static bool WritingTopLevelSharedObject(string path)
-        {
-            var parts = path.Split('.');
-            if (parts.Length == 2 && parts[0] == "SharedObjects" && Guid.TryParse(parts[1], out var _))
+            if (parts.Length == 2 && parts[0] == propertyName && Guid.TryParse(parts[1], out var _))
             {
                 return true;
             }
@@ -350,7 +340,7 @@ namespace Elements.Serialization.JSON
         {
             // The serialized value is an identifier, so the expectation is
             // that the element with that id has already been deserialized.
-            if (typeof(Element).IsAssignableFrom(objectType) && !WritingTopLevelElement(reader.Path) && reader.Value != null)
+            if (typeof(Element).IsAssignableFrom(objectType) && !PathIsTopLevel(reader.Path, "Elements") && reader.Value != null)
             {
                 var id = Guid.Parse(reader.Value.ToString());
                 if (!Elements.ContainsKey(id))
@@ -361,7 +351,7 @@ namespace Elements.Serialization.JSON
                 return Elements[id];
             }
 
-            if (typeof(SharedObject).IsAssignableFrom(objectType) && !WritingTopLevelSharedObject(reader.Path) && reader.Value != null)
+            if (typeof(SharedObject).IsAssignableFrom(objectType) && !PathIsTopLevel(reader.Path, "SharedObjects") && reader.Value != null)
             {
                 var id = Guid.Parse(reader.Value.ToString());
                 if (!SharedObjects.ContainsKey(id))
@@ -405,7 +395,7 @@ namespace Elements.Serialization.JSON
 
                 // Write the id to the cache so that we can retrieve it next time
                 // instead of de-serializing it again.
-                if (typeof(Element).IsAssignableFrom(objectType) && WritingTopLevelElement(reader.Path))
+                if (typeof(Element).IsAssignableFrom(objectType) && PathIsTopLevel(reader.Path, "Elements"))
                 {
                     var ident = (Element)obj;
                     if (!Elements.ContainsKey(ident.Id))
@@ -414,7 +404,7 @@ namespace Elements.Serialization.JSON
                     }
                 }
 
-                if (typeof(SharedObject).IsAssignableFrom(objectType) && WritingTopLevelSharedObject(reader.Path))
+                if (typeof(SharedObject).IsAssignableFrom(objectType) && PathIsTopLevel(reader.Path, "SharedObjects"))
                 {
                     var ident = (SharedObject)obj;
                     if (!SharedObjects.ContainsKey(ident.Id))

--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -254,8 +254,8 @@ namespace Elements.Serialization.JSON
                     // compare each value in the dictionary
                     else if (Attribute.IsDefined(sharedProperty, typeof(JsonExtensionDataAttribute)))
                     {
-                        if (sharedProperty.GetValue(element.SharedObject) is IDictionary<string, object> extraDataFromSharedObject
-                            && property.GetValue(element) is IDictionary<string, object> extraDataFromElement)
+                        if (sharedValue is IDictionary<string, object> extraDataFromSharedObject
+                            && elementValue is IDictionary<string, object> extraDataFromElement)
                         {
                             foreach (var extraDataFromSharedObjectKey in extraDataFromSharedObject.Keys)
                             {


### PR DESCRIPTION
🌌 BACKGROUND:
Suggestion functions generate numerous components for each space, many of which contain repeated information. This redundant data can be stored as shared objects to improve efficiency and reduce duplication.

📋 DESCRIPTION:
This PR:

- Introduces `SharedObjects` serialization to the model, stored as a dictionary structure similar to Elements.
- Adds support for skipping SharedObjects marked with the JsonIgnore attribute during serialization.
- Optimizes elements referencing shared objects by:
   - Removing redundant properties from elements that are already present in the referenced shared object during serialization.

🧪 TESTING:

- Tested with [classroom](https://github.com/hypar-io/suggestions-classroom/pull/2) and cafe functions to ensure proper functionality.
- Verified that RepresentationInstances are not saved to JSON.
- Confirmed that shared objects are correctly serialized and referenced, with no loss of critical information.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1090)
<!-- Reviewable:end -->
