### PR TITLE
support zero-thickness wall deserialization

### DIFF
--- a/Elements/src/StandardWall.cs
+++ b/Elements/src/StandardWall.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Elements.Geometry;
 using Elements.Geometry.Solids;
 using Elements;
+using Newtonsoft.Json;
 
 namespace Elements
 {
@@ -29,6 +30,11 @@ namespace Elements
         /// </summary>
         public new double Height { get; protected set; }
 
+        /// <summary>
+        /// An internal flag indicating the version of walls behavior this wall
+        /// is using. Can be null, '2', or '3'.
+        /// </summary>
+        public string WallsVersion { get; set; }
 
         /// <summary>
         /// Construct a wall along a line.
@@ -46,12 +52,44 @@ namespace Elements
         /// <exception>Thrown when the height of the wall is less than or equal to zero.</exception>
         /// <exception>Thrown when the Z components of wall's start and end points are not the same.</exception>
         public StandardWall(Line centerLine,
+                                double thickness,
+                                double height,
+                                Material material,
+                                Transform transform,
+                                Representation representation,
+                                bool isElementDefinition,
+                                Guid id = default(Guid),
+                                string name = null) : this(centerLine, thickness, height, material, transform, representation, isElementDefinition, null, id, name)
+        {
+            // just a convenience overload for backwards compatibility.
+        }
+
+        /// <summary>
+        /// Construct a wall along a line.
+        /// </summary>
+        /// <param name="centerLine">The center line of the wall.</param>
+        /// <param name="thickness">The thickness of the wall.</param>
+        /// <param name="height">The height of the wall.</param>
+        /// <param name="material">The wall's material.</param>
+        /// <param name="transform">The transform of the wall.
+        /// This transform will be concatenated to the transform created to describe the wall in 2D.</param>
+        /// <param name="representation">The wall's representation.</param>
+        /// <param name="isElementDefinition">Is this an element definition?</param>
+        /// <param name="wallsVersion">The version of walls behavior this wall is using. Can be null, '2', or '3'.</param>
+        /// <param name="id">The id of the wall.</param>
+        /// <param name="name">The name of the wall.</param>
+        /// <exception>Thrown when the height of the wall is less than or equal to zero.</exception>
+        /// <exception>Thrown when the Z components of wall's start and end points are not the same.</exception>
+        [JsonConstructor]
+
+        public StandardWall(Line centerLine,
                             double thickness,
                             double height,
                             Material material = null,
                             Transform transform = null,
                             Representation representation = null,
                             bool isElementDefinition = false,
+                            string wallsVersion = null,
                             Guid id = default(Guid),
                             string name = null) : base(transform != null ? transform : new Transform(),
                                                        material != null ? material : BuiltInMaterials.Concrete,
@@ -70,7 +108,7 @@ namespace Elements
                 throw new ArgumentException("The wall could not be created. The Z component of the start and end points of the wall's center line must be the same.");
             }
 
-            if (thickness <= 0.0)
+            if (wallsVersion == null && thickness <= 0.0)
             {
                 throw new ArgumentOutOfRangeException($"The provided thickness ({thickness}) was less than or equal to zero.");
             }
@@ -78,6 +116,7 @@ namespace Elements
             this.CenterLine = centerLine;
             this.Height = height;
             this.Thickness = thickness;
+            this.WallsVersion = wallsVersion;
         }
 
         /// <summary>

--- a/Elements/test/ModelTests.cs
+++ b/Elements/test/ModelTests.cs
@@ -242,6 +242,15 @@ namespace Elements.Tests
         }
 
         [Fact]
+        public void DeserializationHandlesZeroThicknessWalls()
+        {
+            var json = File.ReadAllText("../../../models/Elements/zeroThicknessWalls.json");
+            var model = Model.FromJson(json);
+            var walls = model.AllElementsOfType<StandardWall>();
+            Assert.True(walls.Any((w) => w.Thickness == 0));
+        }
+
+        [Fact]
         public void DeserializationSkipsUnknownProperties()
         {
             var column = new Column(Vector3.Origin, 5, null, new Profile(Polygon.Rectangle(1, 1)));

--- a/Elements/test/models/Elements/zeroThicknessWalls.json
+++ b/Elements/test/models/Elements/zeroThicknessWalls.json
@@ -1,0 +1,2672 @@
+{
+    "Transform": {
+        "Matrix": {
+            "Components": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0
+            ]
+        }
+    },
+    "Elements": {
+        "30379006-7292-43f1-929c-c6bf9595d35f": {
+            "discriminator": "Elements.SpaceBoundary",
+            "Boundary": {
+                "discriminator": "Elements.Geometry.Profile",
+                "Perimeter": {
+                    "discriminator": "Elements.Geometry.Polygon",
+                    "Vertices": [
+                        {
+                            "X": -1.8288000000000002,
+                            "Y": -1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": 1.8288000000000002,
+                            "Y": -1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": 1.8288000000000002,
+                            "Y": 1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": -1.8288000000000002,
+                            "Y": 1.8288000000000002,
+                            "Z": 0
+                        }
+                    ]
+                },
+                "Voids": [],
+                "Id": "95e1eb98-b03a-48ee-96b8-cac3d2f07368"
+            },
+            "Height": 3.0480000000000005,
+            "Hypar Space Type": "Meeting Room",
+            "Id": "30379006-7292-43f1-929c-c6bf9595d35f",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Name": "Meeting Room",
+            "Parent": null,
+            "Program Type": "Meeting Room",
+            "ProgramName": "Meeting Room",
+            "Representation": null,
+            "Top Level": "da605445-d036-4ead-8f1b-e92120db7db0",
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        1,
+                        0,
+                        0,
+                        -2.1807518100949315,
+                        0,
+                        1,
+                        0,
+                        1.0546408045276277,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "WallThickness": 0.13335,
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ],
+            "Config Id": "",
+            "Type": {
+                "configurationSource": "space-type",
+                "name": "New Space Type",
+                "id": "88ec5146-897f-4eab-a717-a1beee4f2b3b",
+                "initialDimensions": {
+                    "width": 3.6576000000000004,
+                    "depth": 3.6576000000000004
+                }
+            }
+        },
+        "68cb547d-64d9-4138-bc76-bbe453296de7": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": null,
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "68cb547d-64d9-4138-bc76-bbe453296de7",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "30379006-7292-43f1-929c-c6bf9595d35f",
+            "Representation": null,
+            "SegmentIndex": 0,
+            "StartMiter": 0,
+            "Thickness": 0,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        1,
+                        0,
+                        0,
+                        -4.009551810094932,
+                        0,
+                        1,
+                        0,
+                        -0.7741591954723726,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "8da0e9fb-333f-4e4f-a209-6a17a3bd8fc0": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.7909500000000005,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.7242750000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "8da0e9fb-333f-4e4f-a209-6a17a3bd8fc0",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "30379006-7292-43f1-929c-c6bf9595d35f",
+            "Representation": null,
+            "SegmentIndex": 1,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        0,
+                        -1,
+                        0,
+                        -0.35195181009493126,
+                        1,
+                        0,
+                        0,
+                        -0.7741591954723726,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "00bf0202-3828-4906-9ebf-1dd323aa8a06": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": -0.13335000000000008,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.7909500000000005,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": -0.06667500000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.7242750000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "00bf0202-3828-4906-9ebf-1dd323aa8a06",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "30379006-7292-43f1-929c-c6bf9595d35f",
+            "Representation": null,
+            "SegmentIndex": 2,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        -1,
+                        0,
+                        0,
+                        -0.35195181009493126,
+                        0,
+                        -1,
+                        0,
+                        2.883440804527628,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "e4ebf8d7-fc34-4054-b909-019a004ef01e": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": -0.13335000000000008,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": -0.06667500000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "e4ebf8d7-fc34-4054-b909-019a004ef01e",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "30379006-7292-43f1-929c-c6bf9595d35f",
+            "Representation": null,
+            "SegmentIndex": 3,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        0,
+                        1,
+                        0,
+                        -4.009551810094932,
+                        -1,
+                        0,
+                        0,
+                        2.883440804527628,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "e68c3c58-054d-44d9-b3f3-60f2f47218f0": {
+            "discriminator": "Elements.SpaceBoundary",
+            "Boundary": {
+                "discriminator": "Elements.Geometry.Profile",
+                "Perimeter": {
+                    "discriminator": "Elements.Geometry.Polygon",
+                    "Vertices": [
+                        {
+                            "X": -1.8288000000000002,
+                            "Y": -1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": 1.8288000000000002,
+                            "Y": -1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": 1.8288000000000002,
+                            "Y": 1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": -1.8288000000000002,
+                            "Y": 1.8288000000000002,
+                            "Z": 0
+                        }
+                    ]
+                },
+                "Voids": [],
+                "Id": "11bb2dc2-74ab-4eab-b516-555174478d4b"
+            },
+            "Height": 3.0480000000000005,
+            "Hypar Space Type": "Meeting Room",
+            "Id": "e68c3c58-054d-44d9-b3f3-60f2f47218f0",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Name": "Meeting Room",
+            "Parent": null,
+            "Program Type": "Meeting Room",
+            "ProgramName": "Meeting Room",
+            "Representation": null,
+            "Top Level": "da605445-d036-4ead-8f1b-e92120db7db0",
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        2.683823606058878e-11,
+                        -0.9999999999999998,
+                        0,
+                        1.610198197595592,
+                        0.9999999999999998,
+                        2.683823606058878e-11,
+                        0,
+                        1.0546408122181516,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "WallThickness": 0.13335,
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ],
+            "Config Id": "",
+            "Type": {
+                "configurationSource": "space-type",
+                "name": "New Space Type",
+                "id": "88ec5146-897f-4eab-a717-a1beee4f2b3b",
+                "initialDimensions": {
+                    "width": 3.6576000000000004,
+                    "depth": 3.6576000000000004
+                }
+            }
+        },
+        "00474af6-85cb-43cd-9153-fba98266ebc7": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": null,
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "00474af6-85cb-43cd-9153-fba98266ebc7",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "e68c3c58-054d-44d9-b3f3-60f2f47218f0",
+            "Representation": null,
+            "SegmentIndex": 0,
+            "StartMiter": 0,
+            "Thickness": 0,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        2.683823606058878e-11,
+                        -0.9999999999999998,
+                        0,
+                        3.4389981975465096,
+                        0.9999999999999998,
+                        2.683823606058878e-11,
+                        0,
+                        -0.77415918783093,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "1f757c3c-261c-43a9-a70d-a8879dddb43c": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.7909500000000005,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.7242750000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "1f757c3c-261c-43a9-a70d-a8879dddb43c",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "e68c3c58-054d-44d9-b3f3-60f2f47218f0",
+            "Representation": null,
+            "SegmentIndex": 1,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        -0.9999999999999998,
+                        -2.683823606058878e-11,
+                        0,
+                        3.4389981976446737,
+                        2.683823606058878e-11,
+                        -0.9999999999999998,
+                        0,
+                        2.8834408121690696,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "5746a43a-f1ad-4411-8d2d-c380b47dab24": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": -0.13335000000000008,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.7909500000000005,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": -0.06667500000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.7242750000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "5746a43a-f1ad-4411-8d2d-c380b47dab24",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "e68c3c58-054d-44d9-b3f3-60f2f47218f0",
+            "Representation": null,
+            "SegmentIndex": 2,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        -2.683823606058878e-11,
+                        0.9999999999999998,
+                        0,
+                        -0.218601802355326,
+                        -0.9999999999999998,
+                        -2.683823606058878e-11,
+                        0,
+                        2.8834408122672333,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "7bd5b510-c7a9-4097-b57e-51eb75e07ad4": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": -0.13335000000000008,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": -0.06667500000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "7bd5b510-c7a9-4097-b57e-51eb75e07ad4",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "e68c3c58-054d-44d9-b3f3-60f2f47218f0",
+            "Representation": null,
+            "SegmentIndex": 3,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        0.9999999999999998,
+                        2.683823606058878e-11,
+                        0,
+                        -0.2186018024534897,
+                        -2.683823606058878e-11,
+                        0.9999999999999998,
+                        0,
+                        -0.7741591877327663,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "bd1a89c1-fde3-44e3-b6b2-4de84d57dbc2": {
+            "discriminator": "Elements.SpaceBoundary",
+            "Boundary": {
+                "discriminator": "Elements.Geometry.Profile",
+                "Perimeter": {
+                    "discriminator": "Elements.Geometry.Polygon",
+                    "Vertices": [
+                        {
+                            "X": -1.8288000000000002,
+                            "Y": -1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": 1.8288000000000002,
+                            "Y": -1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": 1.8288000000000002,
+                            "Y": 1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": -1.8288000000000002,
+                            "Y": 1.8288000000000002,
+                            "Z": 0
+                        }
+                    ]
+                },
+                "Voids": [],
+                "Id": "95e1eb98-b03a-48ee-96b8-cac3d2f07368"
+            },
+            "Height": 3.0480000000000005,
+            "Hypar Space Type": "Meeting Room",
+            "Id": "bd1a89c1-fde3-44e3-b6b2-4de84d57dbc2",
+            "IsElementDefinition": false,
+            "Level": "da605445-d036-4ead-8f1b-e92120db7db0",
+            "Material": null,
+            "Name": "Meeting Room",
+            "Parent": null,
+            "Program Type": "Meeting Room",
+            "ProgramName": "Meeting Room",
+            "Representation": null,
+            "Top Level": "f39f221a-0971-4871-b0bf-243a5b7c78f9",
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        1,
+                        0,
+                        0,
+                        -2.1807518100949315,
+                        0,
+                        1,
+                        0,
+                        1.0546408045276277,
+                        0,
+                        0,
+                        1,
+                        3.0480000000000005
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "WallThickness": 0.13335,
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ],
+            "Config Id": "",
+            "Type": {
+                "configurationSource": "space-type",
+                "name": "New Space Type",
+                "id": "88ec5146-897f-4eab-a717-a1beee4f2b3b",
+                "initialDimensions": {
+                    "width": 3.6576000000000004,
+                    "depth": 3.6576000000000004
+                }
+            }
+        },
+        "e6f01a94-9b51-43f1-8e97-1edeee71ff0d": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": null,
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "e6f01a94-9b51-43f1-8e97-1edeee71ff0d",
+            "IsElementDefinition": false,
+            "Level": "da605445-d036-4ead-8f1b-e92120db7db0",
+            "Material": null,
+            "Openings": [],
+            "Parent": "bd1a89c1-fde3-44e3-b6b2-4de84d57dbc2",
+            "Representation": null,
+            "SegmentIndex": 0,
+            "StartMiter": 0,
+            "Thickness": 0,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        1,
+                        0,
+                        0,
+                        -4.009551810094932,
+                        0,
+                        1,
+                        0,
+                        -0.7741591954723726,
+                        0,
+                        0,
+                        1,
+                        3.0480000000000005
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "d93480fe-3788-4100-b278-b5ad423a8ee1": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.7909500000000005,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.7242750000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "d93480fe-3788-4100-b278-b5ad423a8ee1",
+            "IsElementDefinition": false,
+            "Level": "da605445-d036-4ead-8f1b-e92120db7db0",
+            "Material": null,
+            "Openings": [],
+            "Parent": "bd1a89c1-fde3-44e3-b6b2-4de84d57dbc2",
+            "Representation": null,
+            "SegmentIndex": 1,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        0,
+                        -1,
+                        0,
+                        -0.35195181009493126,
+                        1,
+                        0,
+                        0,
+                        -0.7741591954723726,
+                        0,
+                        0,
+                        1,
+                        3.0480000000000005
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "37f09e4e-ca98-4d87-819e-2a2534da9fe9": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": -0.13335000000000008,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.7909500000000005,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": -0.06667500000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.7242750000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "37f09e4e-ca98-4d87-819e-2a2534da9fe9",
+            "IsElementDefinition": false,
+            "Level": "da605445-d036-4ead-8f1b-e92120db7db0",
+            "Material": null,
+            "Openings": [],
+            "Parent": "bd1a89c1-fde3-44e3-b6b2-4de84d57dbc2",
+            "Representation": null,
+            "SegmentIndex": 2,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        -1,
+                        0,
+                        0,
+                        -0.35195181009493126,
+                        0,
+                        -1,
+                        0,
+                        2.883440804527628,
+                        0,
+                        0,
+                        1,
+                        3.0480000000000005
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "d9d5d91b-7a56-4cde-a2e6-bfa797f45be2": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": -0.13335000000000008,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": -0.06667500000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "d9d5d91b-7a56-4cde-a2e6-bfa797f45be2",
+            "IsElementDefinition": false,
+            "Level": "da605445-d036-4ead-8f1b-e92120db7db0",
+            "Material": null,
+            "Openings": [],
+            "Parent": "bd1a89c1-fde3-44e3-b6b2-4de84d57dbc2",
+            "Representation": null,
+            "SegmentIndex": 3,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        0,
+                        1,
+                        0,
+                        -4.009551810094932,
+                        -1,
+                        0,
+                        0,
+                        2.883440804527628,
+                        0,
+                        0,
+                        1,
+                        3.0480000000000005
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "a0e5eda9-f386-47e7-ae1f-797483295c7f": {
+            "discriminator": "Elements.SpaceBoundary",
+            "Boundary": {
+                "discriminator": "Elements.Geometry.Profile",
+                "Id": "427f45a7-2724-4bb0-9608-cdbcdc85f6b7",
+                "Perimeter": {
+                    "Vertices": [
+                        {
+                            "X": -1.8288000000000004,
+                            "Y": -0.7620000000000005,
+                            "Z": 0
+                        },
+                        {
+                            "X": 1.8287999999999998,
+                            "Y": -1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": 1.8287999999999998,
+                            "Y": 1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": -1.8288000000000004,
+                            "Y": 1.8288000000000002,
+                            "Z": 0
+                        }
+                    ],
+                    "discriminator": "Elements.Geometry.Polygon"
+                }
+            },
+            "Height": 3.0480000000000005,
+            "Hypar Space Type": "Meeting Room",
+            "Id": "a0e5eda9-f386-47e7-ae1f-797483295c7f",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Name": "Meeting Room",
+            "Parent": null,
+            "Program Type": "Meeting Room",
+            "ProgramName": "Meeting Room",
+            "Representation": null,
+            "Top Level": "da605445-d036-4ead-8f1b-e92120db7db0",
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        -1,
+                        2.028653274546429e-9,
+                        0,
+                        -2.1807518100949315,
+                        -2.028653274546429e-9,
+                        -1,
+                        0,
+                        4.845590804527628,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "WallThickness": 0.13335,
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ],
+            "Config Id": "",
+            "Type": {
+                "configurationSource": "space-type",
+                "name": "New Space Type",
+                "id": "88ec5146-897f-4eab-a717-a1beee4f2b3b",
+                "initialDimensions": {
+                    "width": 3.6576,
+                    "depth": 3.6576000000000004
+                },
+                "profileLinkedToType": false
+            }
+        },
+        "9bef3dac-15bc-4f9b-878c-a5a367b13169": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.8100000000000005,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": -0.13890625000000023,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.8100000000000005,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.874008000000001,
+                        "Y": 0.018669000000000047,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.8100000000000005,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": -0.06945312500000012,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.874008000000001,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "9bef3dac-15bc-4f9b-878c-a5a367b13169",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "a0e5eda9-f386-47e7-ae1f-797483295c7f",
+            "Representation": null,
+            "SegmentIndex": 0,
+            "StartMiter": 0,
+            "Thickness": 0,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        -0.9600000005680229,
+                        -0.27999999805249276,
+                        0,
+                        -0.35195181164076494,
+                        0.27999999805249276,
+                        -0.9600000005680229,
+                        0,
+                        5.60759080823763,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "1a5f8409-af69-4521-abf8-ca3b924a052d": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": -0.06667500000000004,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.7909500000000005,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.7242750000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "1a5f8409-af69-4521-abf8-ca3b924a052d",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "a0e5eda9-f386-47e7-ae1f-797483295c7f",
+            "Representation": null,
+            "SegmentIndex": 1,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        2.028653274546429e-9,
+                        1,
+                        0,
+                        -4.009551813804933,
+                        -1,
+                        2.028653274546429e-9,
+                        0,
+                        6.674390800817627,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "49db0be6-317b-4186-9086-16341c945a5a": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": -0.13335000000000008,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.7909500000000005,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": -0.06667500000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.7242750000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "49db0be6-317b-4186-9086-16341c945a5a",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "a0e5eda9-f386-47e7-ae1f-797483295c7f",
+            "Representation": null,
+            "SegmentIndex": 2,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        1,
+                        -2.028653274546429e-9,
+                        0,
+                        -4.0095518063849305,
+                        2.028653274546429e-9,
+                        1,
+                        0,
+                        3.0167908008176267,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "6248eacf-33f5-4ab9-b362-b89de5a51261": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 2.5908000000000007,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": -0.13335000000000008,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 2.551906250000001,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 2.5908000000000007,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 2.5908000000000007,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": -0.06667500000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 2.571353125000001,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "6248eacf-33f5-4ab9-b362-b89de5a51261",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "a0e5eda9-f386-47e7-ae1f-797483295c7f",
+            "Representation": null,
+            "SegmentIndex": 3,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        -2.028653274546429e-9,
+                        -1,
+                        0,
+                        -0.35195180638492984,
+                        1,
+                        -2.028653274546429e-9,
+                        0,
+                        3.016790808237629,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "6092c84b-a54a-41ca-b185-b3c101eb20ef": {
+            "discriminator": "Elements.SpaceBoundary",
+            "Boundary": {
+                "discriminator": "Elements.Geometry.Profile",
+                "Perimeter": {
+                    "discriminator": "Elements.Geometry.Polygon",
+                    "Vertices": [
+                        {
+                            "X": -1.8288000000000002,
+                            "Y": -1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": 1.8288000000000002,
+                            "Y": -1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": 1.8288000000000002,
+                            "Y": 1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": -1.8288000000000002,
+                            "Y": 1.8288000000000002,
+                            "Z": 0
+                        }
+                    ]
+                },
+                "Voids": [],
+                "Id": "11bb2dc2-74ab-4eab-b516-555174478d4b"
+            },
+            "Height": 3.0480000000000005,
+            "Hypar Space Type": "Meeting Room",
+            "Id": "6092c84b-a54a-41ca-b185-b3c101eb20ef",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Name": "Meeting Room",
+            "Parent": null,
+            "Program Type": "Meeting Room",
+            "ProgramName": "Meeting Room",
+            "Representation": null,
+            "Top Level": "da605445-d036-4ead-8f1b-e92120db7db0",
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        7.85368516584606e-9,
+                        1,
+                        0,
+                        5.267798197595591,
+                        -1,
+                        7.85368516584606e-9,
+                        0,
+                        1.0546407987660567,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "WallThickness": 0.13335,
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ],
+            "Config Id": "",
+            "Type": {
+                "configurationSource": "space-type",
+                "name": "New Space Type",
+                "id": "88ec5146-897f-4eab-a717-a1beee4f2b3b",
+                "initialDimensions": {
+                    "width": 3.6576000000000004,
+                    "depth": 3.6576000000000004
+                }
+            }
+        },
+        "cfe36901-d6f5-43e5-b310-acead89e48bd": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": null,
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "cfe36901-d6f5-43e5-b310-acead89e48bd",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "6092c84b-a54a-41ca-b185-b3c101eb20ef",
+            "Representation": null,
+            "SegmentIndex": 0,
+            "StartMiter": 0,
+            "Thickness": 0,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        7.85368516584606e-9,
+                        1,
+                        0,
+                        3.438998183232772,
+                        -1,
+                        7.85368516584606e-9,
+                        0,
+                        2.8834407844032377,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "2cc46820-04fd-45b7-8336-2adb9cd19dc7": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.7909500000000005,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.7242750000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "2cc46820-04fd-45b7-8336-2adb9cd19dc7",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "6092c84b-a54a-41ca-b185-b3c101eb20ef",
+            "Representation": null,
+            "SegmentIndex": 1,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        1,
+                        -7.85368516584606e-9,
+                        0,
+                        3.4389982119584106,
+                        7.85368516584606e-9,
+                        1,
+                        0,
+                        -0.7741592155967629,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "8ce6a6e1-370b-4d41-8f22-7a5b5d39e5aa": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": -0.13335000000000008,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.7909500000000005,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": -0.06667500000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.7242750000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "8ce6a6e1-370b-4d41-8f22-7a5b5d39e5aa",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "6092c84b-a54a-41ca-b185-b3c101eb20ef",
+            "Representation": null,
+            "SegmentIndex": 2,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        -7.85368516584606e-9,
+                        -1,
+                        0,
+                        7.096598211958411,
+                        1,
+                        -7.85368516584606e-9,
+                        0,
+                        -0.7741591868711242,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "f76edf3e-1adf-4357-b657-84121d3f3d95": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": -0.13335000000000008,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": -0.06667500000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "f76edf3e-1adf-4357-b657-84121d3f3d95",
+            "IsElementDefinition": false,
+            "Level": "09a19027-7312-4ea9-8226-fc09a80794fd",
+            "Material": null,
+            "Openings": [],
+            "Parent": "6092c84b-a54a-41ca-b185-b3c101eb20ef",
+            "Representation": null,
+            "SegmentIndex": 3,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        -1,
+                        7.85368516584606e-9,
+                        0,
+                        7.096598183232772,
+                        -7.85368516584606e-9,
+                        -1,
+                        0,
+                        2.8834408131288765,
+                        0,
+                        0,
+                        1,
+                        0
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "c501ea63-77a4-4452-83f9-95a193690383": {
+            "discriminator": "Elements.SpaceBoundary",
+            "Boundary": {
+                "discriminator": "Elements.Geometry.Profile",
+                "Perimeter": {
+                    "discriminator": "Elements.Geometry.Polygon",
+                    "Vertices": [
+                        {
+                            "X": -1.8288000000000002,
+                            "Y": -1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": 1.8288000000000002,
+                            "Y": -1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": 1.8288000000000002,
+                            "Y": 1.8288000000000002,
+                            "Z": 0
+                        },
+                        {
+                            "X": -1.8288000000000002,
+                            "Y": 1.8288000000000002,
+                            "Z": 0
+                        }
+                    ]
+                },
+                "Voids": [],
+                "Id": "11bb2dc2-74ab-4eab-b516-555174478d4b"
+            },
+            "Height": 3.0480000000000005,
+            "Hypar Space Type": "Meeting Room",
+            "Id": "c501ea63-77a4-4452-83f9-95a193690383",
+            "IsElementDefinition": false,
+            "Level": "da605445-d036-4ead-8f1b-e92120db7db0",
+            "Material": null,
+            "Name": "Meeting Room",
+            "Parent": null,
+            "Program Type": "Meeting Room",
+            "ProgramName": "Meeting Room",
+            "Representation": null,
+            "Top Level": "f39f221a-0971-4871-b0bf-243a5b7c78f9",
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        7.85368516584606e-9,
+                        1,
+                        0,
+                        5.267798197595591,
+                        -1,
+                        7.85368516584606e-9,
+                        0,
+                        1.0546407987660567,
+                        0,
+                        0,
+                        1,
+                        3.0480000000000005
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "WallThickness": 0.13335,
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ],
+            "Config Id": "",
+            "Type": {
+                "configurationSource": "space-type",
+                "name": "New Space Type",
+                "id": "88ec5146-897f-4eab-a717-a1beee4f2b3b",
+                "initialDimensions": {
+                    "width": 3.6576000000000004,
+                    "depth": 3.6576000000000004
+                }
+            }
+        },
+        "df337c81-6cfd-4302-8353-351a3e431369": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": null,
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "df337c81-6cfd-4302-8353-351a3e431369",
+            "IsElementDefinition": false,
+            "Level": "da605445-d036-4ead-8f1b-e92120db7db0",
+            "Material": null,
+            "Openings": [],
+            "Parent": "c501ea63-77a4-4452-83f9-95a193690383",
+            "Representation": null,
+            "SegmentIndex": 0,
+            "StartMiter": 0,
+            "Thickness": 0,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        7.85368516584606e-9,
+                        1,
+                        0,
+                        3.438998183232772,
+                        -1,
+                        7.85368516584606e-9,
+                        0,
+                        2.8834407844032377,
+                        0,
+                        0,
+                        1,
+                        3.0480000000000005
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "f9ba3753-6f6a-4d0e-b975-b3d581dab361": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.7909500000000005,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.7242750000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "f9ba3753-6f6a-4d0e-b975-b3d581dab361",
+            "IsElementDefinition": false,
+            "Level": "da605445-d036-4ead-8f1b-e92120db7db0",
+            "Material": null,
+            "Openings": [],
+            "Parent": "c501ea63-77a4-4452-83f9-95a193690383",
+            "Representation": null,
+            "SegmentIndex": 1,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        1,
+                        -7.85368516584606e-9,
+                        0,
+                        3.4389982119584106,
+                        7.85368516584606e-9,
+                        1,
+                        0,
+                        -0.7741592155967629,
+                        0,
+                        0,
+                        1,
+                        3.0480000000000005
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "b8174cec-6969-4538-b423-9ce95c800122": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": -0.13335000000000008,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.7909500000000005,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": -0.06667500000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.7242750000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "b8174cec-6969-4538-b423-9ce95c800122",
+            "IsElementDefinition": false,
+            "Level": "da605445-d036-4ead-8f1b-e92120db7db0",
+            "Material": null,
+            "Openings": [],
+            "Parent": "c501ea63-77a4-4452-83f9-95a193690383",
+            "Representation": null,
+            "SegmentIndex": 2,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        -7.85368516584606e-9,
+                        -1,
+                        0,
+                        7.096598211958411,
+                        1,
+                        -7.85368516584606e-9,
+                        0,
+                        -0.7741591868711242,
+                        0,
+                        0,
+                        1,
+                        3.0480000000000005
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        },
+        "33c62e18-a2d3-494c-9697-6f73fcc3f91d": {
+            "BaseLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": 0,
+                    "Z": 0
+                }
+            },
+            "Boundary": {
+                "Vertices": [
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": -0.13335000000000008,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": -0.13335000000000008,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    {
+                        "X": 3.6576000000000004,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                ],
+                "discriminator": "Elements.Geometry.Polygon"
+            },
+            "CenterLine": {
+                "discriminator": "Elements.Geometry.Line",
+                "Start": {
+                    "X": -0.06667500000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                },
+                "End": {
+                    "X": 3.6576000000000004,
+                    "Y": -0.06667500000000004,
+                    "Z": 0
+                }
+            },
+            "discriminator": "Elements.StandardWall",
+            "EndMiter": 0,
+            "Height": 3.0480000000000005,
+            "Id": "33c62e18-a2d3-494c-9697-6f73fcc3f91d",
+            "IsElementDefinition": false,
+            "Level": "da605445-d036-4ead-8f1b-e92120db7db0",
+            "Material": null,
+            "Openings": [],
+            "Parent": "c501ea63-77a4-4452-83f9-95a193690383",
+            "Representation": null,
+            "SegmentIndex": 3,
+            "StartMiter": 0,
+            "Thickness": 0.13335,
+            "Transform": {
+                "Matrix": {
+                    "Components": [
+                        -1,
+                        7.85368516584606e-9,
+                        0,
+                        7.096598183232772,
+                        -7.85368516584606e-9,
+                        -1,
+                        0,
+                        2.8834408131288765,
+                        0,
+                        0,
+                        1,
+                        3.0480000000000005
+                    ]
+                }
+            },
+            "WallsVersion": "3",
+            "OptionIds": [
+                "650fd95a-503b-499f-93ea-0fb7890df192"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
we want to create room separation lines from zero-thickness walls, which are now "legal" as of wallsversion 2 / 3. This will be needed for the new Walls LOD 200 function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1094)
<!-- Reviewable:end -->
