### PR TITLE
exclude pyRevitLabs from JSON Convert

### DIFF
--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -155,7 +155,6 @@ namespace Elements.Serialization.JSON
         {
             if (t.IsPublic && t.IsClass)
             {
-                Console.WriteLine(t);
                 var attrib = t.GetCustomAttribute<JsonConverterAttribute>();
                 if (attrib != null && attrib.ConverterType == typeof(JsonInheritanceConverter))
                 {

--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -89,7 +89,7 @@ namespace Elements.Serialization.JSON
             _discriminator = discriminator;
         }
 
-        private static readonly List<string> TypePrefixesExcludedFromTypeCache = new List<string> { "System", "SixLabors", "Newtonsoft" };
+        private static readonly List<string> TypePrefixesExcludedFromTypeCache = new List<string> { "System", "SixLabors", "Newtonsoft", "pyRevitLabs" };
 
         /// <summary>
         /// When we build up the element type cache, we iterate over all types in the app domain.
@@ -155,6 +155,7 @@ namespace Elements.Serialization.JSON
         {
             if (t.IsPublic && t.IsClass)
             {
+                Console.WriteLine(t);
                 var attrib = t.GetCustomAttribute<JsonConverterAttribute>();
                 if (attrib != null && attrib.ConverterType == typeof(JsonInheritanceConverter))
                 {


### PR DESCRIPTION
BACKGROUND:
- We were encountering dll exceptions due to a dependency in the unit test of pyRevit beta 5. We don't need to pull in pyRevit types, so let's exclude them.

DESCRIPTION:
- Excludes pyRevit from App Domain Assemblies used in Json convert.

TESTING:
- Tested by importing any pringle model with Revit 2025 and pyRevit beta 5.
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1091)
<!-- Reviewable:end -->
