### PR TITLE
don't make a representation for zero thickness walls (it errors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - `AdaptiveGrid.Clone`
 - `AdditionalProperties` to ContentConfiguration.
 - `Line.Projected(Line line)`
+- Make zero thickness walls not error out when creating a solid.
 
 ### Fixed
 

--- a/Elements/src/StandardWall.cs
+++ b/Elements/src/StandardWall.cs
@@ -168,6 +168,11 @@ namespace Elements
         public override void UpdateRepresentations()
         {
             this.Representation.SolidOperations.Clear();
+            // new versions of walls can have zero thickness representing no wall, and then should not have a solid representation
+            if (WallsVersion != null && Thickness.ApproximatelyEquals(0))
+            {
+                return;
+            }
             var e1 = this.CenterLine.Offset(this.Thickness / 2, false);
             var e2 = this.CenterLine.Offset(this.Thickness / 2, true);
             var profile = new Polygon(new[] { e1.Start, e1.End, e2.End, e2.Start });


### PR DESCRIPTION
BACKGROUND:
- ElementsToModel for Walls is throwing errors for our new walls structure which allows for zero thickness.  
- When the wall is added to the model we call UpdateRepresentation, which creates a Polygon to make the shape.
- The polygon constructor removed duplicate vertices and runs validation which fails if there are fewer than 3 vertices, and since a 0 thickness wall results in dulicate vertices, this errors.

DESCRIPTION:
- If a StandardWall of a new wall version has zero thickness don't make a representation

TESTING:
- Pringle function with Wall in Test and WallsLOD200 should produce the right number of walls with zero thickness.  These have both been published with this local version of elements for the time being.
  - (WallsLOD200 also has the latest `wall-thickness-2` fixes)
  
FUTURE WORK:
- Our rigidity with geometric operations continues to bite us, we should make all of this friendlier.

REQUIRED:
- [x] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1097)
<!-- Reviewable:end -->
