### PR TITLE
Fix: missing column edges by correcting MergeSubResult handling for SharedObjects

### DIFF
--- a/Elements/src/Model.cs
+++ b/Elements/src/Model.cs
@@ -43,7 +43,7 @@ namespace Elements
             {
                 if (isTypeRelatedToSharedObjects)
                 {
-                    ElementsFromSharedObjectProperties.AddRange(gatherResult.ElementsFromSharedObjectProperties);
+                    ElementsFromSharedObjectProperties.AddRange(gatherResult.Elements);
                 }
                 else
                 {


### PR DESCRIPTION
BACKGROUND:
- After introducing [Optimize model serialization by using SharedObjects for reusable data](https://github.com/hypar-io/Elements/pull/1090) republishing the Columns function caused column edges to disappear. This issue occurred because the material was not included in the `ElementsFromSharedObjectProperties` list.

DESCRIPTION:
This PR: 
- Fixes the `MergeSubResult` method in `GatherSubElementsResult`, ensuring that elements collected from types related to shared objects are correctly added to `ElementsFromSharedObjectProperties`.
- 
TESTING:
- Republishing the Column function (latest TEST version) successfully restored column edges:
   
![image](https://github.com/user-attachments/assets/c0d6af48-46ca-4a51-9812-27e547bb20c2)

