### PR TITLE
continue propagate with zero leftover

### DIFF
--- a/Elements.MEP/src/Fittings/StraightSegment.cs
+++ b/Elements.MEP/src/Fittings/StraightSegment.cs
@@ -166,7 +166,11 @@ namespace Elements.Fittings
 
             if (leftover.IsZero())
             {
-                return false;
+                // returning true here is a hack to let fittings with multiple
+                // branches with different offsets continue to propogate their
+                // transforms.  If this returns false it seems that the other
+                // branches aren't checked.
+                return true;
             }
             else
             {


### PR DESCRIPTION
BACKGROUND:
- While working on fittings that have multiple offsets @andrzej-rudzki  realize this was stopping him from implementing a fix.

DESCRIPTION:
- Let propogation continue even if there's no leftover transform.

TESTING:
- Tests still pass.
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Elements/1104)
<!-- Reviewable:end -->
