### PR TITLE
ubuntu-latest on alpha ghworkflow

### DIFF
--- a/.github/workflows/build-and-publish-alpha.yml
+++ b/.github/workflows/build-and-publish-alpha.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-bump-alpha-publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo.
         uses: actions/checkout@v2


### PR DESCRIPTION
BACKGROUND:
- action to publish failed

DESCRIPTION:
- Use ubuntu latest, it's already used in other actions

TESTING:
- 🤞
