### PR TITLE
Bump ImgeSharp, SkiaSharp and Newtonsoft.Json package versions

### DIFF
--- a/Elements.Serialization.SVG/src/Elements.Serialization.SVG.csproj
+++ b/Elements.Serialization.SVG/src/Elements.Serialization.SVG.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -18,8 +18,8 @@
 
     <ItemGroup>
         <PackageReference Include="Svg.Skia" Version="0.6.0-preview2" />
-        <PackageReference Include="SkiaSharp" Version="2.88.3" />
-        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.3" />
+        <PackageReference Include="SkiaSharp" Version="2.88.6" />
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Elements/src/Elements.csproj
+++ b/Elements/src/Elements.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Hypar.Elements</AssemblyName>
@@ -17,9 +17,9 @@
     <PackageReference Include="glTF2Loader" Version="1.1.3-alpha" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.11.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta19" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.10" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
     <PackageReference Include="Unofficial.LibTessDotNet" Version="2.0.0" />


### PR DESCRIPTION
BACKGROUND:
Bump ImgeSharp, SkiaSharp and Newtonsoft.Json package versions to avoid vulnerabilities that were found in the version that we were using 
