### PR TITLE
Prevent curve overwrite during GridLine deserialization

### DIFF
--- a/Elements/src/GridLine.cs
+++ b/Elements/src/GridLine.cs
@@ -23,14 +23,16 @@ namespace Elements
         /// <summary>
         /// Initializes a new instance of the GridLine class.
         /// </summary>
-        public GridLine()
+        public GridLine() : base()
         {
             deserializationIsInProgress = false;
         }
 
         // TODO: Remove this constructor once we remove the Line and Geometry properties.
         [JsonConstructor]
-        private GridLine(BoundedCurve curve, Polyline geometry, Line line)
+        private GridLine(BoundedCurve curve, Polyline geometry, Line line,
+        Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+            : base(@transform, @material, @representation, @isElementDefinition, @id, @name)
         {
             deserializationIsInProgress = true;
             if (curve != null)

--- a/Elements/src/GridLine.cs
+++ b/Elements/src/GridLine.cs
@@ -20,6 +20,14 @@ namespace Elements
         // TODO: Remove this flag once we remove the Line and Geometry properties.
         private bool deserializationIsInProgress = false;
 
+        /// <summary>
+        /// Initializes a new instance of the GridLine class.
+        /// </summary>
+        public GridLine()
+        {
+            deserializationIsInProgress = false;
+        }
+
         // TODO: Remove this constructor once we remove the Line and Geometry properties.
         [JsonConstructor]
         private GridLine(BoundedCurve curve, Polyline geometry, Line line)

--- a/Elements/src/GridLine.cs
+++ b/Elements/src/GridLine.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Elements.Geometry;
+using Newtonsoft.Json;
 
 namespace Elements
 {
@@ -10,8 +12,33 @@ namespace Elements
     /// <example>
     /// [!code-csharp[Main](../../Elements/test/GridLineTests.cs?name=example)]
     /// </example>
-    public class GridLine : GeometricElement
+    // TODO: remove IDeserializationCallback implementation once we remove the Line and Geometry properties.
+    // Remove its usage from JsonInheritanceConverter..
+    [JsonConverter(typeof(Serialization.JSON.JsonInheritanceConverter), "discriminator")]
+    public class GridLine : GeometricElement, IDeserializationCallback
     {
+        // TODO: Remove this flag once we remove the Line and Geometry properties.
+        private bool deserializationIsInProgress = false;
+
+        // TODO: Remove this constructor once we remove the Line and Geometry properties.
+        [JsonConstructor]
+        private GridLine(BoundedCurve curve, Polyline geometry, Line line)
+        {
+            deserializationIsInProgress = true;
+            if (curve != null)
+            {
+                Curve = curve;
+            }
+            else if (geometry != null)
+            {
+                Geometry = geometry;
+            }
+            else
+            {
+                Line = line;
+            }
+        }
+
         /// <summary>
         /// Line that runs from the start of the gridline to its end.
         /// </summary>
@@ -19,7 +46,13 @@ namespace Elements
         public Line Line
         {
             get { return this.Curve as Line; }
-            set { this.Curve = value; }
+            set
+            {
+                if (!deserializationIsInProgress)
+                {
+                    this.Curve = value;
+                }
+            }
         }
 
         /// <summary>
@@ -29,8 +62,15 @@ namespace Elements
         public Polyline Geometry
         {
             get { return this.Curve as Polyline; }
-            set { this.Curve = value; }
+            set
+            {
+                if (!deserializationIsInProgress)
+                {
+                    this.Curve = value;
+                }
+            }
         }
+
 
         /// <summary>
         /// Curve that runs from the start of the gridline to its end.
@@ -77,7 +117,7 @@ namespace Elements
 
             var circleVertexTransform = GetCircleTransform();
             var circle = new Arc(circleVertexTransform, Radius);
-            
+
             renderVertices.AddRange(circle.RenderVertices());
 
             if (ExtensionBeginning > 0)
@@ -133,6 +173,14 @@ namespace Elements
         {
             var circleCenter = this.GetCircleTransform();
             texts.Add((circleCenter.Origin, circleCenter.ZAxis, circleCenter.XAxis, this.Name, color));
+        }
+
+        /// <summary>
+        /// This method is called after the object has been deserialized.
+        /// </summary>
+        public void OnDeserialization(object sender)
+        {
+            deserializationIsInProgress = false;
         }
     }
 }

--- a/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
+++ b/Elements/src/Serialization/JSON/JsonInheritanceConverter.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Runtime.Serialization;
 
 namespace Elements.Serialization.JSON
 {
@@ -415,6 +416,11 @@ namespace Elements.Serialization.JSON
                     {
                         SharedObjects.Add(ident.Id, ident);
                     }
+                }
+
+                if (obj is IDeserializationCallback callback)
+                {
+                    callback.OnDeserialization(obj);
                 }
 
                 return obj;


### PR DESCRIPTION
#### 🌌 BACKGROUND:
`GridLine` has three properties that can set its geometry: `Curve`, `Geometry`, and `Line`.
In some workflows (e.g., created by a function and later edited in Pringle), a `GridLine` can enter a corrupt state where:

* `Curve` contains the correct value,
* but it is overwritten during deserialization by `Line` or `Geometry` values,
* leading to incorrect behavior or rendering.

#### 📋 DESCRIPTION:
This PR prevents unwanted overwriting of the `Curve` during deserialization:

* Introduces a `deserializationIsInProgress` flag:

  * Set to `true` inside the `JsonConstructor`.
  * Reset to `false` in the `OnDeserialized` callback.
* Modifies the `Line` and `Geometry` setters to **skip assigning to `Curve`** during deserialization, preserving the original `Curve` if it's already set.

#### 🧪 TESTING:
* Enabled the `suggest-everywhere` flag.
* Added a GridLine via suggestion.
* Modified an existing GridLine.
* Copied the GridLine to clipboard.
* Saved and reloaded the file using deserialization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1101)
<!-- Reviewable:end -->
