### PR TITLE
Fix SharedObject reference loss by removing it from `AdditionalProperties`

### DIFF
--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -402,6 +402,10 @@ namespace Elements.Serialization.JSON
                     {
                         Elements.Add(ident.Id, ident);
                     }
+
+                    // TODO: remove this hack. It's added to make sure that we are not duplicating shared object id to the AdditionalProperties.
+                    // It must be deleted after SharedObjects deserialization is implemented.
+                    ident.AdditionalProperties.Remove(nameof(Element.SharedObject));
                 }
 
                 if (typeof(SharedObject).IsAssignableFrom(objectType) && PathIsTopLevel(reader.Path, "SharedObjects"))


### PR DESCRIPTION
🌌 BACKGROUND:
When a function retrieves components created by a suggestion function, they contain a shared object ID. However, during deserialization:
1. The shared object is not yet part of the model and is not properly deserialized.
2. The shared object ID gets stored in `AdditionalProperties`.
3. When cloning the element and assigning a new shared object, the ID from `AdditionalProperties` overrides the correct reference, causing the element to lose its new shared object.

📋 DESCRIPTION:
This PR:
- Deletes the `SharedObject` reference from `AdditionalProperties` during deserialization, preventing incorrect overrides.

🧪 TESTING:
- Re-published the Private Office Suggestion function to confirm the fix.
- Verified that the issue shown in [this video](https://github.com/hypar-io/suggestions-open-office/pull/1) no longer occurs.

🔮 FUTURE WORK:
Pringle: Remove SharedObject ID from an element if it has been unpacked (i.e., all properties from the shared object have been assigned to the element).
Elements: Add SharedObjects deserialization

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1093)
<!-- Reviewable:end -->
