### PR TITLE
use ubuntu latest

### DIFF
--- a/.github/workflows/build-and-publish-alpha.yml
+++ b/.github/workflows/build-and-publish-alpha.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-bump-alpha-publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo.
         uses: actions/checkout@v2


### PR DESCRIPTION
our build-bump-alpha-publish action failed. IDK if this will fix it, but all our other actions use ubuntu-latest